### PR TITLE
Add autocomplete to xp commands and staff test-mode

### DIFF
--- a/apps/bot/src/__tests__/xpCommand.test.ts
+++ b/apps/bot/src/__tests__/xpCommand.test.ts
@@ -15,6 +15,7 @@ describe('xp claim command validation', () => {
       guildId: 'guild-1',
       options: {
         getSubcommand: vi.fn(() => 'claim'),
+        getBoolean: vi.fn(() => null),
         getString: vi.fn((name: string) => {
           const values: Record<string, string> = {
             character: 'Alice',

--- a/apps/bot/src/commands/xp.ts
+++ b/apps/bot/src/commands/xp.ts
@@ -30,19 +30,49 @@ export const data = new SlashCommandBuilder()
           .setAutocomplete(true)
           .setRequired(false),
       )
-      .addStringOption((o) => o.setName('play_period').setDescription('Optional preselected period label').setRequired(false)),
+      .addStringOption((o) => o.setName('play_period').setDescription('Optional preselected period label').setRequired(false))
+      .addBooleanOption((o) =>
+        o.setName('test').setDescription('Staff only: simulate player-scoped visibility').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('test_as_discord_id')
+          .setDescription('Staff only: player Discord ID to emulate (snowflake)')
+          .setRequired(false),
+      ),
   )
   .addSubcommand((s) =>
     s
       .setName('summary')
       .setDescription('Get XP summary for a character from the web-app adapter')
-      .addStringOption((o) => o.setName('character').setDescription('Character name').setRequired(true)),
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name')
+          .setRequired(true)
+          .setAutocomplete(true),
+      )
+      .addBooleanOption((o) =>
+        o.setName('test').setDescription('Staff only: simulate player-scoped visibility').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('test_as_discord_id')
+          .setDescription('Staff only: player Discord ID to emulate (snowflake)')
+          .setRequired(false),
+      ),
   )
   .addSubcommand((s) =>
     s
       .setName('claim')
       .setDescription('Submit a simple XP claim via adapter')
-      .addStringOption((o) => o.setName('character').setDescription('Character name').setRequired(true))
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name')
+          .setRequired(true)
+          .setAutocomplete(true),
+      )
       .addStringOption((o) => o.setName('play_period').setDescription('Period label').setRequired(true))
       .addStringOption((o) =>
         o
@@ -51,13 +81,28 @@ export const data = new SlashCommandBuilder()
           .setRequired(true)
           .addChoices(...CLAIM_CATEGORY_CHOICES),
       )
-      .addStringOption((o) => o.setName('link').setDescription('Discord post link').setRequired(true)),
+      .addStringOption((o) => o.setName('link').setDescription('Discord post link').setRequired(true))
+      .addBooleanOption((o) =>
+        o.setName('test').setDescription('Staff only: simulate player-scoped visibility').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('test_as_discord_id')
+          .setDescription('Staff only: player Discord ID to emulate (snowflake)')
+          .setRequired(false),
+      ),
   )
   .addSubcommand((s) =>
     s
       .setName('spend')
       .setDescription('Submit an XP spend request via adapter')
-      .addStringOption((o) => o.setName('character').setDescription('Character name').setRequired(true))
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name')
+          .setRequired(true)
+          .setAutocomplete(true),
+      )
       .addStringOption((o) =>
         o
           .setName('category')
@@ -73,7 +118,16 @@ export const data = new SlashCommandBuilder()
         o.setName('new_dots').setDescription('New dots').setRequired(true).setMinValue(0).setMaxValue(10),
       )
       .addStringOption((o) => o.setName('justification').setDescription('RP rationale').setRequired(true))
-      .addBooleanOption((o) => o.setName('is_in_clan').setDescription('In-clan discipline?').setRequired(false)),
+      .addBooleanOption((o) => o.setName('is_in_clan').setDescription('In-clan discipline?').setRequired(false))
+      .addBooleanOption((o) =>
+        o.setName('test').setDescription('Staff only: simulate player-scoped visibility').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('test_as_discord_id')
+          .setDescription('Staff only: player Discord ID to emulate (snowflake)')
+          .setRequired(false),
+      ),
   )
   .addSubcommand((s) =>
     s
@@ -103,18 +157,22 @@ export const name = 'xp';
 
 export async function autocomplete(interaction: AutocompleteInteraction, { adapter }: CommandContext) {
   const option = interaction.options.getFocused(true);
-  const sub = interaction.options.getSubcommand(false);
-  if (sub !== 'submit' || option.name !== 'character') {
+  const sub = interaction.options.getSubcommand(false) ?? '';
+  const supportsCharacterAutocomplete = new Set(['submit', 'summary', 'claim', 'spend']);
+  if (!supportsCharacterAutocomplete.has(sub) || option.name !== 'character') {
     await interaction.respond([]);
     return;
   }
 
   try {
-    const query = String(option.value ?? '').trim().toLowerCase();
-    const context = await adapter.getClaimContext({
+    const requester = {
       requesterDiscordId: interaction.user.id,
       requesterDiscordName: interaction.user.username,
-    });
+      testMode: interaction.options.getBoolean('test') ?? false,
+      testAsDiscordId: interaction.options.getString('test_as_discord_id') ?? undefined,
+    };
+    const query = String(option.value ?? '').trim().toLowerCase();
+    const context = await adapter.getClaimContext(requester);
     const values = context.activeCharacters;
 
     const startsWith = values.filter((v: string) => v.toLowerCase().startsWith(query));
@@ -140,6 +198,8 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
   const requester = {
     requesterDiscordId: interaction.user.id,
     requesterDiscordName: interaction.user.username,
+    testMode: interaction.options.getBoolean('test') ?? false,
+    testAsDiscordId: interaction.options.getString('test_as_discord_id') ?? undefined,
   };
   const meta = {
     interactionId: interaction.id,
@@ -154,7 +214,7 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
     const playPeriod = interaction.options.getString('play_period') ?? undefined;
     await interaction.deferReply({ ephemeral: true });
     try {
-      await startClaimWizard(interaction, adapter, character, playPeriod);
+      await startClaimWizard(interaction, adapter, character, playPeriod, requester);
       logEvent('info', 'xp_submit_ready', meta);
     } catch (error) {
       logEvent('error', 'xp_submit_failed', { ...meta, error: errorToMessage(error) });
@@ -205,8 +265,7 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
     const result = await adapter.submitClaim({
       characterName: character,
       playPeriod,
-      requesterDiscordId: requester.requesterDiscordId,
-      requesterDiscordName: requester.requesterDiscordName,
+      ...requester,
       categories: {
         [category]: link,
       },
@@ -228,8 +287,7 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
 
     const result = await adapter.submitSpend({
       characterName: character,
-      requesterDiscordId: requester.requesterDiscordId,
-      requesterDiscordName: requester.requesterDiscordName,
+      ...requester,
       spendCategory: spendCategory as XpSpendCategory,
       traitName,
       currentDots,

--- a/apps/bot/src/interactiveClaimWizard.ts
+++ b/apps/bot/src/interactiveClaimWizard.ts
@@ -13,7 +13,7 @@ import {
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import type { TrackerAdapter } from './services/adapter';
-import type { XpClaimCategory } from './types';
+import type { RequesterContext, XpClaimCategory } from './types';
 import { parseMessageLink } from './utils/linkValidator';
 
 const CATEGORY_OPTIONS = [
@@ -51,6 +51,7 @@ type ClaimDraft = {
   periodPage: number;
   categories: XpClaimCategory[];
   links: Partial<Record<XpClaimCategory, string>>;
+  requester: RequesterContext;
   createdAt: number;
 };
 
@@ -250,13 +251,17 @@ export async function startClaimWizard(
   adapter: TrackerAdapter,
   initialCharacter?: string,
   initialPlayPeriod?: string,
+  requester?: RequesterContext,
 ) {
   cleanupExpiredDrafts();
 
-  const context = await adapter.getClaimContext({
-    requesterDiscordId: interaction.user.id,
-    requesterDiscordName: interaction.user.username,
-  });
+  const resolvedRequester: RequesterContext =
+    requester ?? {
+      requesterDiscordId: interaction.user.id,
+      requesterDiscordName: interaction.user.username,
+    };
+
+  const context = await adapter.getClaimContext(resolvedRequester);
 
   const characterName = initialCharacter && context.activeCharacters.includes(initialCharacter)
     ? initialCharacter
@@ -276,6 +281,7 @@ export async function startClaimWizard(
     periodPage: pageForValue(context.openPeriods, playPeriod),
     categories: [],
     links: {},
+    requester: resolvedRequester,
     createdAt: Date.now(),
   };
   drafts.set(interaction.user.id, draft);
@@ -461,8 +467,7 @@ export async function handleClaimWizardButton(interaction: ButtonInteraction, ad
     const result = await adapter.submitClaim({
       characterName: draft.characterName,
       playPeriod: draft.playPeriod,
-      requesterDiscordId: interaction.user.id,
-      requesterDiscordName: interaction.user.username,
+      ...draft.requester,
       categories: payloadCategories,
     });
 

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -74,6 +74,12 @@ export class WebAppAdapter implements TrackerAdapter {
     if (requester.requesterDiscordName) {
       params.set('requesterDiscordName', requester.requesterDiscordName);
     }
+    if (requester.testMode) {
+      params.set('testMode', 'true');
+    }
+    if (requester.testAsDiscordId) {
+      params.set('testAsDiscordId', requester.testAsDiscordId);
+    }
     const url = `${this.baseUrl}/api/characters/${encodeURIComponent(characterName)}/summary?${params.toString()}`;
     const resp = await this.fetchWithTimeout(url, {
       headers: this.authHeaders(),
@@ -252,6 +258,12 @@ export class WebAppAdapter implements TrackerAdapter {
         const params = new URLSearchParams({ requesterDiscordId: requester.requesterDiscordId });
         if (requester.requesterDiscordName) {
           params.set('requesterDiscordName', requester.requesterDiscordName);
+        }
+        if (requester.testMode) {
+          params.set('testMode', 'true');
+        }
+        if (requester.testAsDiscordId) {
+          params.set('testAsDiscordId', requester.testAsDiscordId);
         }
         const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/meta/claim-context?${params.toString()}`, {
           headers: this.authHeaders(),

--- a/apps/bot/src/types.ts
+++ b/apps/bot/src/types.ts
@@ -25,6 +25,8 @@ export type ClaimContext = {
 export type RequesterContext = {
   requesterDiscordId: string;
   requesterDiscordName?: string;
+  testMode?: boolean;
+  testAsDiscordId?: string;
 };
 
 export type ClaimPayload = {

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -164,30 +164,73 @@ def _requester_from_query():
     requester_discord_id = str(request.args.get('requesterDiscordId', '')).strip()
     requester_discord_name = str(request.args.get('requesterDiscordName', '')).strip()
     if not requester_discord_id:
-        return None, None, (jsonify({'error': 'requesterDiscordId is required'}), 400)
+        return None, None, None, None, None, (jsonify({'error': 'requesterDiscordId is required'}), 400)
     if not DISCORD_ID_RE.fullmatch(requester_discord_id):
-        return None, None, (jsonify({'error': 'requesterDiscordId must be a Discord snowflake'}), 400)
-    return requester_discord_id, requester_discord_name, None
+        return None, None, None, None, None, (jsonify({'error': 'requesterDiscordId must be a Discord snowflake'}), 400)
+    test_mode = str(request.args.get('testMode', '')).strip().lower() in {'1', 'true', 'yes', 'on'}
+    test_as_discord_id = str(request.args.get('testAsDiscordId', '')).strip()
+    effective_discord_id, effective_name, error = _resolve_effective_requester(
+        requester_discord_id=requester_discord_id,
+        requester_discord_name=requester_discord_name,
+        test_mode=test_mode,
+        test_as_discord_id=test_as_discord_id,
+    )
+    if error:
+        return None, None, None, None, None, error
+    return requester_discord_id, requester_discord_name, effective_discord_id, effective_name, test_mode, None
 
 
 def _requester_from_payload(payload: dict):
     requester_discord_id = str(payload.get('requesterDiscordId', '')).strip()
     requester_discord_name = str(payload.get('requesterDiscordName', '')).strip()
     if not requester_discord_id:
-        return None, None, (jsonify({'error': 'requesterDiscordId is required'}), 400)
+        return None, None, None, None, None, (jsonify({'error': 'requesterDiscordId is required'}), 400)
     if not DISCORD_ID_RE.fullmatch(requester_discord_id):
-        return None, None, (jsonify({'error': 'requesterDiscordId must be a Discord snowflake'}), 400)
-    return requester_discord_id, requester_discord_name, None
+        return None, None, None, None, None, (jsonify({'error': 'requesterDiscordId must be a Discord snowflake'}), 400)
+    test_mode = str(payload.get('testMode', '')).strip().lower() in {'1', 'true', 'yes', 'on'}
+    test_as_discord_id = str(payload.get('testAsDiscordId', '')).strip()
+    effective_discord_id, effective_name, error = _resolve_effective_requester(
+        requester_discord_id=requester_discord_id,
+        requester_discord_name=requester_discord_name,
+        test_mode=test_mode,
+        test_as_discord_id=test_as_discord_id,
+    )
+    if error:
+        return None, None, None, None, None, error
+    return requester_discord_id, requester_discord_name, effective_discord_id, effective_name, test_mode, None
 
 
 def _is_requester_staff(requester_discord_id: str) -> bool:
     return is_allowed_discord_user(requester_discord_id)
 
 
-def _requester_can_access_character(char, requester_discord_id: str) -> bool:
-    if _is_requester_staff(requester_discord_id):
+def _requester_can_access_character(char, requester_discord_id: str, allow_staff_bypass: bool = True) -> bool:
+    if allow_staff_bypass and _is_requester_staff(requester_discord_id):
         return True
     return str(char.player_discord or '').strip() == requester_discord_id
+
+
+def _resolve_effective_requester(
+    requester_discord_id: str,
+    requester_discord_name: str,
+    test_mode: bool,
+    test_as_discord_id: str,
+):
+    if not test_mode:
+        return requester_discord_id, requester_discord_name, None
+
+    if not _is_requester_staff(requester_discord_id):
+        return None, None, _forbidden('Test mode is staff-only')
+
+    effective_discord_id = test_as_discord_id or requester_discord_id
+    if not DISCORD_ID_RE.fullmatch(effective_discord_id):
+        return None, None, (jsonify({'error': 'testAsDiscordId must be a Discord snowflake'}), 400)
+
+    if test_as_discord_id and test_as_discord_id != requester_discord_id:
+        effective_name = f'test-as:{test_as_discord_id}'
+    else:
+        effective_name = requester_discord_name
+    return effective_discord_id, effective_name, None
 
 
 @bp.route('/health', methods=['GET'])
@@ -202,14 +245,14 @@ def claim_context():
     backend = _require_sheets()
     if backend:
         return backend
-    requester_discord_id, _, error = _requester_from_query()
+    requester_discord_id, _, effective_discord_id, _, test_mode, error = _requester_from_query()
     if error:
         return error
 
-    if _is_requester_staff(requester_discord_id):
+    if (not test_mode) and effective_discord_id == requester_discord_id and _is_requester_staff(requester_discord_id):
         characters = sheets_client.get_active_characters()
     else:
-        characters = [c for c in sheets_client.get_characters_by_discord_id(requester_discord_id) if c.active]
+        characters = [c for c in sheets_client.get_characters_by_discord_id(effective_discord_id) if c.active]
     characters.sort(key=lambda c: c.character_name.lower())
     open_periods = _open_periods_desc()
 
@@ -229,14 +272,14 @@ def character_summary(name: str):
     backend = _require_sheets()
     if backend:
         return backend
-    requester_discord_id, _, error = _requester_from_query()
+    _, _, effective_discord_id, _, test_mode, error = _requester_from_query()
     if error:
         return error
 
     char = sheets_client.get_character(name)
     if not char:
         return jsonify({'error': 'Character not found'}), 404
-    if not _requester_can_access_character(char, requester_discord_id):
+    if not _requester_can_access_character(char, effective_discord_id, allow_staff_bypass=not test_mode):
         return jsonify({'error': 'Character not found'}), 404
 
     totals = sheets_client.get_xp_totals(name)
@@ -261,7 +304,7 @@ def submit_claim():
         return backend
 
     payload = request.get_json(silent=True) or {}
-    requester_discord_id, requester_discord_name, error = _requester_from_payload(payload)
+    requester_discord_id, requester_discord_name, effective_discord_id, effective_name, test_mode, error = _requester_from_payload(payload)
     if error:
         return error
     character_name = str(payload.get('characterName', '')).strip()
@@ -274,7 +317,7 @@ def submit_claim():
     char = sheets_client.get_character(character_name)
     if not char:
         return jsonify({'error': 'Character not found'}), 404
-    if not _requester_can_access_character(char, requester_discord_id):
+    if not _requester_can_access_character(char, effective_discord_id, allow_staff_bypass=not test_mode):
         return jsonify({'error': 'Character not found'}), 404
 
     if not char.active:
@@ -300,7 +343,7 @@ def submit_claim():
             target=character_name,
             details=(
                 f'Claim submitted for {play_period} by '
-                f'{requester_discord_name or requester_discord_id}'
+                f'{effective_name or requester_discord_name or requester_discord_id}'
             ),
         )
     except ValueError as exc:
@@ -319,7 +362,7 @@ def submit_spend():
         return backend
 
     payload = request.get_json(silent=True) or {}
-    requester_discord_id, requester_discord_name, error = _requester_from_payload(payload)
+    requester_discord_id, requester_discord_name, effective_discord_id, effective_name, test_mode, error = _requester_from_payload(payload)
     if error:
         return error
 
@@ -344,7 +387,7 @@ def submit_spend():
     char = sheets_client.get_character(character_name)
     if not char:
         return jsonify({'error': 'Character not found'}), 404
-    if not _requester_can_access_character(char, requester_discord_id):
+    if not _requester_can_access_character(char, effective_discord_id, allow_staff_bypass=not test_mode):
         return jsonify({'error': 'Character not found'}), 404
 
     try:
@@ -363,7 +406,7 @@ def submit_spend():
             target=character_name,
             details=(
                 f'{spend_category}: {trait_name} ({current_dots}->{new_dots}) '
-                f'for {xp_cost} XP by {requester_discord_name or requester_discord_id}'
+                f'for {xp_cost} XP by {effective_name or requester_discord_name or requester_discord_id}'
             ),
         )
     except ValueError as exc:

--- a/apps/web/tests/test_api_requester_authz.py
+++ b/apps/web/tests/test_api_requester_authz.py
@@ -79,6 +79,28 @@ def test_claim_context_requires_requester_and_filters_to_owner():
         assert body['openPeriods'] == ['Night 77']
 
 
+def test_staff_test_mode_can_emulate_player_scope():
+    app = _app(FakeSheets())
+    with app.test_client() as client:
+        res = client.get(
+            '/api/meta/claim-context?requesterDiscordId=999999999999999999&testMode=true&testAsDiscordId=222222222222222222',
+            headers=_auth(),
+        )
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body['activeCharacters'] == ['Bob']
+
+
+def test_non_staff_cannot_use_test_mode():
+    app = _app(FakeSheets())
+    with app.test_client() as client:
+        res = client.get(
+            '/api/meta/claim-context?requesterDiscordId=111111111111111111&testMode=true',
+            headers=_auth(),
+        )
+        assert res.status_code == 403
+
+
 def test_summary_requires_character_ownership_for_non_staff():
     app = _app(FakeSheets())
     with app.test_client() as client:


### PR DESCRIPTION
## Summary\n- add character autocomplete for /xp summary, /xp claim, and /xp spend\n- add staff-only test mode options (, ) on submit/summary/claim/spend\n- propagate test context through bot adapter and wizard submit flow\n- add backend API support for requester test emulation with strict staff-only enforcement\n- add/expand tests for requester authz and test-mode behavior\n\n## Validation\n- apps/bot: npm run check\n- backend: ./venv/bin/pytest -q (17 passed)\n