### PR TITLE
Fix recurring MONOREPO_ROOT error after Docker restarts

### DIFF
--- a/compose.full.yml
+++ b/compose.full.yml
@@ -15,6 +15,7 @@ services:
       PYTHONDONTWRITEBYTECODE: "1"
       TZ: ${TZ:-America/Chicago}
       WEB_LOG_DIR: /run/logs
+      MONOREPO_ROOT: /app
     ports:
       - "127.0.0.1:5001:5001"
     volumes:

--- a/compose.web.yml
+++ b/compose.web.yml
@@ -15,6 +15,7 @@ services:
       PYTHONDONTWRITEBYTECODE: "1"
       TZ: ${TZ:-America/Chicago}
       WEB_LOG_DIR: /run/logs
+      MONOREPO_ROOT: /app
     ports:
       - "127.0.0.1:5001:5001"
     volumes:


### PR DESCRIPTION
## Summary

- Set `MONOREPO_ROOT=/app` in both `compose.web.yml` and `compose.full.yml` so the app never needs to walk the filesystem to locate the project root
- Eliminates the `RuntimeError: Unable to determine monorepo root` crash that appeared on macOS after Docker Desktop auto-restarted containers (file-sharing layer not ready in time)

## Test plan

- [ ] `./scripts/bootstrap-local.sh web-only` starts clean
- [ ] `./scripts/bootstrap-local.sh web+bot` starts clean
- [ ] Reboot machine, confirm containers restart without the MONOREPO_ROOT error

🤖 Generated with [Claude Code](https://claude.com/claude-code)