### PR TITLE
Redirect /xp commands to player portal; DB-backed reminder prefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cd apps/web && ./setup-secrets.sh    # sync env values to GCP Secret Manager
 | [docs/API_ENDPOINTS.md](docs/API_ENDPOINTS.md) | Bot-facing REST API reference |
 | [docs/ENV_AND_SECRETS.md](docs/ENV_AND_SECRETS.md) | All env vars, secrets flow, Docker notes |
 | [docs/PRODUCTION_ENV_PROFILE.md](docs/PRODUCTION_ENV_PROFILE.md) | Production-safe env baseline and rollout sequence |
-| [docs/CODEBASE_AUDIT_2026-03-30.md](docs/CODEBASE_AUDIT_2026-03-30.md) | Current cross-app audit snapshot + security/cost/UX improvement pointers |
+| [docs/CODEBASE_AUDIT_2026-04-09.md](docs/CODEBASE_AUDIT_2026-04-09.md) | Current cross-app audit snapshot + cost/functionality/doc-parity updates |
 | [docs/RUN_WEB_DOCKER.md](docs/RUN_WEB_DOCKER.md) | Web Docker runbook |
 | [docs/RUN_BOT_DOCKER.md](docs/RUN_BOT_DOCKER.md) | Bot Docker runbook and audit log ops |
 | [docs/INSTALL_LITE.md](docs/INSTALL_LITE.md) | Install guide: web only |

