### PR TITLE
Overhaul /lasombra broadcast with autocomplete targeting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,4 +124,5 @@ The `docker-and-docs-hygiene` job validates all compose files and smoke-starts t
 - `docs/RUN_BOT_DOCKER.md` — bot Docker runbook with audit log instructions
 - `docs/INSTALL_LITE.md` / `docs/INSTALL_REGULAR.md` — install guides
 - `docs/RELEASE_2026-03-13_TURSO_DB_MIGRATION.md` — Turso DB migration release notes
-- `docs/RELEASE_2026-03-16_BOT_HEALTH_AND_FIXES.md` — latest release notes (bot health monitoring, cubby monitor fix, sidebar pin, Docker ARM64 fixes)
+- `docs/RELEASE_2026-03-16_BOT_HEALTH_AND_FIXES.md` — bot health monitoring, cubby monitor fix, sidebar pin, Docker ARM64 fixes
+- `docs/RELEASE_2026-04-07_BROADCAST_AND_SCHEDULER_FIX.md` — latest release notes (staff broadcast overhaul, passage-of-time scheduler fix, MONOREPO_ROOT Docker fix)

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -90,7 +90,7 @@ export async function execute(interaction: ChatInputCommandInteraction, _ctx: Co
       .setLabel('Message')
       .setStyle(TextInputStyle.Paragraph)
       .setPlaceholder('Your announcement...')
-      .setMaxLength(2000)
+      .setMaxLength(1800)
       .setRequired(true);
 
     modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
@@ -207,9 +207,14 @@ export async function handleBroadcastModal(
     mentionParts.push(`<@${pending.mentionCharDiscordId}>`);
   }
 
-  const fullMessage = mentionParts.length > 0
-    ? `${mentionParts.join(' ')}\n\n${messageBody}`
-    : messageBody;
+  const prefix = mentionParts.length > 0 ? `${mentionParts.join(' ')}\n\n` : '';
+  const fullMessage = `${prefix}${messageBody}`;
+  if (fullMessage.length > 2000) {
+    await interaction.editReply(
+      `Message is too long after adding mentions (${fullMessage.length}/2000 chars). Shorten the body and try again.`,
+    );
+    return true;
+  }
 
   const guild = interaction.guild;
   if (!guild) {
@@ -331,6 +336,13 @@ export async function handleBroadcastModal(
       logEvent('warn', 'broadcast_channel_send_failed', { channelId: singleChannelId, error: errorToMessage(err) });
       results.push('⚠️ Failed to send to target channel.');
     }
+  }
+
+  if (results.length === 0) {
+    await interaction.editReply(
+      `⚠️ Unknown broadcast target \`${target}\`. Please re-run the command and choose a target from the autocomplete list.`,
+    );
+    return true;
   }
 
   await interaction.editReply(results.join('\n'));

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -1,5 +1,6 @@
 import {
   ActionRowBuilder,
+  AutocompleteInteraction,
   ChatInputCommandInteraction,
   ModalBuilder,
   SlashCommandBuilder,
@@ -9,7 +10,7 @@ import {
 import type { CommandContext } from '../discord';
 import { config } from '../config';
 import { liveConfig } from '../liveConfig';
-import { buildCubbyChannelMap, normalizeChannelName } from '../services/cubbyChannels';
+import { buildCubbyChannelMap, getChannelsInCubbyCategories, normalizeChannelName } from '../services/cubbyChannels';
 import { errorToMessage, logEvent } from '../logger';
 
 export const name = 'lasombra';
@@ -18,12 +19,48 @@ export const data = new SlashCommandBuilder()
   .setName('lasombra')
   .setDescription('Staff-only commands')
   .addSubcommand((s) =>
-    s.setName('broadcast').setDescription('Send a message to #announcements, all active character cubbies, or both'),
+    s
+      .setName('broadcast')
+      .setDescription('Send a message to announcements, cubbies, or a specific channel')
+      .addStringOption((o) =>
+        o
+          .setName('target')
+          .setDescription('Where to send — e.g. "cubbies", "announcements", a character name, or a channel')
+          .setRequired(true)
+          .setAutocomplete(true),
+      )
+      .addBooleanOption((o) =>
+        o.setName('mention-kindred').setDescription('Prepend an @Kindred mention').setRequired(false),
+      )
+      .addBooleanOption((o) =>
+        o.setName('mention-ghouls').setDescription('Prepend an @Ghouls mention').setRequired(false),
+      )
+      .addBooleanOption((o) =>
+        o.setName('mention-mortals').setDescription('Prepend an @Mortals mention').setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('mention-character')
+          .setDescription("Ping a specific character's player at the top of the message")
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
   );
 
 const BROADCAST_MODAL_ID = 'lasombra:broadcast:modal';
 
-export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+type PendingBroadcast = {
+  target: string;
+  mentionKindred: boolean;
+  mentionGhouls: boolean;
+  mentionMortals: boolean;
+  mentionCharDiscordId: string | null;
+};
+
+// Keyed by user ID — a user can only have one modal open at a time.
+const pendingBroadcasts = new Map<string, PendingBroadcast>();
+
+export async function execute(interaction: ChatInputCommandInteraction, _ctx: CommandContext): Promise<void> {
   const sub = interaction.options.getSubcommand();
 
   if (sub === 'broadcast') {
@@ -32,9 +69,21 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       return;
     }
 
-    const modal = new ModalBuilder()
-      .setCustomId(BROADCAST_MODAL_ID)
-      .setTitle('Staff Broadcast');
+    const target = interaction.options.getString('target', true);
+    const mentionKindred = interaction.options.getBoolean('mention-kindred') ?? false;
+    const mentionGhouls = interaction.options.getBoolean('mention-ghouls') ?? false;
+    const mentionMortals = interaction.options.getBoolean('mention-mortals') ?? false;
+    const mentionCharDiscordId = interaction.options.getString('mention-character') ?? null;
+
+    pendingBroadcasts.set(interaction.user.id, {
+      target,
+      mentionKindred,
+      mentionGhouls,
+      mentionMortals,
+      mentionCharDiscordId,
+    });
+
+    const modal = new ModalBuilder().setCustomId(BROADCAST_MODAL_ID).setTitle('Staff Broadcast');
 
     const messageInput = new TextInputBuilder()
       .setCustomId('message')
@@ -44,21 +93,83 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       .setMaxLength(2000)
       .setRequired(true);
 
-    const targetInput = new TextInputBuilder()
-      .setCustomId('target')
-      .setLabel('Send to')
-      .setStyle(TextInputStyle.Short)
-      .setPlaceholder('announcements / cubbies / both')
-      .setRequired(true);
-
-    modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(targetInput),
-    );
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
 
     await interaction.showModal(modal);
+  }
+}
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.testerDiscordIds.has(interaction.user.id)) {
+    await interaction.respond([]);
     return;
   }
+
+  const focused = interaction.options.getFocused(true);
+  const query = focused.value.toLowerCase();
+
+  if (focused.name === 'target') {
+    const choices: Array<{ name: string; value: string }> = [];
+
+    // Static targets
+    const statics = [
+      { name: 'All cubbies', value: 'cubbies' },
+      { name: 'Announcements channel', value: 'announcements' },
+      { name: 'Cubbies + announcements', value: 'both' },
+    ];
+    for (const s of statics) {
+      if (s.name.toLowerCase().includes(query) || s.value.includes(query)) {
+        choices.push(s);
+      }
+    }
+
+    // Individual character cubbies from active roster
+    try {
+      const roster = await ctx.adapter.getActiveRoster();
+      for (const charName of roster.characters) {
+        if (choices.length >= 25) break;
+        if (charName.toLowerCase().includes(query) || query === '') {
+          choices.push({ name: `Cubby: ${charName}`, value: `cubby:${charName}` });
+        }
+      }
+    } catch {
+      // Roster unavailable — skip dynamic cubby choices
+    }
+
+    // Channels inside the four cubby categories
+    if (interaction.guild && choices.length < 25) {
+      try {
+        const cubbyChannels = await getChannelsInCubbyCategories(interaction.guild);
+        for (const ch of cubbyChannels) {
+          if (choices.length >= 25) break;
+          if (ch.name.toLowerCase().includes(query) || query === '') {
+            choices.push({ name: `#${ch.name}`, value: `channel:${ch.id}` });
+          }
+        }
+      } catch {
+        // Channel fetch failed — skip
+      }
+    }
+
+    await interaction.respond(choices.slice(0, 25));
+    return;
+  }
+
+  if (focused.name === 'mention-character') {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      const choices = roster.characters
+        .filter((c) => c.discordId && c.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((c) => ({ name: c.name, value: c.discordId as string }));
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  await interaction.respond([]);
 }
 
 export async function handleBroadcastModal(
@@ -71,18 +182,34 @@ export async function handleBroadcastModal(
 
   await interaction.deferReply({ ephemeral: true });
 
-  const message = interaction.fields.getTextInputValue('message').trim();
-  const targetRaw = interaction.fields.getTextInputValue('target').trim().toLowerCase();
+  const pending = pendingBroadcasts.get(interaction.user.id);
+  pendingBroadcasts.delete(interaction.user.id);
 
-  if (!['announcements', 'cubbies', 'both'].includes(targetRaw)) {
-    await interaction.editReply(
-      'Invalid target. Please enter `announcements`, `cubbies`, or `both`.',
-    );
+  if (!pending) {
+    await interaction.editReply('Broadcast options expired. Please run the command again.');
     return true;
   }
 
-  const sendToAnnouncements = targetRaw === 'announcements' || targetRaw === 'both';
-  const sendToCubbies = targetRaw === 'cubbies' || targetRaw === 'both';
+  const messageBody = interaction.fields.getTextInputValue('message').trim();
+
+  // Build mention prefix
+  const mentionParts: string[] = [];
+  if (pending.mentionKindred && config.passageOfTimeKindredRoleId) {
+    mentionParts.push(`<@&${config.passageOfTimeKindredRoleId}>`);
+  }
+  if (pending.mentionGhouls && config.passageOfTimeGhoulRoleId) {
+    mentionParts.push(`<@&${config.passageOfTimeGhoulRoleId}>`);
+  }
+  if (pending.mentionMortals && config.passageOfTimeMortalRoleId) {
+    mentionParts.push(`<@&${config.passageOfTimeMortalRoleId}>`);
+  }
+  if (pending.mentionCharDiscordId) {
+    mentionParts.push(`<@${pending.mentionCharDiscordId}>`);
+  }
+
+  const fullMessage = mentionParts.length > 0
+    ? `${mentionParts.join(' ')}\n\n${messageBody}`
+    : messageBody;
 
   const guild = interaction.guild;
   if (!guild) {
@@ -90,8 +217,15 @@ export async function handleBroadcastModal(
     return true;
   }
 
+  const { target } = pending;
   const results: string[] = [];
 
+  const sendToAnnouncements = target === 'announcements' || target === 'both';
+  const sendToAllCubbies = target === 'cubbies' || target === 'both';
+  const singleCubbyName = target.startsWith('cubby:') ? target.slice('cubby:'.length) : null;
+  const singleChannelId = target.startsWith('channel:') ? target.slice('channel:'.length) : null;
+
+  // --- Announcements ---
   if (sendToAnnouncements) {
     const channelId = liveConfig.announcementsChannelId ?? config.announcementsChannelId;
     if (!channelId) {
@@ -100,7 +234,7 @@ export async function handleBroadcastModal(
       try {
         const channel = await guild.channels.fetch(channelId);
         if (channel && 'send' in channel && typeof channel.send === 'function') {
-          await (channel as { send: (content: string) => Promise<unknown> }).send(message);
+          await (channel as { send: (content: string) => Promise<unknown> }).send(fullMessage);
           results.push(`✅ Sent to <#${channelId}>.`);
         } else {
           results.push('⚠️ Announcements channel not found or not sendable.');
@@ -112,7 +246,8 @@ export async function handleBroadcastModal(
     }
   }
 
-  if (sendToCubbies) {
+  // --- All cubbies ---
+  if (sendToAllCubbies) {
     let characters: string[] = [];
     try {
       const roster = await ctx.adapter.getActiveRoster();
@@ -124,9 +259,6 @@ export async function handleBroadcastModal(
       return true;
     }
 
-    let sent = 0;
-    let missing = 0;
-
     let channelMap: Map<string, import('../services/cubbyChannels').NotificationChannel>;
     try {
       channelMap = await buildCubbyChannelMap(guild);
@@ -137,6 +269,8 @@ export async function handleBroadcastModal(
       return true;
     }
 
+    let sent = 0;
+    let missing = 0;
     for (const characterName of characters) {
       const channel = channelMap.get(normalizeChannelName(characterName));
       if (!channel) {
@@ -145,14 +279,11 @@ export async function handleBroadcastModal(
         continue;
       }
       try {
-        await channel.send({ content: message });
+        await channel.send({ content: fullMessage });
         sent += 1;
       } catch (err) {
         missing += 1;
-        logEvent('warn', 'broadcast_cubby_send_failed', {
-          characterName,
-          error: errorToMessage(err),
-        });
+        logEvent('warn', 'broadcast_cubby_send_failed', { characterName, error: errorToMessage(err) });
       }
     }
 
@@ -160,11 +291,57 @@ export async function handleBroadcastModal(
     results.push(`✅ Sent to ${sent} cubby channel${sent !== 1 ? 's' : ''}${missedNote}.`);
   }
 
+  // --- Single cubby ---
+  if (singleCubbyName) {
+    let channelMap: Map<string, import('../services/cubbyChannels').NotificationChannel>;
+    try {
+      channelMap = await buildCubbyChannelMap(guild);
+    } catch (err) {
+      logEvent('warn', 'broadcast_channel_map_failed', { error: errorToMessage(err) });
+      results.push('⚠️ Failed to fetch channel list.');
+      await interaction.editReply(results.join('\n'));
+      return true;
+    }
+
+    const channel = channelMap.get(normalizeChannelName(singleCubbyName));
+    if (!channel) {
+      results.push(`⚠️ Could not find cubby channel for **${singleCubbyName}**.`);
+    } else {
+      try {
+        await channel.send({ content: fullMessage });
+        results.push(`✅ Sent to ${channel.name}'s cubby.`);
+      } catch (err) {
+        logEvent('warn', 'broadcast_cubby_send_failed', { characterName: singleCubbyName, error: errorToMessage(err) });
+        results.push(`⚠️ Failed to send to ${singleCubbyName}'s cubby.`);
+      }
+    }
+  }
+
+  // --- Named channel ---
+  if (singleChannelId) {
+    try {
+      const channel = await guild.channels.fetch(singleChannelId);
+      if (channel && 'send' in channel && typeof channel.send === 'function') {
+        await (channel as { send: (content: string) => Promise<unknown> }).send(fullMessage);
+        results.push(`✅ Sent to <#${singleChannelId}>.`);
+      } else {
+        results.push('⚠️ Target channel not found or not sendable.');
+      }
+    } catch (err) {
+      logEvent('warn', 'broadcast_channel_send_failed', { channelId: singleChannelId, error: errorToMessage(err) });
+      results.push('⚠️ Failed to send to target channel.');
+    }
+  }
+
   await interaction.editReply(results.join('\n'));
 
   logEvent('info', 'broadcast_sent', {
     userId: interaction.user.id,
-    target: targetRaw,
+    target,
+    mentionKindred: pending.mentionKindred,
+    mentionGhouls: pending.mentionGhouls,
+    mentionMortals: pending.mentionMortals,
+    mentionCharDiscordId: pending.mentionCharDiscordId,
   });
 
   return true;

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -33,6 +33,7 @@ export interface TrackerAdapter {
   getSummary(characterName: string, requester: RequesterContext, opts?: { includeHistory?: boolean }): Promise<XpSummary | null>;
   getClaimContext(requester: RequesterContext, opts?: { forceRefresh?: boolean }): Promise<ClaimContext>;
   getActiveRoster(): Promise<{ characters: string[] }>;
+  getActiveRosterWithIds(): Promise<{ characters: Array<{ name: string; discordId: string | null }> }>;
   getClaimReminderTargets(): Promise<ClaimReminderSnapshot>;
   getReviewEvents(opts?: {
     sinceEpoch?: number;
@@ -140,6 +141,10 @@ const reviewEventsSchema = z.object({
 
 const activeRosterSchema = z.object({
   characters: z.array(z.string()),
+});
+
+const activeRosterWithIdsSchema = z.object({
+  characters: z.array(z.object({ name: z.string(), discordId: z.string().nullable() })),
 });
 
 const claimReminderTargetsSchema = z.object({
@@ -291,6 +296,20 @@ export class WebAppAdapter implements TrackerAdapter {
     }
     const raw = await resp.json();
     return activeRosterSchema.parse(raw);
+  }
+
+  async getActiveRosterWithIds(): Promise<{ characters: Array<{ name: string; discordId: string | null }> }> {
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/meta/active-roster?includeDiscordIds=1`, {
+      headers: this.readAuthHeaders(),
+    }).catch(() => null);
+    if (!resp) {
+      throw new Error('Unable to reach web app active-roster API.');
+    }
+    if (!resp.ok) {
+      throw new Error(`Web app active-roster API failed (${resp.status})`);
+    }
+    const raw = await resp.json();
+    return activeRosterWithIdsSchema.parse(raw);
   }
 
   async getClaimReminderTargets(): Promise<ClaimReminderSnapshot> {

--- a/apps/bot/src/services/cubbyChannels.ts
+++ b/apps/bot/src/services/cubbyChannels.ts
@@ -1,5 +1,12 @@
 import { ChannelType, type Guild, type GuildBasedChannel } from 'discord.js';
 
+export const CUBBY_CATEGORY_NAMES = [
+  'ancilla character cubbies',
+  'neonate character cubbies',
+  'fledgeling character cubbies',
+  'mortal character cubbies',
+] as const;
+
 export type NotificationChannel = GuildBasedChannel & {
   send: (payload: { content: string; components?: unknown[]; allowedMentions?: { parse?: string[] } }) => Promise<unknown>;
 };
@@ -80,4 +87,31 @@ export async function buildCubbyChannelMap(guild: Guild): Promise<Map<string, No
   }
 
   return map;
+}
+
+/**
+ * Returns all text channels whose parent category is one of the four cubby
+ * category sections, suitable for use in autocomplete.
+ */
+export async function getChannelsInCubbyCategories(guild: Guild): Promise<Array<{ id: string; name: string }>> {
+  const channels = await guild.channels.fetch();
+
+  const cubbyParentIds = new Set<string>();
+  for (const channel of channels.values()) {
+    if (channel && channel.type === ChannelType.GuildCategory) {
+      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+        cubbyParentIds.add(channel.id);
+      }
+    }
+  }
+
+  const result: Array<{ id: string; name: string }> = [];
+  for (const channel of channels.values()) {
+    if (!channel || channel.type !== ChannelType.GuildText) continue;
+    if (channel.parentId && cubbyParentIds.has(channel.parentId)) {
+      result.push({ id: channel.id, name: channel.name });
+    }
+  }
+  result.sort((a, b) => a.name.localeCompare(b.name));
+  return result;
 }

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -329,6 +329,16 @@ def active_roster():
         return backend
     characters = db_service.get_active_characters()
     characters.sort(key=lambda c: c.character_name.lower())
+    if request.args.get('includeDiscordIds') == '1':
+        return jsonify({
+            'characters': [
+                {
+                    'name': c.character_name,
+                    'discordId': str(c.player_discord).strip() if c.player_discord else None,
+                }
+                for c in characters
+            ]
+        })
     return jsonify({'characters': [c.character_name for c in characters]})
 
 

--- a/docs/BOT.md
+++ b/docs/BOT.md
@@ -13,19 +13,63 @@ The bot calls the web app's REST API (`/api/*`) using a bearer token. It never w
 | Command | Who Can Use | Description |
 |---------|-------------|-------------|
 | `/ping` | Everyone | Basic liveness check |
-| `/xp submit` | Players | Interactive multi-step wizard to submit an XP claim |
-| `/xp claim` | Players | Submit an XP claim directly |
-| `/xp spend` | Players | Submit an XP spend request |
+| `/xp submit` | Players | Redirect to the web player portal claim flow |
+| `/xp claim` | Players | Redirect to the web player portal claim flow |
+| `/xp spend` | Players | Redirect to the web player portal spend flow |
 | `/xp spend-cost` | Everyone | Calculate the XP cost of a potential spend without submitting |
 | `/xp summary` | Players | Show a character's XP totals (earned, spent, available) |
+| `/xp history` | Players | Show recent approved claims and spends |
 | `/xp health` | Everyone | Check bot and web app connectivity status |
 | `/xp help` | Everyone | Show player help and links |
-| `/xp test-reminder` | Staff only | Trigger a claim reminder DM for testing |
+| `/xp test-reminder` | Staff only | Trigger a claim reminder post in a cubby channel for testing |
 | `/xp test-passage` | Staff only | Trigger a passage-of-time announcement for testing |
 | `/xp sync-cubby-access` | Staff only | Resync channel access for character cubbies |
-| `/combat` | Players / Staff | Combat setup wizard (initiates multi-step modal flow) |
+| `/lasombra broadcast` | Staff only | Send a message to announcements, all cubbies, a single cubby, or any channel in the cubby categories. Supports optional role and player @mentions. See [Staff Broadcast](#staff-broadcast-lasombra-broadcast) below. |
+| `/combat start` | Players / Staff | Combat setup wizard (initiates multi-step modal flow) |
 
 Staff-only commands are restricted to Discord IDs in `BOT_TESTER_IDS`.
+
+## Staff Broadcast (`/lasombra broadcast`)
+
+Sends a freeform staff message to one or more destinations. The command accepts options first, then presents a modal for the message body.
+
+### Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `target` | Yes | Where to send. Autocomplete offers static targets and dynamic character/channel choices (see below). |
+| `mention-kindred` | No | Prepend `@Kindred` to the message. |
+| `mention-ghouls` | No | Prepend `@Ghouls` to the message. |
+| `mention-mortals` | No | Prepend `@Mortals` to the message. |
+| `mention-character` | No | Prepend a ping to a specific character's player. Autocomplete shows active characters that have a Discord ID on file. |
+
+### Target autocomplete
+
+| What you see | What it does |
+|---|---|
+| `All cubbies` | Posts to every active character's cubby channel |
+| `Announcements channel` | Posts to the configured `ANNOUNCEMENTS_CHANNEL_ID` |
+| `Cubbies + announcements` | Posts to all cubbies and announcements |
+| `Cubby: <CharacterName>` | Posts to a single character's cubby only |
+| `#<channel-name>` | Posts to a specific channel inside one of the four cubby categories |
+
+The four cubby categories searched for individual channel targets are:
+- Ancilla Character Cubbies
+- Neonate Character Cubbies
+- Fledgeling Character Cubbies
+- Mortal Character Cubbies
+
+### Mention behaviour
+
+All selected mentions are prepended to the message body, separated by spaces, followed by a blank line:
+
+```
+@Kindred @Ghouls <@PlayerDiscordId>
+
+Your message here...
+```
+
+Role IDs are read from `PASSAGE_OF_TIME_KINDRED_ROLE_ID`, `PASSAGE_OF_TIME_GHOUL_ROLE_ID`, and `PASSAGE_OF_TIME_MORTAL_ROLE_ID`.
 
 ## Background Services
 
@@ -43,7 +87,7 @@ Requires: `SUBMISSION_NOTIFIER_ENABLED=true`, `SUBMISSION_NOTIFIER_CHANNEL_ID`.
 
 ### claimReminderService
 
-Sends DM reminders to players who have not yet submitted an XP claim for the current open play period. Runs on a configurable schedule (commonly Sunday 12:00 America/Chicago in project templates; code fallback default is Sunday 08:00 if env vars are omitted). Players can opt out or snooze via buttons in the DM. Opt-out/snooze state is persisted to `data/claim-reminder-preferences.json`.
+Sends reminder posts in each character's cubby channel for players who have not yet submitted an XP claim for the current open play period. Runs on a configurable schedule (commonly Sunday 12:00 America/Chicago in project templates; code fallback default is Sunday 08:00 if env vars are omitted). Players can open the player portal, snooze reminders, or opt out via buttons on the reminder post. Opt-out/snooze state is persisted via the web API (`/api/reminder-prefs`) in the web database.
 
 Requires: `CLAIM_REMINDER_ENABLED=true`, `CLAIM_REMINDER_GUILD_ID`.
 
@@ -61,7 +105,7 @@ Requires: `AUTO_PERIOD_CREATOR_ENABLED=true` (bot side) and `AUTO_CREATE_PERIODS
 
 ### autoPeriodCloser
 
-Periodically calls `POST /api/periods/auto-close` (default every 60 min). When the web app closes a period, it returns the list of players who had not submitted a claim; the bot DMs those players a close notification.
+Periodically calls `POST /api/periods/auto-close` (default every 60 min). When the web app closes a period, it returns the list of players who had not submitted a claim; the bot posts close notifications in those characters' cubby channels.
 
 Requires: `AUTO_PERIOD_CLOSER_ENABLED=true` (bot side) and `AUTO_CLOSE_PERIODS_ENABLED=true` (web side).
 
@@ -81,7 +125,7 @@ POSTs to `POST /api/bot-heartbeat` on a 60-second interval. The web app records 
 
 ### cubbyChannelMonitor
 
-Monitors channel creation and deletion events in the guild and keeps the internal cubby-channel lookup cache up to date. Used by `reviewNotifier` to find the correct channel or thread for each character.
+Monitors new channels/threads in cubby categories. On channel creation it grants the bot required send/read permissions; on thread creation it joins the thread so review/reminder posts work without manual intervention.
 
 ## Persistent State Files
 
@@ -91,8 +135,9 @@ All state files are written relative to the bot's working directory (`apps/bot/`
 |------|---------|----------|
 | `data/review-notifier-cursor.json` | reviewNotifier | Last processed review event epoch and event key |
 | `data/submission-notifier-cursor.json` | submissionNotifier | Last processed submission event epoch and event key |
-| `data/claim-reminder-preferences.json` | claimReminderService | Per-user opt-out and snooze state |
 | `data/passage-of-time-state.json` | passageOfTimeService | Dedupe keys for posted cadence messages |
+
+Claim reminder preferences are stored in the web app DB (via `/api/reminder-prefs`), not a bot-local file.
 
 ## Docker Ops
 

--- a/docs/RELEASE_2026-04-07_BROADCAST_AND_SCHEDULER_FIX.md
+++ b/docs/RELEASE_2026-04-07_BROADCAST_AND_SCHEDULER_FIX.md
@@ -1,0 +1,57 @@
+# Release: 2026-04-07 — Staff Broadcast Overhaul & Passage-of-Time Scheduler Fix
+
+## Included
+
+### Staff broadcast command overhaul (`/lasombra broadcast`)
+
+**`apps/bot` — `src/commands/lasombra.ts`**
+
+The broadcast command has been fully reworked. Target selection is now a slash command option with autocomplete rather than a freetext modal field, enabling precise routing and eliminating typo errors.
+
+**New options:**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `target` | string (autocomplete) | Where to send. Static choices: `All cubbies`, `Announcements channel`, `Cubbies + announcements`. Dynamic choices: `Cubby: <CharacterName>` per active character; `#<channel-name>` per channel in the four cubby categories. |
+| `mention-kindred` | boolean | Prepend `@Kindred` mention. |
+| `mention-ghouls` | boolean | Prepend `@Ghouls` mention. |
+| `mention-mortals` | boolean | Prepend `@Mortals` mention. |
+| `mention-character` | string (autocomplete) | Prepend a ping to a specific character's player. Shows active characters with a Discord ID on file; value is the Discord user ID. |
+
+The modal now collects only the message body. Options are staged in a module-level `Map<userId, PendingBroadcast>` (keyed by user ID; a user can only have one modal open at a time) so the 100-character customId limit is not a constraint.
+
+**Cubby category channel lookup** (`src/services/cubbyChannels.ts`)
+
+Added `CUBBY_CATEGORY_NAMES` constant (the four cubby category names, lowercase) and `getChannelsInCubbyCategories(guild)` helper, which fetches all guild channels, identifies the four cubby parent categories by name, and returns all `GuildText` channels within them sorted alphabetically.
+
+The four recognised categories:
+- Ancilla Character Cubbies
+- Neonate Character Cubbies
+- Fledgeling Character Cubbies
+- Mortal Character Cubbies
+
+**`apps/web` — `blueprints/api.py`**
+
+`GET /api/meta/active-roster` now accepts `?includeDiscordIds=1`. When set, the response changes from `{ characters: string[] }` to `{ characters: [{ name, discordId }] }`. Used by the `mention-character` autocomplete to look up the owning player's Discord ID without a separate API call.
+
+**`apps/bot` — `src/services/adapter.ts`**
+
+Added `getActiveRosterWithIds()` method and `activeRosterWithIdsSchema` Zod schema to match the new response shape.
+
+---
+
+### Passage-of-time scheduler alignment fix
+
+**`apps/bot` — `src/services/passageOfTimeService.ts`**
+
+Previously the service checked whether the current minute fell in a fixed `[minuteLocal, minuteLocal + intervalMinutes)` window. If the bot happened to start at a minute offset that never landed in that window, the event would be silently skipped.
+
+**Fix:** The service now tracks `lastTickTime` (initialised to `now − intervalMs` in the constructor). On each tick it computes `prevMin` and `nowMin` as minutes-of-day in the configured timezone and fires if the target time falls in `(prevMin, nowMin]`. This works regardless of when the bot started and is resilient to delayed ticks caused by system load.
+
+---
+
+### MONOREPO_ROOT Docker fix
+
+**`compose.web.yml` / `compose.full.yml`**
+
+Added `MONOREPO_ROOT: /app` to the web service environment. After a macOS reboot, Docker auto-restarts containers before Docker Desktop's file-sharing layer is ready, causing bind mounts to appear empty. The `_repo_root()` path-walk in `shared_contract.py` previously failed in this state. Setting `MONOREPO_ROOT` bypasses the walk entirely (the configured-path branch only checks that the directory exists, not the marker file).


### PR DESCRIPTION
## Summary

- **Autocomplete target selection**: choose from the announcements channel, any individual character cubby, or any of the four cubby category channels (ancilla/neonate/fledgeling/mortal)
- **Role mention flags**: `mention-kindred`, `mention-ghouls`, `mention-mortals` boolean options prepend the corresponding `@role` mentions
- **Character player ping**: `mention-character` autocomplete lets you select a character by name and ping their player's Discord account
- **Modal carries only the message body** — pending options stored in a module-level `Map<userId, PendingBroadcast>` to work around Discord's 100-char `customId` limit
- **Web API**: `GET /api/meta/active-roster?includeDiscordIds=1` returns `{name, discordId}` objects for mention autocomplete

## Test plan

- [ ] `/lasombra broadcast` shows correct autocomplete for `target` (announcements, cubbies, category channels)
- [ ] `mention-character` autocomplete searches active roster with Discord IDs
- [ ] `both` target sends to announcements channel + all cubby channels
- [ ] `cubby:NAME` target sends to that character's cubby only
- [ ] `channel:ID` target sends to the selected category channel
- [ ] Role mention flags prepend the correct `@role` strings
- [ ] `mention-character` with a matched Discord ID prepends `<@discordId>`
- [ ] Re-register slash commands after deploy: `npm run register` in `apps/bot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)