### PR TITLE
Make announcements channel ID configurable from settings UI

### DIFF
--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js';
 import type { CommandContext } from '../discord';
 import { config } from '../config';
+import { liveConfig } from '../liveConfig';
 import { buildCubbyChannelMap, normalizeChannelName } from '../services/cubbyChannels';
 import { errorToMessage, logEvent } from '../logger';
 
@@ -92,7 +93,7 @@ export async function handleBroadcastModal(
   const results: string[] = [];
 
   if (sendToAnnouncements) {
-    const channelId = config.announcementsChannelId;
+    const channelId = liveConfig.announcementsChannelId ?? config.announcementsChannelId;
     if (!channelId) {
       results.push('⚠️ `ANNOUNCEMENTS_CHANNEL_ID` is not configured — skipped #announcements.');
     } else {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -71,6 +71,7 @@ async function applyStartupConfigOverrides(): Promise<void> {
     if (cfg.reviewNotifierIntervalMs !== null) liveConfig.reviewNotifierIntervalMs = cfg.reviewNotifierIntervalMs;
     if (cfg.submissionNotifierIntervalMs !== null) liveConfig.submissionNotifierIntervalMs = cfg.submissionNotifierIntervalMs;
     if (cfg.claimReminderIntervalMs !== null) liveConfig.claimReminderIntervalMs = cfg.claimReminderIntervalMs;
+    if (cfg.announcementsChannelId) liveConfig.announcementsChannelId = cfg.announcementsChannelId;
     logEvent('info', 'startup_config_loaded', { liveConfig });
   } catch (err) {
     logEvent('warn', 'startup_config_fetch_failed', { error: errorToMessage(err) });

--- a/apps/bot/src/liveConfig.ts
+++ b/apps/bot/src/liveConfig.ts
@@ -12,4 +12,6 @@ export const liveConfig = {
   reviewNotifierIntervalMs: null as number | null,
   submissionNotifierIntervalMs: null as number | null,
   claimReminderIntervalMs: null as number | null,
+  /** DB-override channel IDs (null = use .env default). Applied on next bot restart. */
+  announcementsChannelId: null as string | null,
 };

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -26,6 +26,7 @@ export interface BotConfigResponse {
   reviewNotifierIntervalMs: number | null;
   submissionNotifierIntervalMs: number | null;
   claimReminderIntervalMs: number | null;
+  announcementsChannelId: string | null;
 }
 
 export interface TrackerAdapter {

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -25,6 +25,7 @@ export class ConfigSyncWorker {
       liveConfig.reviewNotifierIntervalMs = cfg.reviewNotifierIntervalMs ?? null;
       liveConfig.submissionNotifierIntervalMs = cfg.submissionNotifierIntervalMs ?? null;
       liveConfig.claimReminderIntervalMs = cfg.claimReminderIntervalMs ?? null;
+      liveConfig.announcementsChannelId = cfg.announcementsChannelId ?? null;
       logEvent('debug', 'config_sync_done', { liveConfig });
 
       if (cfg.restartRequested) {

--- a/apps/web/app/app_settings.py
+++ b/apps/web/app/app_settings.py
@@ -27,6 +27,8 @@ EDITABLE_KEYS = {
     'BOT_HUNT_CONSEQUENCE_ENABLED',
     # Bot restart signal
     'BOT_RESTART_REQUESTED',
+    # Bot channel IDs (polled by bot via /api/bot-config; take effect after restart)
+    'BOT_ANNOUNCEMENTS_CHANNEL_ID',
     # Bot tuning (polled by bot via /api/bot-config; take effect after restart)
     'BOT_PASSAGE_OF_TIME_INTERVAL_MS',
     'BOT_REVIEW_NOTIFIER_INTERVAL_MS',

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -606,7 +606,10 @@ def bot_config():
         'BOT_SUBMISSION_NOTIFIER_INTERVAL_MS': 'submissionNotifierIntervalMs',
         'BOT_CLAIM_REMINDER_INTERVAL_MS': 'claimReminderIntervalMs',
     }
-    all_keys = list(BOOL_KEYS) + list(INT_KEYS)
+    STR_KEYS = {
+        'BOT_ANNOUNCEMENTS_CHANNEL_ID': 'announcementsChannelId',
+    }
+    all_keys = list(BOOL_KEYS) + list(INT_KEYS) + list(STR_KEYS)
     from app.db import AppSetting
     records = {r.key: r for r in AppSetting.query.filter(AppSetting.key.in_(all_keys)).all()}
     result = {}
@@ -622,6 +625,9 @@ def bot_config():
                 result[api_key] = int(record.value)
             except (ValueError, TypeError):
                 result[api_key] = None
+    for db_key, api_key in STR_KEYS.items():
+        record = records.get(db_key)
+        result[api_key] = record.value.strip() if record else None
     return jsonify(result)
 
 

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -278,6 +278,24 @@ def index():
         },
     ]
 
+    # ── Bot channel IDs (DB-backed; take effect after bot restart) ────────
+    def _eff_str(key):
+        record = overrides.get(key)
+        return record.value.strip() if record else None
+
+    bot_channels = [
+        {
+            'label': 'Announcements channel',
+            'key': 'BOT_ANNOUNCEMENTS_CHANNEL_ID',
+            'env': 'ANNOUNCEMENTS_CHANNEL_ID',
+            'value': _eff_str('BOT_ANNOUNCEMENTS_CHANNEL_ID'),
+            'placeholder': 'Discord channel ID (18–19 digits)',
+            'overridden': 'BOT_ANNOUNCEMENTS_CHANNEL_ID' in overrides,
+            'editable': True,
+            'description': 'Channel ID for /lasombra broadcast → announcements target.',
+        },
+    ]
+
     # ── Bot tuning (DB-backed; take effect after bot restart) ─────────────
     bot_tuning = [
         {
@@ -346,6 +364,7 @@ def index():
         web_tuning=web_tuning,
         integrations=integrations,
         bot_flags=bot_flags,
+        bot_channels=bot_channels,
         bot_tuning=bot_tuning,
         can_edit=can_edit,
         bot_heartbeat_age=bot_heartbeat_age,
@@ -391,6 +410,11 @@ def update():
         or session.get('discord_id', 'unknown')
     )
 
+    # Keys that store raw strings (no type coercion).
+    _STR_KEYS = {
+        'BOT_ANNOUNCEMENTS_CHANNEL_ID',
+    }
+
     # Keys that are always boolean regardless of whether they appear in app.config.
     _BOOL_KEYS = {
         'AUTO_CREATE_PERIODS_ENABLED',
@@ -412,7 +436,9 @@ def update():
     else:
         raw_value = request.form.get('value', '').strip()
         cfg_val = current_app.config.get(key)
-        if key in _BOOL_KEYS or isinstance(cfg_val, bool):
+        if key in _STR_KEYS:
+            set_app_setting(key, raw_value, updated_by)
+        elif key in _BOOL_KEYS or isinstance(cfg_val, bool):
             coerced = raw_value.lower() in ('true', '1', 'yes', 'on')
             set_app_setting(key, str(coerced).lower(), updated_by)
         else:

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -183,6 +183,64 @@
     </div>
   </div>
 
+  {# ═══ Bot — Channel IDs ═══ #}
+  <h5 class="text-muted text-uppercase small mb-2 mt-4">Bot — Channel IDs</h5>
+  <p class="text-muted small mb-2">
+    Stored in the database. Click <strong>Restart Bot</strong> above to apply. Leave blank to use the bot's <code>.env</code> value.
+  </p>
+  <div class="card mb-4">
+    <div class="card-body p-0">
+      <table class="table table-dark table-sm mb-0 align-middle">
+        <thead>
+          <tr>
+            <th style="width:220px">Channel</th>
+            <th style="width:{% if can_edit %}280px{% else %}180px{% endif %}">ID</th>
+            <th>Description</th>
+            <th class="d-none d-md-table-cell text-muted" style="width:280px">Env var</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for c in bot_channels %}
+          <tr>
+            <td class="fw-semibold">
+              {{ c.label }}
+              {% if c.overridden %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
+            </td>
+            <td>
+              {% if can_edit and c.editable %}
+                <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1">
+                  <input type="hidden" name="key" value="{{ c.key }}">
+                  <input type="hidden" name="action" value="set">
+                  <input type="text" name="value" value="{{ c.value or '' }}"
+                    placeholder="{{ c.placeholder }}"
+                    pattern="\d{17,20}" title="Discord snowflake (17–20 digits)"
+                    class="form-control form-control-sm bg-dark text-light border-secondary font-monospace" style="width:160px">
+                  <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
+                </form>
+                {% if c.overridden %}
+                <form method="POST" action="{{ url_for('settings.update') }}" class="mt-1">
+                  <input type="hidden" name="key" value="{{ c.key }}">
+                  <input type="hidden" name="action" value="reset">
+                  <button type="submit" class="btn btn-sm btn-link text-muted p-0" style="font-size:.75rem">reset to env</button>
+                </form>
+                {% endif %}
+              {% else %}
+                {% if c.value %}
+                  <span class="badge bg-dark border border-secondary font-monospace">{{ c.value }}</span>
+                {% else %}
+                  <span class="text-muted small">env default</span>
+                {% endif %}
+              {% endif %}
+            </td>
+            <td class="text-muted small">{{ c.description }}</td>
+            <td class="d-none d-md-table-cell"><code class="small text-info">{{ c.env }}</code></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   {# ═══ Bot — Tuning ═══ #}
   <h5 class="text-muted text-uppercase small mb-2 mt-4">Bot — Tuning</h5>
   <p class="text-muted small mb-2">


### PR DESCRIPTION
## Summary
- Adds a new **Bot — Channel IDs** section to the settings page with a text input for the announcements channel Discord snowflake
- Stored as `BOT_ANNOUNCEMENTS_CHANNEL_ID` in the DB — no `.env` edit needed
- Bot reads the DB value at startup and via live sync; `/lasombra broadcast` prefers the DB value over `.env`
- Supports reset-to-env via the reset link

## Test plan
- [ ] Navigate to Settings → Bot — Channel IDs
- [ ] Enter the announcements channel snowflake and save
- [ ] Use `/lasombra broadcast` → announcements — confirm it posts without the "not configured" warning
- [ ] Click "reset to env" — confirm it reverts to the `.env` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)