--- a/apps/bot/src/__tests__/xpCommand.test.ts
+++ b/apps/bot/src/__tests__/xpCommand.test.ts
@@ -134,7 +134,7 @@ describe('xp claim command validation', () => {
     expect(reply).toHaveBeenCalledTimes(1);
     const payload = reply.mock.calls[0][0] as { content: string; ephemeral: boolean };
     expect(payload.ephemeral).toBe(true);
-    expect(payload.content).toContain('`/xp submit`');
+    expect(payload.content).toContain('player portal');
     expect(payload.content).toContain('Full player guide: https://discord.com/channels/1/2/3');
 
     vi.unstubAllEnvs();

--- a/apps/bot/src/claimReminderInteractions.ts
+++ b/apps/bot/src/claimReminderInteractions.ts
@@ -28,7 +28,7 @@ export async function handleClaimReminderButton(interaction: ButtonInteraction, 
 
   if (action === CLAIM_REMINDER_ACTION_START) {
     await interaction.reply({
-      content: 'Use `/xp submit` (wizard) or `/xp claim` when you are ready.',
+      content: `Open the player portal to submit your claim: ${config.playerWebUrl}`,
       ephemeral: true,
     });
     return true;

--- a/apps/bot/src/commands/xp.ts
+++ b/apps/bot/src/commands/xp.ts
@@ -34,7 +34,7 @@ export const data = new SlashCommandBuilder()
   .addSubcommand((s) =>
     s
       .setName('submit')
-      .setDescription('Open interactive XP claim wizard with live character/night context')
+      .setDescription('Open the player portal to submit an XP claim')
       .addStringOption((o) =>
         o
           .setName('character')
@@ -98,7 +98,7 @@ export const data = new SlashCommandBuilder()
   .addSubcommand((s) =>
     s
       .setName('claim')
-      .setDescription('Submit a simple XP claim via adapter')
+      .setDescription('Open the player portal to submit an XP claim')
       .addStringOption((o) =>
         o
           .setName('character')
@@ -174,7 +174,7 @@ export const data = new SlashCommandBuilder()
   .addSubcommand((s) =>
     s
       .setName('spend')
-      .setDescription('Submit an XP spend request via adapter')
+      .setDescription('Open the player portal to submit an XP spend request')
       .addStringOption((o) =>
         o
           .setName('character')
@@ -476,9 +476,9 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
   if (sub === 'help') {
     const lines = [
       '**XP Quick Help**',
-      '- `/xp submit`: guided XP claim wizard (recommended)',
-      '- `/xp claim`: quick claim (1-6 category/link pairs in one submission)',
-      '- `/xp spend`: submit an XP spend request',
+      '- `/xp submit`: opens the player portal claim flow',
+      '- `/xp claim`: opens the player portal claim flow',
+      '- `/xp spend`: opens the player portal spend flow',
       '- `/xp summary`: show your character XP totals',
       '- `/xp history`: show recent approved claims and spends',
       '- `/xp spend-cost`: preview spend XP cost',

--- a/apps/bot/src/services/claimReminderService.ts
+++ b/apps/bot/src/services/claimReminderService.ts
@@ -27,8 +27,8 @@ type ClaimReminderServiceConfig = {
 
 export function buildClaimReminderText(currentNight: string, characterName: string, discordId: string, webUrl?: string): string {
   const callToAction = webUrl
-    ? `Submit your claim at ${webUrl} or use \`/xp submit\` in Discord.`
-    : 'Use `/xp submit` in Discord when ready.';
+    ? `Submit your claim at ${webUrl}.`
+    : 'Open the player portal to submit your claim.';
   return [
     `Hey <@${discordId}>`,
     '',

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -200,7 +200,7 @@
                                           </div>
                                           <div class="col-auto" style="width: 90px;">
                                             <input type="number" class="form-control form-control-sm wildcard-amount-input"
-                                                   name="wildcard_amount" min="1" max="20" value="1"
+                                                   name="wildcard_amount" min="1" max="10" value="1"
                                                    placeholder="XP" title="Number of XP">
                                           </div>
                                         </div>

--- a/docs/ENV_AND_SECRETS.md
+++ b/docs/ENV_AND_SECRETS.md
@@ -150,14 +150,14 @@ cp apps/bot/.env.example apps/bot/.env
 | Var | Required | Default | Description |
 |-----|----------|---------|-------------|
 | `AUTO_PERIOD_CLOSER_ENABLED` | No | `false` | Enable bot-side trigger. Also requires `AUTO_CLOSE_PERIODS_ENABLED=true` on web. |
-| `AUTO_PERIOD_CLOSER_GUILD_ID` | No | falls back to `REVIEW_NOTIFIER_GUILD_ID` | Guild ID for close DM sends. |
+| `AUTO_PERIOD_CLOSER_GUILD_ID` | No | falls back to `REVIEW_NOTIFIER_GUILD_ID` | Guild ID for close notifications in character cubby channels. |
 | `AUTO_PERIOD_CLOSER_INTERVAL_MS` | No | `3600000` | Poll interval (ms). |
 
 ### Claim Reminder Service
 
 | Var | Required | Default | Description |
 |-----|----------|---------|-------------|
-| `CLAIM_REMINDER_ENABLED` | No | `false` | Enable scheduled DM reminders to players who haven't claimed. |
+| `CLAIM_REMINDER_ENABLED` | No | `false` | Enable scheduled reminder posts in character cubby channels for players who haven't claimed. |
 | `CLAIM_REMINDER_GUILD_ID` | Conditional | — | Guild ID. Required when enabled. |
 | `CLAIM_REMINDER_INTERVAL_MS` | No | `900000` | How often to check the schedule (ms). |
 | `CLAIM_REMINDER_WEEKDAY_LOCAL` | No | `0` (Sunday) | Weekday to send reminders (0=Sun … 6=Sat). |

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -48,8 +48,8 @@ Use this checklist when promoting the merged web + bot setup to production.
 - [ ] `/ping` works.
 - [ ] `/xp health` reports web adapter as healthy.
 - [ ] `/xp summary` returns expected character data.
-- [ ] `/xp claim` submits successfully.
-- [ ] `/xp spend` computes/creates requests using current XP rules.
+- [ ] `/xp submit` / `/xp claim` / `/xp spend` redirect to the player portal URL.
+- [ ] Player portal claim and spend submissions succeed end-to-end.
 - [ ] Web UI and bot show consistent XP totals after a test claim/spend.
 
 ## 6) Cost Guardrails (Free-Tier Focus)

--- a/docs/PLAYER_QUICKSTART.md
+++ b/docs/PLAYER_QUICKSTART.md
@@ -1,6 +1,6 @@
 # Player Quickstart (Web + Bot)
 
-Use either the web interface or Discord bot. Both submit into the same XP workflow.
+Use the web player portal for claim/spend submissions. Discord bot commands are still available for summaries and cost checks.
 
 ## 1) Web Interface (Recommended)
 
@@ -17,23 +17,23 @@ Use either the web interface or Discord bot. Both submit into the same XP workfl
 Run `/xp help` in Discord anytime for the same summary.
 
 - `/xp submit`
-  - Guided wizard for claims (recommended bot flow).
+  - Redirects you to the player portal claim flow.
 - `/xp claim`
-  - Quick one-category claim.
-  - `play_period` is autocomplete from active nights.
+  - Redirects you to the player portal claim flow.
 - `/xp spend`
-  - Submit an XP spend request.
+  - Redirects you to the player portal spend flow.
 - `/xp summary`
   - View current XP totals for your character.
+- `/xp history`
+  - View recent approved claims/spends for your character.
 - `/xp spend-cost`
   - Preview the calculated XP cost.
 
 ## 3) Tips To Avoid Errors
 
 - Always pick your character from autocomplete.
-- Always pick night/period from autocomplete.
-- For `/xp claim`, paste a valid Discord message link from this server.
-- If you are unsure, use `/xp submit` instead of `/xp claim`.
+- Submit claims/spends in the web portal (`/player`), not in Discord command payloads.
+- Use `/xp spend-cost` before submitting a spend if you want a quick cost sanity check.
 
 ## 4) Staff Review
 

--- a/docs/RUN_BOT_LOCAL.md
+++ b/docs/RUN_BOT_LOCAL.md
@@ -84,7 +84,7 @@ For first-time setup, follow [INSTALL_REGULAR.md](INSTALL_REGULAR.md).
 - At configured local day/time, bot pulls reminder targets for the current open night.
 - For each eligible character, bot posts in that character's cubby channel/thread.
 - Message mentions linked player (`player_discord`) and includes quick actions:
-  - `Start Claim` (use `/xp submit` or `/xp claim`)
+  - `Start Claim` (opens the player portal URL)
   - `Not Now` (snoozes reminders)
   - `Stop Reminders` (opt-out)
 - Buttons are locked to the linked player for that reminder post.
@@ -105,11 +105,11 @@ For first-time setup, follow [INSTALL_REGULAR.md](INSTALL_REGULAR.md).
 - Recommended command for full UI/button test:
   - `/xp test-reminder character:"Dummy One" target_user:@you current_night:"Night TEST"`
 - Then click:
-  - `Start Claim`: confirms manual claim path.
+  - `Start Claim`: confirms player-portal jump path.
   - `Not Now`: writes a snooze preference.
   - `Stop Reminders`: writes opt-out preference.
-- Preference state file (local bot host):
-  - `apps/bot/data/claim-reminder-preferences.json`
+- Preference state persistence:
+  - Stored via web API (`/api/reminder-prefs`) in the web app database.
 
 ### Bulk grant bot access to all cubbies
 


### PR DESCRIPTION
## Summary

- `/xp submit`, `/xp claim`, `/xp spend` now send a player portal URL instead of running an in-Discord wizard — reduces bot complexity and keeps all submission logic in the web app
- Claim reminder snooze/opt-out preferences now stored in the web app DB via `PUT /api/reminder-prefs/:id` instead of a local `data/` JSON file; preferences survive bot restarts and redeploys
- Fix `wildcard_amount` max in player template (was 20, now correctly capped at 10)
- Update docs (`PLAYER_QUICKSTART.md`, `GO_LIVE_CHECKLIST.md`, `ENV_AND_SECRETS.md`, `RUN_BOT_LOCAL.md`) to reflect portal-first submission flow

## Test plan

- [ ] `/xp submit` in Discord responds with the player portal URL
- [ ] `/xp claim` and `/xp spend` similarly redirect to the portal
- [ ] Claim reminder snooze persists across bot restart
- [ ] Opt-out persists across bot restart
- [ ] Wildcard amount field in player portal caps at 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)