### PR TITLE
Fix passage-of-time announcements missing scheduled time

### DIFF
--- a/apps/bot/src/services/passageOfTimeService.ts
+++ b/apps/bot/src/services/passageOfTimeService.ts
@@ -287,11 +287,16 @@ export class PassageOfTimeService {
         if (parts.weekday !== event.weekdayLocal) {
           continue;
         }
-        // Fire if the target time falls in the window (prevTick, now] — works regardless of tick alignment
+        // Fire if the target time falls in the window (prevTick, now].
+        // When the tick spans midnight the window wraps: (prevMin, 1440) ∪ [0, nowMin].
         const targetMin = event.hourLocal * 60 + event.minuteLocal;
         const nowMin = parts.hour * 60 + parts.minute;
         const prevMin = prevParts.hour * 60 + prevParts.minute;
-        if (nowMin < targetMin || prevMin >= targetMin) {
+        const crossesMidnight = prevParts.dateKey !== parts.dateKey;
+        const inWindow = crossesMidnight
+          ? targetMin > prevMin || targetMin <= nowMin
+          : targetMin > prevMin && targetMin <= nowMin;
+        if (!inWindow) {
           continue;
         }
         if (!isCadenceDate(parts.dateKey, event.anchorDate, event.cadenceWeeks)) {

--- a/apps/bot/src/services/passageOfTimeService.ts
+++ b/apps/bot/src/services/passageOfTimeService.ts
@@ -201,10 +201,12 @@ export class PassageOfTimeService {
   private readonly config: PassageOfTimeConfig;
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private lastTickTime: Date;
 
   constructor(client: Client, config: PassageOfTimeConfig) {
     this.client = client;
     this.config = config;
+    this.lastTickTime = new Date(Date.now() - config.intervalMs);
   }
 
   start() {
@@ -272,9 +274,10 @@ export class PassageOfTimeService {
 
       const now = new Date();
       const parts = localParts(now, this.config.timezone);
+      const prevParts = localParts(this.lastTickTime, this.config.timezone);
+      this.lastTickTime = now;
       const state = readState();
       const posted = new Set(state.postedKeys);
-      const minuteWindow = Math.max(1, Math.ceil(this.config.intervalMs / 60_000));
       let postedCount = 0;
 
       for (const event of this.config.events) {
@@ -284,10 +287,11 @@ export class PassageOfTimeService {
         if (parts.weekday !== event.weekdayLocal) {
           continue;
         }
-        if (parts.hour !== event.hourLocal) {
-          continue;
-        }
-        if (parts.minute < event.minuteLocal || parts.minute >= event.minuteLocal + minuteWindow) {
+        // Fire if the target time falls in the window (prevTick, now] — works regardless of tick alignment
+        const targetMin = event.hourLocal * 60 + event.minuteLocal;
+        const nowMin = parts.hour * 60 + parts.minute;
+        const prevMin = prevParts.hour * 60 + prevParts.minute;
+        if (nowMin < targetMin || prevMin >= targetMin) {
           continue;
         }
         if (!isCadenceDate(parts.dateKey, event.anchorDate, event.cadenceWeeks)) {


### PR DESCRIPTION
## Summary

- Replace the fixed-minute-window check in `PassageOfTimeService.tick()` with a sliding window between the previous tick and now
- An event fires if the target time falls in `(lastTickTime, now]` — this works regardless of when the bot was started, eliminating the tick-alignment offset that caused announcements to be silently skipped

**Before:** checked if `now.minute` was within a fixed ±N window of the target minute. If the bot started at an odd offset, the window could never align.

**After:** tracks `lastTickTime` (initialised to `now - intervalMs`) and fires if `prevMin < targetMin <= nowMin`. Every tick correctly covers the elapsed interval.

## Test plan

- [ ] Start bot at an arbitrary minute offset from the scheduled announcement time
- [ ] Confirm announcement still fires within one tick interval of the scheduled time
- [ ] Confirm no double-posts on the same date key

🤖 Generated with [Claude Code](https://claude.com/claude-code)