### PR TITLE
Fix adapter smoke check for requester-scoped claim-context

### DIFF
--- a/apps/bot/scripts/check-adapter.sh
+++ b/apps/bot/scripts/check-adapter.sh
@@ -21,8 +21,18 @@ echo "Health: ${WEB_APP_BASE_URL}/api/health"
 curl -fsS "${WEB_APP_BASE_URL}/api/health" | sed -n '1,3p'
 
 if [[ -n "${WEB_APP_API_TOKEN:-}" ]]; then
-  echo "Claim context (auth): ${WEB_APP_BASE_URL}/api/meta/claim-context"
-  curl -fsS -H "Authorization: Bearer ${WEB_APP_API_TOKEN}" "${WEB_APP_BASE_URL}/api/meta/claim-context" | sed -n '1,5p'
+  REQUESTER_DISCORD_ID="${REQUESTER_DISCORD_ID:-${TEST_REQUESTER_DISCORD_ID:-}}"
+  if [[ -z "${REQUESTER_DISCORD_ID}" ]]; then
+    echo "ERROR: REQUESTER_DISCORD_ID (or TEST_REQUESTER_DISCORD_ID) is required for claim-context check."
+    echo "Set one in apps/bot/.env to test authenticated caller-scoped context."
+    exit 1
+  fi
+  echo "Claim context (auth): ${WEB_APP_BASE_URL}/api/meta/claim-context?requesterDiscordId=<masked>"
+  curl -fsS \
+    -H "Authorization: Bearer ${WEB_APP_API_TOKEN}" \
+    --get \
+    --data-urlencode "requesterDiscordId=${REQUESTER_DISCORD_ID}" \
+    "${WEB_APP_BASE_URL}/api/meta/claim-context" | sed -n '1,5p'
 else
   echo "WEB_APP_API_TOKEN not set; skipping authenticated check"
 fi


### PR DESCRIPTION
## Summary\n- update apps/bot/scripts/check-adapter.sh to include requesterDiscordId query param for /api/meta/claim-context\n- require REQUESTER_DISCORD_ID (or TEST_REQUESTER_DISCORD_ID) in env for authenticated caller-scoped check\n\n## Validation\n- npm run ops:check-adapter passes against local web+bot stack\n