### PR TITLE
Harden bot/web shared Discord identity enforcement

### DIFF
--- a/apps/bot/src/commands/xp.ts
+++ b/apps/bot/src/commands/xp.ts
@@ -111,7 +111,10 @@ export async function autocomplete(interaction: AutocompleteInteraction, { adapt
 
   try {
     const query = String(option.value ?? '').trim().toLowerCase();
-    const context = await adapter.getClaimContext();
+    const context = await adapter.getClaimContext({
+      requesterDiscordId: interaction.user.id,
+      requesterDiscordName: interaction.user.username,
+    });
     const values = context.activeCharacters;
 
     const startsWith = values.filter((v: string) => v.toLowerCase().startsWith(query));
@@ -134,6 +137,10 @@ export async function autocomplete(interaction: AutocompleteInteraction, { adapt
 
 export async function execute(interaction: ChatInputCommandInteraction, { adapter }: CommandContext) {
   const sub = interaction.options.getSubcommand();
+  const requester = {
+    requesterDiscordId: interaction.user.id,
+    requesterDiscordName: interaction.user.username,
+  };
   const meta = {
     interactionId: interaction.id,
     userId: interaction.user?.id,
@@ -161,7 +168,7 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
   if (sub === 'summary') {
     const character = interaction.options.getString('character', true);
     logEvent('info', 'xp_summary_start', { ...meta, character });
-    const summary = await adapter.getSummary(character);
+    const summary = await adapter.getSummary(character, requester);
     if (!summary) {
       await interaction.reply({ content: `No summary found for ${character}.`, ephemeral: true });
       return;
@@ -198,6 +205,8 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
     const result = await adapter.submitClaim({
       characterName: character,
       playPeriod,
+      requesterDiscordId: requester.requesterDiscordId,
+      requesterDiscordName: requester.requesterDiscordName,
       categories: {
         [category]: link,
       },
@@ -219,6 +228,8 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
 
     const result = await adapter.submitSpend({
       characterName: character,
+      requesterDiscordId: requester.requesterDiscordId,
+      requesterDiscordName: requester.requesterDiscordName,
       spendCategory: spendCategory as XpSpendCategory,
       traitName,
       currentDots,
@@ -261,7 +272,7 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
     const startedAt = Date.now();
     await interaction.deferReply({ ephemeral: true });
     try {
-      const report = await adapter.getHealthReport();
+      const report = await adapter.getHealthReport(requester);
       const totalMs = Date.now() - startedAt;
       const claim = report.claimContext;
       const web = report.webApi;

--- a/apps/bot/src/interactiveClaimWizard.ts
+++ b/apps/bot/src/interactiveClaimWizard.ts
@@ -253,7 +253,10 @@ export async function startClaimWizard(
 ) {
   cleanupExpiredDrafts();
 
-  const context = await adapter.getClaimContext();
+  const context = await adapter.getClaimContext({
+    requesterDiscordId: interaction.user.id,
+    requesterDiscordName: interaction.user.username,
+  });
 
   const characterName = initialCharacter && context.activeCharacters.includes(initialCharacter)
     ? initialCharacter
@@ -458,6 +461,8 @@ export async function handleClaimWizardButton(interaction: ButtonInteraction, ad
     const result = await adapter.submitClaim({
       characterName: draft.characterName,
       playPeriod: draft.playPeriod,
+      requesterDiscordId: interaction.user.id,
+      requesterDiscordName: interaction.user.username,
       categories: payloadCategories,
     });
 

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -1,14 +1,21 @@
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 import { errorToMessage, logEvent } from '../logger';
-import type { AdapterHealthReport, ClaimContext, ClaimPayload, SpendPayload, XpSummary } from '../types';
+import type {
+  AdapterHealthReport,
+  ClaimContext,
+  ClaimPayload,
+  RequesterContext,
+  SpendPayload,
+  XpSummary,
+} from '../types';
 
 export interface TrackerAdapter {
-  getSummary(characterName: string): Promise<XpSummary | null>;
-  getClaimContext(opts?: { forceRefresh?: boolean }): Promise<ClaimContext>;
+  getSummary(characterName: string, requester: RequesterContext): Promise<XpSummary | null>;
+  getClaimContext(requester: RequesterContext, opts?: { forceRefresh?: boolean }): Promise<ClaimContext>;
   submitClaim(payload: ClaimPayload): Promise<{ ok: boolean; message: string }>;
   submitSpend(payload: SpendPayload): Promise<{ ok: boolean; message: string }>;
-  getHealthReport(): Promise<AdapterHealthReport>;
+  getHealthReport(requester: RequesterContext): Promise<AdapterHealthReport>;
 }
 
 const summarySchema = z.object({
@@ -42,8 +49,8 @@ type ClaimContextResult = {
 };
 
 export class WebAppAdapter implements TrackerAdapter {
-  private claimContextCache?: { value: ClaimContext; fetchedAt: number };
-  private claimContextInFlight?: Promise<ClaimContextResult>;
+  private claimContextCache = new Map<string, { value: ClaimContext; fetchedAt: number }>();
+  private claimContextInFlight = new Map<string, Promise<ClaimContextResult>>();
   private readonly baseUrl: string;
   private readonly apiToken?: string;
   private readonly requestTimeoutMs: number;
@@ -62,8 +69,12 @@ export class WebAppAdapter implements TrackerAdapter {
     this.claimContextRetryBaseMs = opts.claimContextRetryBaseMs ?? 250;
   }
 
-  async getSummary(characterName: string): Promise<XpSummary | null> {
-    const url = `${this.baseUrl}/api/characters/${encodeURIComponent(characterName)}/summary`;
+  async getSummary(characterName: string, requester: RequesterContext): Promise<XpSummary | null> {
+    const params = new URLSearchParams({ requesterDiscordId: requester.requesterDiscordId });
+    if (requester.requesterDiscordName) {
+      params.set('requesterDiscordName', requester.requesterDiscordName);
+    }
+    const url = `${this.baseUrl}/api/characters/${encodeURIComponent(characterName)}/summary?${params.toString()}`;
     const resp = await this.fetchWithTimeout(url, {
       headers: this.authHeaders(),
     }).catch(() => null);
@@ -80,8 +91,8 @@ export class WebAppAdapter implements TrackerAdapter {
     return summarySchema.parse(raw);
   }
 
-  async getClaimContext(opts: { forceRefresh?: boolean } = {}): Promise<ClaimContext> {
-    const result = await this.getClaimContextResult(opts.forceRefresh === true);
+  async getClaimContext(requester: RequesterContext, opts: { forceRefresh?: boolean } = {}): Promise<ClaimContext> {
+    const result = await this.getClaimContextResult(requester, opts.forceRefresh === true);
     return result.context;
   }
 
@@ -93,7 +104,7 @@ export class WebAppAdapter implements TrackerAdapter {
     return this.post('/api/spends', payload, 'Spend request submitted to web app API.');
   }
 
-  async getHealthReport(): Promise<AdapterHealthReport> {
+  async getHealthReport(requester: RequesterContext): Promise<AdapterHealthReport> {
     const now = new Date().toISOString();
     const healthStart = Date.now();
     let webApi: AdapterHealthReport['webApi'];
@@ -117,7 +128,7 @@ export class WebAppAdapter implements TrackerAdapter {
 
     let claimContext: AdapterHealthReport['claimContext'];
     try {
-      const result = await this.getClaimContextResult(true);
+      const result = await this.getClaimContextResult(requester, true);
       claimContext = {
         ok: true,
         status: 200,
@@ -175,66 +186,74 @@ export class WebAppAdapter implements TrackerAdapter {
     return { ok: true, message: successMessage };
   }
 
-  private getCacheAgeMs(): number {
-    if (!this.claimContextCache) {
+  private getCacheAgeMs(requesterDiscordId: string): number {
+    const cacheEntry = this.claimContextCache.get(requesterDiscordId);
+    if (!cacheEntry) {
       return 0;
     }
-    return Date.now() - this.claimContextCache.fetchedAt;
+    return Date.now() - cacheEntry.fetchedAt;
   }
 
-  private async getClaimContextResult(forceRefresh = false): Promise<ClaimContextResult> {
-    const cached = this.claimContextCache;
-    if (!forceRefresh && cached && this.getCacheAgeMs() <= this.claimContextCacheTtlMs) {
+  private async getClaimContextResult(requester: RequesterContext, forceRefresh = false): Promise<ClaimContextResult> {
+    const cacheKey = requester.requesterDiscordId;
+    const cached = this.claimContextCache.get(cacheKey);
+    if (!forceRefresh && cached && this.getCacheAgeMs(cacheKey) <= this.claimContextCacheTtlMs) {
       return {
         context: cached.value,
         source: 'cache',
         retries: 0,
         latencyMs: 0,
-        cacheAgeMs: this.getCacheAgeMs(),
+        cacheAgeMs: this.getCacheAgeMs(cacheKey),
       };
     }
 
-    if (this.claimContextInFlight) {
-      return this.claimContextInFlight;
+    const inFlight = this.claimContextInFlight.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
     }
 
-    this.claimContextInFlight = this.fetchClaimContextWithRetry()
+    const request = this.fetchClaimContextWithRetry(requester)
       .then((fresh) => {
-        this.claimContextCache = { value: fresh.context, fetchedAt: Date.now() };
+        this.claimContextCache.set(cacheKey, { value: fresh.context, fetchedAt: Date.now() });
         return fresh;
       })
       .catch((error) => {
-        const stale = this.claimContextCache;
-        if (stale && this.getCacheAgeMs() <= this.claimContextStaleIfErrorMs) {
+        const stale = this.claimContextCache.get(cacheKey);
+        if (stale && this.getCacheAgeMs(cacheKey) <= this.claimContextStaleIfErrorMs) {
           logEvent('warn', 'claim_context_stale_cache_fallback', {
             error: errorToMessage(error),
-            cacheAgeMs: this.getCacheAgeMs(),
+            cacheAgeMs: this.getCacheAgeMs(cacheKey),
           });
           return {
             context: stale.value,
             source: 'stale-cache' as const,
             retries: this.claimContextMaxRetries,
             latencyMs: 0,
-            cacheAgeMs: this.getCacheAgeMs(),
+            cacheAgeMs: this.getCacheAgeMs(cacheKey),
           };
         }
         throw error;
       })
       .finally(() => {
-        this.claimContextInFlight = undefined;
+        this.claimContextInFlight.delete(cacheKey);
       });
 
-    return this.claimContextInFlight;
+    this.claimContextInFlight.set(cacheKey, request);
+    return request;
   }
 
-  private async fetchClaimContextWithRetry(): Promise<ClaimContextResult> {
+  private async fetchClaimContextWithRetry(requester: RequesterContext): Promise<ClaimContextResult> {
     const startedAt = Date.now();
     let retries = 0;
     let lastError = 'Unknown error';
 
     for (let attempt = 0; attempt <= this.claimContextMaxRetries; attempt += 1) {
       try {
-        const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/meta/claim-context`, {
+        const params = new URLSearchParams({ requesterDiscordId: requester.requesterDiscordId });
+        if (requester.requesterDiscordName) {
+          params.set('requesterDiscordName', requester.requesterDiscordName);
+        }
+        const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/meta/claim-context?${params.toString()}`, {
           headers: this.authHeaders(),
         });
 

--- a/apps/bot/src/types.ts
+++ b/apps/bot/src/types.ts
@@ -22,11 +22,16 @@ export type ClaimContext = {
   currentNight: string | null;
 };
 
+export type RequesterContext = {
+  requesterDiscordId: string;
+  requesterDiscordName?: string;
+};
+
 export type ClaimPayload = {
   characterName: string;
   playPeriod: string;
   categories: Partial<Record<XpClaimCategory, string>>;
-};
+} & RequesterContext;
 
 export type SpendPayload = {
   characterName: string;
@@ -36,7 +41,7 @@ export type SpendPayload = {
   newDots: number;
   isInClan: boolean;
   justification: string;
-};
+} & RequesterContext;
 
 export type ApiProbe = {
   ok: boolean;

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -7,6 +7,7 @@ bearer token (`WEB_APP_API_TOKEN`) separate from staff Discord OAuth.
 from __future__ import annotations
 
 import hmac
+import re
 import threading
 import time
 from functools import wraps
@@ -14,10 +15,12 @@ from functools import wraps
 from flask import Blueprint, current_app, jsonify, request
 
 from app import sheets_client, limiter
+from app.auth import is_allowed_discord_user
 
 bp = Blueprint('api', __name__)
 _seen_nonces: dict[str, int] = {}
 _seen_nonces_lock = threading.Lock()
+DISCORD_ID_RE = re.compile(r'^\d{17,20}$')
 
 
 def _limit(rule: str):
@@ -157,6 +160,36 @@ def _open_periods_desc():
     return periods
 
 
+def _requester_from_query():
+    requester_discord_id = str(request.args.get('requesterDiscordId', '')).strip()
+    requester_discord_name = str(request.args.get('requesterDiscordName', '')).strip()
+    if not requester_discord_id:
+        return None, None, (jsonify({'error': 'requesterDiscordId is required'}), 400)
+    if not DISCORD_ID_RE.fullmatch(requester_discord_id):
+        return None, None, (jsonify({'error': 'requesterDiscordId must be a Discord snowflake'}), 400)
+    return requester_discord_id, requester_discord_name, None
+
+
+def _requester_from_payload(payload: dict):
+    requester_discord_id = str(payload.get('requesterDiscordId', '')).strip()
+    requester_discord_name = str(payload.get('requesterDiscordName', '')).strip()
+    if not requester_discord_id:
+        return None, None, (jsonify({'error': 'requesterDiscordId is required'}), 400)
+    if not DISCORD_ID_RE.fullmatch(requester_discord_id):
+        return None, None, (jsonify({'error': 'requesterDiscordId must be a Discord snowflake'}), 400)
+    return requester_discord_id, requester_discord_name, None
+
+
+def _is_requester_staff(requester_discord_id: str) -> bool:
+    return is_allowed_discord_user(requester_discord_id)
+
+
+def _requester_can_access_character(char, requester_discord_id: str) -> bool:
+    if _is_requester_staff(requester_discord_id):
+        return True
+    return str(char.player_discord or '').strip() == requester_discord_id
+
+
 @bp.route('/health', methods=['GET'])
 def health():
     return jsonify({'ok': True})
@@ -169,8 +202,14 @@ def claim_context():
     backend = _require_sheets()
     if backend:
         return backend
+    requester_discord_id, _, error = _requester_from_query()
+    if error:
+        return error
 
-    characters = sheets_client.get_active_characters()
+    if _is_requester_staff(requester_discord_id):
+        characters = sheets_client.get_active_characters()
+    else:
+        characters = [c for c in sheets_client.get_characters_by_discord_id(requester_discord_id) if c.active]
     characters.sort(key=lambda c: c.character_name.lower())
     open_periods = _open_periods_desc()
 
@@ -190,9 +229,14 @@ def character_summary(name: str):
     backend = _require_sheets()
     if backend:
         return backend
+    requester_discord_id, _, error = _requester_from_query()
+    if error:
+        return error
 
     char = sheets_client.get_character(name)
     if not char:
+        return jsonify({'error': 'Character not found'}), 404
+    if not _requester_can_access_character(char, requester_discord_id):
         return jsonify({'error': 'Character not found'}), 404
 
     totals = sheets_client.get_xp_totals(name)
@@ -217,6 +261,9 @@ def submit_claim():
         return backend
 
     payload = request.get_json(silent=True) or {}
+    requester_discord_id, requester_discord_name, error = _requester_from_payload(payload)
+    if error:
+        return error
     character_name = str(payload.get('characterName', '')).strip()
     play_period = str(payload.get('playPeriod', '')).strip()
     categories = payload.get('categories')
@@ -226,6 +273,8 @@ def submit_claim():
 
     char = sheets_client.get_character(character_name)
     if not char:
+        return jsonify({'error': 'Character not found'}), 404
+    if not _requester_can_access_character(char, requester_discord_id):
         return jsonify({'error': 'Character not found'}), 404
 
     if not char.active:
@@ -246,10 +295,13 @@ def submit_claim():
     try:
         sheets_client.submit_xp_claim(character_name, play_period, normalized)
         sheets_client.log_action(
-            staff_user='bot-api',
+            staff_user=f'bot-api:{requester_discord_id}',
             action_type='bot_claim_submitted',
             target=character_name,
-            details=f'Claim submitted for {play_period}',
+            details=(
+                f'Claim submitted for {play_period} by '
+                f'{requester_discord_name or requester_discord_id}'
+            ),
         )
     except ValueError as exc:
         return jsonify({'error': str(exc)}), 400
@@ -267,6 +319,9 @@ def submit_spend():
         return backend
 
     payload = request.get_json(silent=True) or {}
+    requester_discord_id, requester_discord_name, error = _requester_from_payload(payload)
+    if error:
+        return error
 
     character_name = str(payload.get('characterName', '')).strip()
     spend_category = str(payload.get('spendCategory', '')).strip()
@@ -289,6 +344,8 @@ def submit_spend():
     char = sheets_client.get_character(character_name)
     if not char:
         return jsonify({'error': 'Character not found'}), 404
+    if not _requester_can_access_character(char, requester_discord_id):
+        return jsonify({'error': 'Character not found'}), 404
 
     try:
         xp_cost = sheets_client.submit_spend_request(
@@ -301,12 +358,12 @@ def submit_spend():
             justification=justification,
         )
         sheets_client.log_action(
-            staff_user='bot-api',
+            staff_user=f'bot-api:{requester_discord_id}',
             action_type='bot_spend_submitted',
             target=character_name,
             details=(
                 f'{spend_category}: {trait_name} ({current_dots}->{new_dots}) '
-                f'for {xp_cost} XP'
+                f'for {xp_cost} XP by {requester_discord_name or requester_discord_id}'
             ),
         )
     except ValueError as exc:

--- a/apps/web/tests/test_api_requester_authz.py
+++ b/apps/web/tests/test_api_requester_authz.py
@@ -1,0 +1,145 @@
+from flask import Flask
+
+from app.blueprints import api as api_module
+from app.blueprints.api import bp as api_bp
+from app.models import Character, PlayPeriod
+
+
+def _app(fake_sheets):
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['WEB_APP_API_TOKEN'] = 'legacy-token'
+    app.config['WEB_APP_API_READ_TOKEN'] = ''
+    app.config['WEB_APP_API_WRITE_TOKEN'] = ''
+    app.config['BOT_API_REPLAY_PROTECTION_ENABLED'] = False
+    app.config['ALLOWED_DISCORD_IDS'] = ['999999999999999999']
+    app.register_blueprint(api_bp, url_prefix='/api')
+
+    api_module.sheets_client = fake_sheets
+    api_module.limiter = None
+    return app
+
+
+class FakeSheets:
+    def __init__(self):
+        self.claims = []
+        self.spends = []
+        self.audit = []
+
+    def get_active_characters(self):
+        return [
+            Character(character_name='Alice', player_discord='111111111111111111', active=True),
+            Character(character_name='Bob', player_discord='222222222222222222', active=True),
+            Character(character_name='Retired', player_discord='111111111111111111', active=False),
+        ]
+
+    def get_characters_by_discord_id(self, discord_id: str):
+        return [c for c in self.get_active_characters() if c.player_discord == str(discord_id)]
+
+    def get_all_periods(self):
+        return [PlayPeriod(period_label='Night 77', night_number=77, submissions_open=True, active=True)]
+
+    def get_character(self, name: str):
+        for c in self.get_active_characters():
+            if c.character_name == name:
+                return c
+        return None
+
+    def get_xp_totals(self, _name: str):
+        return {'earned_xp': 4, 'total_xp': 22, 'total_spends': 3, 'ledger_spent': 1, 'available_xp': 18}
+
+    def submit_xp_claim(self, character_name: str, play_period: str, categories: dict):
+        self.claims.append((character_name, play_period, categories))
+
+    def submit_spend_request(self, **kwargs):
+        self.spends.append(kwargs)
+        return 6
+
+    def log_action(self, **kwargs):
+        self.audit.append(kwargs)
+
+
+def _auth(token='legacy-token'):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def test_claim_context_requires_requester_and_filters_to_owner():
+    app = _app(FakeSheets())
+    with app.test_client() as client:
+        missing = client.get('/api/meta/claim-context', headers=_auth())
+        assert missing.status_code == 400
+
+        own = client.get(
+            '/api/meta/claim-context?requesterDiscordId=111111111111111111',
+            headers=_auth(),
+        )
+        assert own.status_code == 200
+        body = own.get_json()
+        assert body['activeCharacters'] == ['Alice']
+        assert body['openPeriods'] == ['Night 77']
+
+
+def test_summary_requires_character_ownership_for_non_staff():
+    app = _app(FakeSheets())
+    with app.test_client() as client:
+        allowed = client.get(
+            '/api/characters/Alice/summary?requesterDiscordId=111111111111111111',
+            headers=_auth(),
+        )
+        assert allowed.status_code == 200
+
+        blocked = client.get(
+            '/api/characters/Bob/summary?requesterDiscordId=111111111111111111',
+            headers=_auth(),
+        )
+        assert blocked.status_code == 404
+
+
+def test_claim_and_spend_include_requester_and_enforce_ownership():
+    fake = FakeSheets()
+    app = _app(fake)
+    with app.test_client() as client:
+        blocked_claim = client.post(
+            '/api/claims',
+            headers=_auth(),
+            json={
+                'characterName': 'Bob',
+                'playPeriod': 'Night 77',
+                'requesterDiscordId': '111111111111111111',
+                'requesterDiscordName': 'alice-user',
+                'categories': {'posted_once': 'https://discord.com/channels/1/2/3'},
+            },
+        )
+        assert blocked_claim.status_code == 404
+
+        ok_claim = client.post(
+            '/api/claims',
+            headers=_auth(),
+            json={
+                'characterName': 'Alice',
+                'playPeriod': 'Night 77',
+                'requesterDiscordId': '111111111111111111',
+                'requesterDiscordName': 'alice-user',
+                'categories': {'posted_once': 'https://discord.com/channels/1/2/3'},
+            },
+        )
+        assert ok_claim.status_code == 201
+
+        ok_spend = client.post(
+            '/api/spends',
+            headers=_auth(),
+            json={
+                'characterName': 'Alice',
+                'spendCategory': 'Merit/Background',
+                'traitName': 'Status',
+                'currentDots': 0,
+                'newDots': 2,
+                'justification': 'Bot flow',
+                'isInClan': False,
+                'requesterDiscordId': '111111111111111111',
+                'requesterDiscordName': 'alice-user',
+            },
+        )
+        assert ok_spend.status_code == 201
+        assert fake.audit
+        assert fake.audit[-1]['staff_user'] == 'bot-api:111111111111111111'


### PR DESCRIPTION
## Summary\n- require requester Discord snowflake on bot API requests\n- enforce requester ownership (or staff allowlist) for summary, claim-context, claims, and spends\n- include requester identity in bot payloads and audit logs\n- scope claim-context caching by requester ID in bot adapter\n- add API tests for requester enforcement and ownership checks\n\n## Validation\n- apps/bot: npm run check\n- backend: ./venv/bin/pytest -q (15 passed)\n- bot runtime: npm run dev (bot_ready + command_registration_guild)\n