### PR TITLE
Docs: explicit Lite and Regular installation guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   - `apps/bot/.env` is the authoritative bot env file.
   - `CLIENT_ID` must be numeric Discord application ID (snowflake).
 
+### Documentation
+
+- Added explicit installation paths:
+  - `docs/INSTALL_LITE.md` (web-only)
+  - `docs/INSTALL_REGULAR.md` (web + bot)
+- Updated README to direct users to Lite vs Regular setup paths.
+- Updated `docs/RUN_BOT_LOCAL.md` env variable guidance to match bot runtime (`BOT_TOKEN`, `CLIENT_ID`, `TEST_GUILD_ID`).
+
 ## [2026-02-26] Security, Performance, and XP Rule Update
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ XP tracking and management for **Music City by Night**, a Vampire: The Masquerad
 - Go-live checklist: [docs/GO_LIVE_CHECKLIST.md](docs/GO_LIVE_CHECKLIST.md)
 - Local bot hosting runbook: [docs/RUN_BOT_LOCAL.md](docs/RUN_BOT_LOCAL.md)
 - Monorepo CI/CD blueprint: [docs/MONOREPO_CI_CD_BLUEPRINT.md](docs/MONOREPO_CI_CD_BLUEPRINT.md)
+- Install guide (Lite, web-only): [docs/INSTALL_LITE.md](docs/INSTALL_LITE.md)
+- Install guide (Regular, web + bot): [docs/INSTALL_REGULAR.md](docs/INSTALL_REGULAR.md)
 
 ### Data and Privacy Disclosure
 
@@ -109,6 +111,13 @@ Expected GCP impact:
 - **Google Sheets API usage is lower or unchanged** due to batching and append optimizations.
 
 ---
+
+## Installation Paths (Choose One)
+
+- **Lite (recommended to start):** web app only. Use [docs/INSTALL_LITE.md](docs/INSTALL_LITE.md).
+- **Regular:** web app + local Discord bot. Use [docs/INSTALL_REGULAR.md](docs/INSTALL_REGULAR.md).
+
+If you are unsure, start with Lite and add the bot later.
 
 ## Local Development
 

--- a/docs/INSTALL_LITE.md
+++ b/docs/INSTALL_LITE.md
@@ -1,0 +1,92 @@
+# Install Guide (Lite): Web App Only
+
+Use this guide if you only want the web interface and do **not** want to run the Discord bot.
+
+## Outcome
+
+- Web app running at `http://127.0.0.1:5001` locally.
+- Same Google Sheet-backed workflow as production.
+
+## 1) Prerequisites
+
+- macOS/Linux shell
+- Python `3.12+`
+- Google service-account JSON with Sheets access
+- Discord OAuth app (for web login)
+
+## 2) Clone and Enter Repo
+
+```bash
+git clone https://github.com/jkomg/mcbn-xp-tracker.git
+cd mcbn-xp-tracker
+```
+
+## 3) Create Python Environment
+
+```bash
+python3 -m venv apps/web/venv
+source apps/web/venv/bin/activate
+pip install -r apps/web/requirements.txt
+```
+
+## 4) Configure Web Environment
+
+```bash
+cp apps/web/.env.example apps/web/.env
+```
+
+Edit `apps/web/.env` and set:
+
+```env
+FLASK_SECRET_KEY=replace-with-random-string
+FLASK_DEBUG=true
+
+GOOGLE_CREDENTIALS_FILE=credentials/service-account.json
+SPREADSHEET_ID=your-google-sheet-id
+
+DISCORD_CLIENT_ID=your-discord-app-client-id
+DISCORD_CLIENT_SECRET=your-discord-app-client-secret
+DISCORD_REDIRECT_URI=http://127.0.0.1:5001/auth/callback
+ALLOWED_DISCORD_IDS=discord-user-id-1,discord-user-id-2
+```
+
+## 5) Add Google Credentials File
+
+Create directory and place your key:
+
+```bash
+mkdir -p apps/web/credentials
+# copy your JSON to:
+# apps/web/credentials/service-account.json
+```
+
+## 6) Initialize Sheet Tabs (Safe to Re-Run)
+
+```bash
+cd apps/web
+python3 -c "from app import create_app; app = create_app(); from app import sheets_client; sheets_client.setup_sheets()"
+cd ../..
+```
+
+## 7) Start Local Web App
+
+```bash
+./dev.sh
+```
+
+Open: `http://127.0.0.1:5001`
+
+## 8) Verify
+
+- Login via Discord works.
+- Player page loads.
+- Staff page loads for IDs listed in `ALLOWED_DISCORD_IDS`.
+
+## Troubleshooting
+
+- `Invalid OAuth2 redirect_uri`:
+  - Ensure Discord app redirect URI exactly matches `DISCORD_REDIRECT_URI`.
+- Port conflict:
+  - This project uses `5001` intentionally.
+- `service-account.json` missing:
+  - Verify path is `apps/web/credentials/service-account.json`.

