### PR TITLE
Clarify README: Turso/SQLite is the authoritative DB, Sheets is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCbN XP Tracker
 
-XP tracking and management for **Music City by Night** (MCbN), a Vampire: the Masquerade V5 chronicle based in Nashville, TN. The system handles XP earning and spending workflows for player characters — claims are submitted via Discord bot or web portal, reviewed by staff through an admin dashboard, and recorded in a Turso/SQLite database with Google Sheets as a backup mirror.
+XP tracking and management for **Music City by Night** (MCbN), a Vampire: the Masquerade V5 chronicle based in Nashville, TN. The system handles XP earning and spending workflows for player characters — claims are submitted via Discord bot or web portal, reviewed by staff through an admin dashboard, and persisted in a **Turso/SQLite database** (the authoritative store). Google Sheets can be configured as an optional background mirror.
 
 **Live:** [mcbn.jkomg.us](https://mcbn.jkomg.us) | **Dev:** `http://127.0.0.1:5001`
 


### PR DESCRIPTION
## Summary

- Update the opening description to make clear Turso/SQLite is the **authoritative** database
- Reframe Google Sheets as an optional background mirror rather than a co-equal system

🤖 Generated with [Claude Code](https://claude.com/claude-code)