### PR TITLE
Add submission window scheduler and Discord message link validation

### DIFF
--- a/src/commands/characterRegister.ts
+++ b/src/commands/characterRegister.ts
@@ -18,6 +18,14 @@ export async function execute(interaction: any, { prisma }: any) {
   const sub = interaction.options.getSubcommand();
   const discordUserId = interaction.user.id;
   if (sub === 'register') {
+    if (interaction.guildId) {
+      await prisma.guild.upsert({
+        where: { id: interaction.guildId },
+        update: {},
+        create: { id: interaction.guildId },
+      });
+    }
+
     const name = interaction.options.getString('name', true);
     const clan = interaction.options.getString('clan') ?? null;
     const sheet = interaction.options.getString('sheet') ?? null;

--- a/src/commands/submitXp.ts
+++ b/src/commands/submitXp.ts
@@ -22,6 +22,20 @@ export async function execute(interaction: any, { prisma, client }: any) {
   const actorId = interaction.user.id;
   const charKey = interaction.options.getString('character', true);
 
+  if (guildId) {
+    await prisma.guild.upsert({
+      where: { id: guildId },
+      update: {},
+      create: { id: guildId },
+    });
+  }
+
+  await prisma.user.upsert({
+    where: { id: actorId },
+    update: { username: interaction.user.tag },
+    create: { id: actorId, username: interaction.user.tag },
+  });
+
   // Lookup character by id or name within this guild
   const character = await prisma.character.findFirst({
     where: { guildId, OR: [{ id: charKey }, { name: charKey }] },

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,97 @@
+import cron from 'node-cron';
+import { DateTime } from 'luxon';
+import type { Client } from 'discord.js';
+import type { PrismaClient } from '@prisma/client';
+
+const DEFAULT_TIMEZONE = 'America/Chicago';
+const DEFAULT_WINDOW_LENGTH_HOURS = 7 * 24;
+const DEFAULT_ANCHOR_WEEKDAY = 7; // 1 = Monday, 7 = Sunday
+const DEFAULT_ANCHOR_HOUR = 12;
+
+type GuildConfig = {
+  timezone?: string;
+  windowLengthHours?: number;
+  anchorWeekday?: number;
+  anchorHour?: number;
+};
+
+function parseGuildConfig(config: unknown): GuildConfig {
+  if (!config || typeof config !== 'object') return {};
+  return config as GuildConfig;
+}
+
+function computeNextAnchor(now: DateTime, config: GuildConfig): DateTime {
+  const timezone = config.timezone ?? DEFAULT_TIMEZONE;
+  const anchorWeekday = config.anchorWeekday ?? DEFAULT_ANCHOR_WEEKDAY;
+  const anchorHour = config.anchorHour ?? DEFAULT_ANCHOR_HOUR;
+
+  const localized = now.setZone(timezone);
+  const anchorThisWeek = localized
+    .set({ weekday: anchorWeekday, hour: anchorHour, minute: 0, second: 0, millisecond: 0 });
+
+  if (localized <= anchorThisWeek) {
+    return anchorThisWeek;
+  }
+
+  return anchorThisWeek.plus({ weeks: 1 });
+}
+
+function computeNextWindowStart(latestStart: DateTime | null, now: DateTime, config: GuildConfig): DateTime {
+  const lengthHours = config.windowLengthHours ?? DEFAULT_WINDOW_LENGTH_HOURS;
+  if (latestStart) {
+    return latestStart.plus({ hours: lengthHours });
+  }
+  return computeNextAnchor(now, config);
+}
+
+async function ensureWindowForGuild(prisma: PrismaClient, guildId: string) {
+  const guild = await prisma.guild.findUnique({ where: { id: guildId } });
+  const config = parseGuildConfig(guild?.config);
+  const timezone = config.timezone ?? DEFAULT_TIMEZONE;
+  const windowLengthHours = config.windowLengthHours ?? DEFAULT_WINDOW_LENGTH_HOURS;
+  const now = DateTime.now().setZone(timezone);
+
+  const latestWindow = await prisma.submissionWindow.findFirst({
+    where: { guildId },
+    orderBy: { startAt: 'desc' },
+  });
+
+  const latestStart = latestWindow ? DateTime.fromJSDate(latestWindow.startAt).setZone(timezone) : null;
+  const nextStart = computeNextWindowStart(latestStart, now, config);
+
+  if (latestWindow && now < DateTime.fromJSDate(latestWindow.endAt).setZone(timezone)) {
+    return;
+  }
+
+  const nextEnd = nextStart.plus({ hours: windowLengthHours });
+  const label = `${nextStart.toFormat('yyyy-LL-dd')} → ${nextEnd.toFormat('yyyy-LL-dd')}`;
+
+  await prisma.submissionWindow.create({
+    data: {
+      guildId,
+      startAt: nextStart.toJSDate(),
+      endAt: nextEnd.toJSDate(),
+      label,
+    },
+  });
+}
+
+export function scheduleWindowsJob(client: Client, prisma: PrismaClient) {
+  const run = async () => {
+    const guilds = await prisma.guild.findMany({ select: { id: true } });
+    if (guilds.length === 0) return;
+    for (const guild of guilds) {
+      await ensureWindowForGuild(prisma, guild.id);
+    }
+  };
+
+  run().catch((err) => {
+    console.error('Scheduler init failed:', err);
+  });
+
+  cron.schedule('*/10 * * * *', () => {
+    run().catch((err) => {
+      console.error('Scheduler run failed:', err);
+    });
+  });
+}

--- a/src/utils/linkValidator.ts
+++ b/src/utils/linkValidator.ts
@@ -1,0 +1,40 @@
+import type { Client } from 'discord.js';
+
+const MESSAGE_LINK_RE = /^https?:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)$/i;
+
+type Expected = {
+  expectedGuildId?: string;
+  expectedChannelId?: string;
+  expectedAuthorId?: string;
+};
+
+export async function fetchDiscordMessageFromLink(client: Client, link: string, expected: Expected) {
+  const match = link.trim().match(MESSAGE_LINK_RE);
+  if (!match) {
+    throw new Error('Invalid Discord message link format.');
+  }
+
+  const [, guildId, channelId, messageId] = match;
+  if (expected.expectedGuildId && expected.expectedGuildId !== guildId) {
+    throw new Error('Message is not from this server.');
+  }
+  if (expected.expectedChannelId && expected.expectedChannelId !== channelId) {
+    throw new Error('Message is not from the expected channel.');
+  }
+
+  const channel = await client.channels.fetch(channelId).catch(() => null);
+  if (!channel || !('messages' in channel)) {
+    throw new Error('Unable to access the referenced channel.');
+  }
+
+  const message = await channel.messages.fetch(messageId).catch(() => null);
+  if (!message) {
+    throw new Error('Unable to fetch the referenced message.');
+  }
+
+  if (expected.expectedAuthorId && message.author.id !== expected.expectedAuthorId) {
+    throw new Error('Message author does not match the character owner.');
+  }
+
+  return message;
+}


### PR DESCRIPTION
### Motivation
- Provide an automated scheduler to create and maintain submission windows for XP collection per guild. 
- Validate Discord message links provided as evidence to ensure they reference the correct server/channel/author. 
- Ensure guild and user records exist in the database before creating characters or submissions to avoid missing foreign keys. 

### Description
- Added `src/scheduler.ts` which computes window anchors using `luxon`, creates `SubmissionWindow` records, and runs every 10 minutes via `node-cron`. 
- Added `src/utils/linkValidator.ts` exporting `fetchDiscordMessageFromLink` that parses message links, fetches the channel/message, and enforces expected guild/channel/author. 
- Updated `src/commands/characterRegister.ts` and `src/commands/submitXp.ts` to upsert the guild (and user in `submitXp`) so required DB records exist prior to creating characters or submissions. 
- Submission windows are labeled with formatted date ranges and respect per-guild config defaults for timezone, anchor weekday/hour, and window length. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694eede874b483288f4cbeeb86917a34)