--- a/docs/INSTALL_REGULAR.md
+++ b/docs/INSTALL_REGULAR.md
@@ -1,0 +1,101 @@
+# Install Guide (Regular): Web App + Discord Bot
+
+Use this guide if you want both:
+- web interface (`apps/web`)
+- Discord bot front-end (`apps/bot`)
+
+## Outcome
+
+- Web app running at `http://127.0.0.1:5001`
+- Bot running locally and registering commands in your test guild
+- No extra managed database/cloud runtime required for bot hosting
+
+## 1) Complete Lite Setup First
+
+Start with: [INSTALL_LITE.md](INSTALL_LITE.md)
+
+Do not continue until web login works locally.
+
+## 2) Node Prerequisite
+
+- Node `20+` recommended for bot runtime.
+
+Check:
+
+```bash
+node -v
+npm -v
+```
+
+## 3) Configure Bot Environment
+
+```bash
+cd apps/bot
+cp .env.example .env
+```
+
+Edit `apps/bot/.env`:
+
+```env
+BOT_TOKEN=your-rotated-discord-bot-token
+CLIENT_ID=your-discord-application-id-numeric-snowflake
+TEST_GUILD_ID=your-discord-server-id
+
+WEB_APP_BASE_URL=http://127.0.0.1:5001
+WEB_APP_API_TOKEN=optional-if-web-api-token-enabled
+```
+
+Notes:
+- `CLIENT_ID` must be numeric (Discord snowflake), not OAuth secret-like text.
+- Keep this file local; never commit it.
+
+## 4) Install Bot Dependencies
+
+```bash
+npm install
+```
+
+## 5) Run Full Bot Sanity Gate
+
+```bash
+npm run check
+```
+
+Expected: lint, format, typecheck, tests, and build all pass.
+
+## 6) Start Bot
+
+```bash
+npm run dev
+```
+
+Expected logs include:
+- `bot_ready`
+- `command_registration_guild`
+
+## 7) Functional Verification in Discord
+
+Run commands:
+- `/ping`
+- `/xp health`
+- `/xp summary`
+- `/xp spend-cost`
+
+If these work, your regular setup is complete.
+
+## Optional: Keep Bot Running After Reboot
+
+Use one of:
+- macOS launchd template: `infra/bot-hosting/launchd/`
+- Linux systemd template: `infra/bot-hosting/systemd/`
+
+Additional runbook: [RUN_BOT_LOCAL.md](RUN_BOT_LOCAL.md)
+
+## Troubleshooting
+
+- `Value "..." is not snowflake`:
+  - Fix `CLIENT_ID` in `apps/bot/.env`.
+- Bot connects but commands missing:
+  - Check `TEST_GUILD_ID` and rerun `npm run dev`.
+- Bot cannot reach web API:
+  - Check `WEB_APP_BASE_URL` and ensure web app is running.

--- a/docs/RUN_BOT_LOCAL.md
+++ b/docs/RUN_BOT_LOCAL.md
@@ -13,12 +13,17 @@ A Discord bot relies on a persistent gateway connection. Running it locally avoi
 
 ## Required bot environment variables
 
+Primary bot env file: `apps/bot/.env`
+
 ```env
-DISCORD_BOT_TOKEN=...
+BOT_TOKEN=...
+CLIENT_ID=your-discord-application-id-numeric-snowflake
+TEST_GUILD_ID=your-discord-server-id
 WEB_APP_BASE_URL=https://mcbn.jkomg.us
 WEB_APP_API_TOKEN=...
-LOG_LEVEL=info
 ```
+
+For first-time setup, follow [INSTALL_REGULAR.md](INSTALL_REGULAR.md).
 
 ## Local run (manual)
 


### PR DESCRIPTION
## Summary\n- add clear web-only (Lite) installation guide\n- add full web+bot (Regular) installation guide\n- link both guides from README\n- align bot local runbook env names with current runtime\n- update changelog with documentation changes\n\n## Validation\n- apps/bot: npm run check\n- backend: ./venv/bin/pytest -q\n\n## Goal\nMake setup approachable for non-bot users and complete for full deployments.