### PR TITLE
Add Discord → Notion sync script and admin UI trigger

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -101,3 +101,28 @@ COMBAT_SYSTEM_HELPER_ROLE_ID=
 
 # Optional channel ID for /staff broadcast announcements target
 ANNOUNCEMENTS_CHANNEL_ID=
+
+# Optional nightly Google Sheets reconciliation (syncs DB → Sheets once per day)
+# Set SHEETS_RECONCILE_ENABLED=true to activate; requires SHEETS integration on the web side.
+SHEETS_RECONCILE_ENABLED=false
+SHEETS_RECONCILE_HOUR_LOCAL=3
+SHEETS_RECONCILE_MINUTE_LOCAL=0
+SHEETS_RECONCILE_TIMEZONE=America/Chicago
+# How often to check whether the scheduled time has arrived (default 5 min)
+SHEETS_RECONCILE_INTERVAL_MS=300000
+
+# ---------------------------------------------------------------------------
+# discord-notion-sync (one-time script — not used by the running bot)
+# Run: npm run notion-sync:dry-run  /  npm run notion-sync
+# ---------------------------------------------------------------------------
+
+# Discord server to read from (falls back to TEST_GUILD_ID)
+DISCORD_GUILD_ID=
+
+# Notion integration token — create at https://www.notion.so/profile/integrations
+# Then invite the integration to the Nashville by Night page:
+#   https://www.notion.so/3013a3e5cab1802fb607d565362b9502
+NOTION_TOKEN=
+
+# Max messages to archive per lore channel (default: 200)
+NOTION_SYNC_MSG_LIMIT=200

--- a/apps/bot/package-lock.json
+++ b/apps/bot/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@notionhq/client": "^2.3.0",
         "discord.js": "^14.25.1",
         "dotenv": "^17.3.1",
         "zod": "^4.3.6"
@@ -602,6 +603,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@notionhq/client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
+      "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -1026,6 +1040,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1166,6 +1190,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1174,6 +1217,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/discord-api-types": {
@@ -1224,12 +1288,71 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1317,6 +1440,22 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1332,6 +1471,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1343,6 +1528,57 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lodash": {
@@ -1373,6 +1609,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1390,6 +1656,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/obug": {
@@ -1588,6 +1874,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
@@ -1801,6 +2093,22 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/why-is-node-running": {

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -17,7 +17,11 @@
     "ops:docker:usage-30d": "bash scripts/export-docker-usage-window.sh lasombra-bot",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "check": "npm run lint && npm run format:check && npm run typecheck && npm run test && npm run build"
+    "check": "npm run lint && npm run format:check && npm run typecheck && npm run test && npm run build",
+    "notion-sync": "tsx src/scripts/discord-notion-sync.ts",
+    "notion-sync:dry-run": "tsx src/scripts/discord-notion-sync.ts --dry-run",
+    "notion-sync:cleanup": "tsx src/scripts/discord-notion-sync.ts --cleanup",
+    "notion-sync:cleanup:dry-run": "tsx src/scripts/discord-notion-sync.ts --cleanup --dry-run"
   },
   "keywords": [
     "discord",
@@ -32,6 +36,7 @@
     "node": ">=20.11"
   },
   "dependencies": {
+    "@notionhq/client": "^2.3.0",
     "discord.js": "^14.25.1",
     "dotenv": "^17.3.1",
     "zod": "^4.3.6"

--- a/apps/bot/scripts/lint.mjs
+++ b/apps/bot/scripts/lint.mjs
@@ -40,7 +40,9 @@ function lintFile(filePath) {
       errors.push(`${rel(filePath)}:${lineNumber} uses explicit any`);
     }
 
-    if (/process\.env\./.test(line) && !filePath.endsWith(`${path.sep}config.ts`)) {
+    const isConfigTs = filePath.endsWith(`${path.sep}config.ts`);
+    const isScript = filePath.includes(`${path.sep}scripts${path.sep}`);
+    if (/process\.env\./.test(line) && !isConfigTs && !isScript) {
       errors.push(`${rel(filePath)}:${lineNumber} accesses process.env outside config.ts`);
     }
   });

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -139,6 +139,9 @@ const envSchema = z.object({
   SHEETS_RECONCILE_MINUTE_LOCAL: z.string().optional(),
   SHEETS_RECONCILE_TIMEZONE: z.string().optional(),
   SHEETS_RECONCILE_INTERVAL_MS: z.string().optional(),
+  NOTION_TOKEN: z.string().optional(),
+  NOTION_SYNC_MSG_LIMIT: z.string().optional(),
+  DISCORD_GUILD_ID: z.string().optional(),
 });
 
 const env = envSchema.parse(process.env);
@@ -313,6 +316,9 @@ export const config = {
     300_000,
     'SHEETS_RECONCILE_INTERVAL_MS',
   ),
+  notionToken: env.NOTION_TOKEN ?? '',
+  notionSyncMsgLimit: parsePositiveInt(env.NOTION_SYNC_MSG_LIMIT, 200, 'NOTION_SYNC_MSG_LIMIT'),
+  discordGuildId: env.DISCORD_GUILD_ID ?? env.TEST_GUILD_ID ?? '',
 };
 
 if (config.testRequesterDiscordId) {

--- a/apps/bot/src/liveConfig.ts
+++ b/apps/bot/src/liveConfig.ts
@@ -14,4 +14,6 @@ export const liveConfig = {
   claimReminderIntervalMs: null as number | null,
   /** DB-override channel IDs (null = use .env default). Applied on next bot restart. */
   announcementsChannelId: null as string | null,
+  /** Set to true by configSyncWorker when the web UI requests a Notion sync run. */
+  notionSyncRequested: false,
 };

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -1,0 +1,819 @@
+/**
+ * discord-notion-sync.ts
+ *
+ * One-time script: reads Discord channels → populates the Nashville by Night Notion page.
+ *
+ * Usage (from apps/bot/):
+ *   npx tsx src/scripts/discord-notion-sync.ts
+ *   npx tsx src/scripts/discord-notion-sync.ts --dry-run
+ *
+ * Required env vars (in apps/bot/.env):
+ *   BOT_TOKEN          Discord bot token
+ *   DISCORD_GUILD_ID   Target server ID (falls back to TEST_GUILD_ID)
+ *   NOTION_TOKEN       Notion integration token (create at notion.so/profile/integrations)
+ *
+ * Optional env vars:
+ *   WEB_APP_BASE_URL          Web app URL for active-roster API (default: http://127.0.0.1:5001)
+ *   WEB_APP_API_READ_TOKEN    Read token for web API (falls back to WEB_APP_API_TOKEN)
+ *   WEB_APP_API_TOKEN         Legacy all-in-one token
+ *   NOTION_SYNC_MSG_LIMIT     Max messages per text channel / posts per forum (default: 200)
+ *
+ * What gets populated:
+ *   PC Tracker       — one entry per active character (name + player Discord handle)
+ *   SPC Tracker      — one entry per post/message in #spc-profiles
+ *                      (forum: thread name = SPC name; text: first line = SPC name)
+ *   Location DB      — one entry per City of Nashville channel
+ *   Hunting Sites    — one entry per pinned message in City of Nashville channels
+ *   Session & Post Log
+ *     text channels  — one archive entry per channel, all messages as page body
+ *     forum channels — one entry per thread/post (title = thread name)
+ *
+ * Note: #backgrounds and #children-of-the-night are forum channels — each forum
+ * post becomes its own Session & Post Log entry.
+ *
+ * The Notion integration must be invited to the Nashville by Night workspace page:
+ *   https://www.notion.so/3013a3e5cab1802fb607d565362b9502
+ */
+
+import path from 'node:path';
+import * as dotenv from 'dotenv';
+import { REST, Routes } from 'discord.js';
+import { Client as NotionClient } from '@notionhq/client';
+
+// ---------------------------------------------------------------------------
+// Public API — call this from the bot process or from the CLI
+// ---------------------------------------------------------------------------
+
+export interface NotionSyncOptions {
+  botToken: string;
+  guildId: string;
+  notionToken: string;
+  webBase?: string;
+  webReadToken?: string;
+  msgLimit?: number;
+  dryRun?: boolean;
+  /** If true, archive all Notion pages that were NOT created by this sync before importing. */
+  cleanup?: boolean;
+}
+
+export async function runNotionSync(opts: NotionSyncOptions): Promise<{ success: boolean; error?: string }> {
+  if (!opts.botToken) return { success: false, error: 'botToken is required' };
+  if (!opts.guildId) return { success: false, error: 'guildId is required' };
+  if (!opts.notionToken) return { success: false, error: 'notionToken is required' };
+  try {
+    await main(opts);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+// Notion database IDs from Nashville by Night page (3013a3e5cab1802fb607d565362b9502)
+const NOTION_DB = {
+  PC_TRACKER:    '251eff53bb584672b99b7a4bea041835',
+  SPC_TRACKER:   '0eeff60c0c624f6d8a2d9f0729f938ce',
+  LOCATION_DB:   'af645074f95d484f991613986753aac1',
+  HUNTING_SITES: 'dafacdfdc5354d8bb468dc8f8ccf4c17',
+  SESSION_LOG:   'a85037ea366349469b230573fa19c5d5',
+};
+
+// Lore channels whose content goes into Session & Post Log.
+// Text channels → one archive entry.  Forum channels → one entry per post/thread.
+const LORE_CHANNEL_NAMES = [
+  'music-city-histories',
+  'state-of-address',
+  'news-feed',
+  'camarilla-decrees',
+  'anarch-mandates',
+  'hecata-notices',
+  'backgrounds',          // forum
+  'children-of-the-night', // forum
+  'spc-profiles',
+];
+
+const CITY_CATEGORY_NAME = 'city of nashville';
+
+// Discord channel type constants
+const CH_TEXT  = 0;
+const CH_CATEGORY = 4;
+const CH_FORUM = 15;
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+  const cliOpts: NotionSyncOptions = {
+    botToken: process.env.BOT_TOKEN ?? '',
+    guildId: process.env.DISCORD_GUILD_ID ?? process.env.TEST_GUILD_ID ?? '',
+    notionToken: process.env.NOTION_TOKEN ?? '',
+    webBase: process.env.WEB_APP_BASE_URL,
+    webReadToken: process.env.WEB_APP_API_READ_TOKEN ?? process.env.WEB_APP_API_TOKEN,
+    msgLimit: Number.parseInt(process.env.NOTION_SYNC_MSG_LIMIT ?? '200', 10),
+    dryRun: process.argv.includes('--dry-run'),
+    cleanup: process.argv.includes('--cleanup'),
+  };
+  if (!cliOpts.botToken) { console.error('BOT_TOKEN is required'); process.exit(1); }
+  if (!cliOpts.guildId) { console.error('DISCORD_GUILD_ID (or TEST_GUILD_ID) is required'); process.exit(1); }
+  if (!cliOpts.notionToken) { console.error('NOTION_TOKEN is required'); process.exit(1); }
+  runNotionSync(cliOpts).then((result) => {
+    if (!result.success) { console.error('Sync failed:', result.error); process.exit(1); }
+  }).catch((err) => { console.error('Fatal:', err); process.exit(1); });
+}
+
+// ---------------------------------------------------------------------------
+// Discord types
+// ---------------------------------------------------------------------------
+
+interface DiscordChannel {
+  id: string;
+  name: string;
+  type: number;
+  parent_id?: string;
+  topic?: string;
+}
+
+interface DiscordThread {
+  id: string;
+  name: string;
+  parent_id: string;
+  type: number;
+  thread_metadata?: { archive_timestamp?: string };
+}
+
+interface DiscordAttachment {
+  url: string;
+  content_type?: string;
+  filename: string;
+}
+
+interface DiscordMessage {
+  id: string;
+  content: string;
+  author: { id: string; username: string; global_name?: string };
+  timestamp: string;
+  attachments?: DiscordAttachment[];
+}
+
+interface DiscordGuildMember {
+  user?: { id: string; username: string; global_name?: string };
+  nick?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function notionCall<T>(fn: () => Promise<T>): Promise<T> {
+  await sleep(350);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === 'notionhq_client_request_timeout' || code === 'notionhq_client_response_error') {
+        if (attempt < 2) {
+          console.log(`  [retry] Notion timeout/error, waiting ${(attempt + 1) * 2}s…`);
+          await sleep((attempt + 1) * 2000);
+          continue;
+        }
+      }
+      throw err;
+    }
+  }
+  throw new Error('unreachable');
+}
+
+function toTitleCase(str: string): string {
+  return str.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function chunks<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) result.push(arr.slice(i, i + size));
+  return result;
+}
+
+function textToBlocks(text: string): object[] {
+  const blocks: object[] = [];
+  let current = '';
+  for (const line of text.split('\n')) {
+    const candidate = current ? `${current}\n${line}` : line;
+    if (candidate.length > 1800) {
+      if (current) {
+        blocks.push(paragraphBlock(current));
+        current = line.slice(0, 1800);
+      } else {
+        blocks.push(paragraphBlock(line.slice(0, 1800)));
+        current = '';
+      }
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) blocks.push(paragraphBlock(current));
+  return blocks;
+}
+
+function paragraphBlock(content: string): object {
+  return {
+    object: 'block',
+    type: 'paragraph',
+    paragraph: { rich_text: [{ type: 'text', text: { content } }] },
+  };
+}
+
+function heading3Block(content: string): object {
+  return {
+    object: 'block',
+    type: 'heading_3',
+    heading_3: { rich_text: [{ type: 'text', text: { content } }] },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discord REST helpers
+// ---------------------------------------------------------------------------
+
+async function fetchAllMessages(rest: REST, channelId: string, limit: number): Promise<DiscordMessage[]> {
+  const all: DiscordMessage[] = [];
+  let before: string | undefined;
+  while (all.length < limit) {
+    const batch = Math.min(100, limit - all.length);
+    const params = new URLSearchParams({ limit: String(batch) });
+    if (before) params.set('before', before);
+    const msgs = await rest.get(`${Routes.channelMessages(channelId)}?${params}`) as DiscordMessage[];
+    if (!msgs.length) break;
+    all.push(...msgs);
+    before = msgs[msgs.length - 1].id;
+    if (msgs.length < 100) break;
+    await sleep(250);
+  }
+  return all.reverse(); // oldest first
+}
+
+async function fetchPins(rest: REST, channelId: string): Promise<DiscordMessage[]> {
+  return rest.get(Routes.channelPins(channelId)) as Promise<DiscordMessage[]>;
+}
+
+async function fetchGuildMember(rest: REST, guildId: string, userId: string): Promise<DiscordGuildMember | null> {
+  try {
+    return await rest.get(Routes.guildMember(guildId, userId)) as DiscordGuildMember;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch all threads for a forum channel (active + archived).
+ * Active threads come from the guild-wide endpoint; archived are paginated per-channel.
+ */
+async function fetchForumThreads(rest: REST, guildId: string, forumChannelId: string): Promise<DiscordThread[]> {
+  const threads: DiscordThread[] = [];
+
+  // Active threads (guild-wide, filter to this forum)
+  const active = await rest.get(Routes.guildActiveThreads(guildId)) as { threads: DiscordThread[] };
+  for (const t of active.threads) {
+    if (t.parent_id === forumChannelId) threads.push(t);
+  }
+  await sleep(200);
+
+  // Archived threads (paginated, forum-specific)
+  let before: string | undefined;
+  for (;;) {
+    const params = new URLSearchParams({ limit: '100' });
+    if (before) params.set('before', before);
+    const archived = await rest.get(
+      `/channels/${forumChannelId}/threads/archived/public?${params}`,
+    ) as { threads: DiscordThread[]; has_more: boolean };
+    threads.push(...archived.threads);
+    if (!archived.has_more || !archived.threads.length) break;
+    before = archived.threads[archived.threads.length - 1].id;
+    await sleep(250);
+  }
+
+  return threads;
+}
+
+// ---------------------------------------------------------------------------
+// Web API: active character roster
+// ---------------------------------------------------------------------------
+
+interface ActiveRosterEntry {
+  name: string;
+  discordId: string | null;
+  clan: string | null;
+  sect: string | null;
+}
+
+async function fetchActiveRoster(webBase: string, webReadToken: string): Promise<ActiveRosterEntry[]> {
+  if (!webReadToken) {
+    console.log('  [warn] No WEB_APP_API_READ_TOKEN — PC Tracker will have no player names');
+    return [];
+  }
+  try {
+    const res = await fetch(`${webBase}/api/meta/active-roster?includeDiscordIds=1`, {
+      headers: { Authorization: `Bearer ${webReadToken}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) { console.log(`  [warn] Active roster API returned ${res.status}`); return []; }
+    const body = await res.json() as { characters: (ActiveRosterEntry | string)[] };
+    return (body.characters ?? []).map((c): ActiveRosterEntry =>
+      typeof c === 'string' ? { name: c, discordId: null, clan: null, sect: null } : c,
+    );
+  } catch (err) {
+    console.log(`  [warn] Could not reach web API: ${err}`);
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Notion helpers
+// ---------------------------------------------------------------------------
+
+async function appendBodyBlocks(notion: NotionClient, pageId: string, blocks: object[]) {
+  for (const chunk of chunks(blocks, 100)) {
+    await notionCall(() =>
+      notion.blocks.children.append({
+        block_id: pageId,
+        children: chunk as Parameters<typeof notion.blocks.children.append>[0]['children'],
+      }),
+    );
+  }
+}
+
+function imageBlock(url: string): object {
+  return {
+    object: 'block',
+    type: 'image',
+    image: { type: 'external', external: { url } },
+  };
+}
+
+/** Build body blocks for a list of messages with author/date headers. */
+function messagesToBlocks(messages: DiscordMessage[]): object[] {
+  const blocks: object[] = [];
+  for (const msg of messages) {
+    const images = (msg.attachments ?? []).filter(
+      (a) => a.content_type?.startsWith('image/') || /\.(png|jpe?g|gif|webp)$/i.test(a.filename),
+    );
+    if (!msg.content.trim() && !images.length) continue;
+    const author = msg.author.global_name ?? msg.author.username;
+    blocks.push(heading3Block(`${author} · ${msg.timestamp.slice(0, 10)}`));
+    if (msg.content.trim()) blocks.push(...textToBlocks(msg.content));
+    for (const img of images) blocks.push(imageBlock(img.url));
+    blocks.push({ object: 'block', type: 'divider', divider: {} });
+  }
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Pre-import cleanup
+// ---------------------------------------------------------------------------
+
+const SOURCE_TAG = 'discord-sync';
+
+// Coterie membership: display name → member character names (lowercase for matching)
+const COTERIE_MEMBERS: Record<string, string[]> = {
+  'The Brood':              ['ratcatcher', 'umaira', 'foxus', 'measly', 'viper'],
+  'Obsidian Citadel':       ['krayt', 'constance', 'patrick', 'nochtli'],
+  'Pillars of Community':   ['sonja', 'alice', 'gabriella', 'raize'],
+  'Danse Macabre':          ['ebba', 'alexander', 'kip'],
+  'The Magnolia Court':     ['cecilia', 'dahlia', 'david'],
+  'Ars Ananke':             ['argento', 'charmaine', 'marcus'],
+  'Culebra':                ['yamata', 'derrick', 'code red', 'percy'],
+  'Phantom Troupe':         ['jester', 'sikorsky', 'coral', 'jennifer jean'],
+  'The Assets':             ['big joey', 'lil joey', 'viktor'],
+  'Earth, Wind and Fire':   ['ashanti', 'aliyah', 'dolohov'],
+  'Midnight Oil':           ['rain', 'sierra', 'nightblazer'],
+};
+
+// Build reverse map: character name (lowercase) → coterie display name
+const CHAR_TO_COTERIE = new Map<string, string>();
+for (const [coterie, members] of Object.entries(COTERIE_MEMBERS)) {
+  for (const m of members) CHAR_TO_COTERIE.set(m, coterie);
+}
+
+// SPC type keywords: if thread/message name contains keyword → Type tag
+const SPC_TYPE_KEYWORDS: { keyword: string; tag: string }[] = [
+  { keyword: 'haven',      tag: 'Haven' },
+  { keyword: 'mawla',      tag: 'Mawla' },
+  { keyword: 'retainer',   tag: 'Retainer' },
+  { keyword: 'contact',    tag: 'Contact' },
+  { keyword: 'allies',     tag: 'Allies' },
+  { keyword: 'ally',       tag: 'Allies' },
+  { keyword: 'herd',       tag: 'Herd' },
+  { keyword: 'rolodex',    tag: 'Rolodex' },
+  { keyword: 'famulus',    tag: 'Famulus' },
+  { keyword: 'touchstone', tag: 'Touchstone' },
+];
+
+function inferSpcType(text: string): string | null {
+  const lower = text.toLowerCase();
+  for (const { keyword, tag } of SPC_TYPE_KEYWORDS) {
+    if (lower.includes(keyword)) return tag;
+  }
+  return null;
+}
+
+function getPageTitle(page: { properties: Record<string, unknown> }): string {
+  for (const val of Object.values(page.properties)) {
+    const v = val as { id?: string; type?: string; title?: { plain_text: string }[] };
+    if (v.type === 'title' && Array.isArray(v.title)) {
+      return v.title.map((t) => t.plain_text).join('') || '(untitled)';
+    }
+  }
+  return '(untitled)';
+}
+
+async function cleanupPreImportEntries(notion: NotionClient, dryRun: boolean): Promise<void> {
+  console.log('\n[cleanup] Archiving pre-import entries from all databases…');
+  for (const [dbName, dbId] of Object.entries(NOTION_DB)) {
+    let cursor: string | undefined;
+    let removed = 0;
+    let kept = 0;
+    for (;;) {
+      const result = await notionCall(() =>
+        notion.databases.query({
+          database_id: dbId,
+          page_size: 100,
+          ...(cursor ? { start_cursor: cursor } : {}),
+        }),
+      );
+      for (const page of result.results) {
+        if (page.object !== 'page' || !('properties' in page)) continue;
+        const props = page.properties as Record<string, unknown>;
+        const source = (props['Source'] as { select?: { name: string } } | undefined)?.select?.name;
+        if (source === SOURCE_TAG) {
+          kept++;
+        } else {
+          const title = getPageTitle({ properties: props });
+          console.log(`  [${dbName}] archive: "${title}"`);
+          if (!dryRun) {
+            await notionCall(() => notion.pages.update({ page_id: page.id, archived: true }));
+          }
+          removed++;
+        }
+      }
+      if (!result.has_more) break;
+      cursor = result.next_cursor ?? undefined;
+    }
+    console.log(`  [${dbName}] kept: ${kept}, archived: ${removed}${dryRun ? ' (dry-run)' : ''}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(opts: NotionSyncOptions) {
+  const GUILD_ID = opts.guildId;
+  const MSG_LIMIT = opts.msgLimit ?? 200;
+  const DRY_RUN = opts.dryRun ?? false;
+  const CLEANUP = opts.cleanup ?? false;
+  const WEB_BASE = (opts.webBase ?? 'http://127.0.0.1:5001').replace(/\/+$/, '');
+  const WEB_READ_TOKEN = opts.webReadToken ?? '';
+
+  const flags = [DRY_RUN && 'DRY RUN', CLEANUP && 'CLEANUP'].filter(Boolean).join(' + ');
+  console.log(`discord-notion-sync${flags ? ` [${flags}]` : ''}`);
+  console.log(`Guild: ${GUILD_ID} | Limit: ${MSG_LIMIT} messages/posts per source`);
+
+  const rest = new REST({ version: '10' }).setToken(opts.botToken);
+  const notion = new NotionClient({ auth: opts.notionToken, timeoutMs: 120_000 });
+
+  // ------------------------------------------------------------------
+  // 0. Ensure Source property exists on all databases
+  // ------------------------------------------------------------------
+  if (!DRY_RUN) {
+    console.log('\n[0/7] Ensuring Source property exists on all databases…');
+    for (const [dbName, dbId] of Object.entries(NOTION_DB)) {
+      await notionCall(() =>
+        notion.databases.update({
+          database_id: dbId,
+          properties: {
+            'Source': { select: {} },
+          },
+        }),
+      );
+      console.log(`  ✓ ${dbName}`);
+    }
+  }
+
+  if (CLEANUP) {
+    await cleanupPreImportEntries(notion, DRY_RUN);
+  }
+
+  // ------------------------------------------------------------------
+  // 1. Fetch guild channel list
+  // ------------------------------------------------------------------
+  console.log('\n[1/7] Fetching guild channels…');
+  const allChannels = await rest.get(Routes.guildChannels(GUILD_ID)) as DiscordChannel[];
+  const channelByName = new Map(allChannels.map((ch) => [ch.name.toLowerCase(), ch]));
+
+  const cityCategory = allChannels.find(
+    (ch) => ch.type === CH_CATEGORY && ch.name.toLowerCase().includes(CITY_CATEGORY_NAME),
+  );
+  const cityChannels = cityCategory
+    ? allChannels.filter((ch) => ch.parent_id === cityCategory.id && ch.type === CH_TEXT)
+    : [];
+
+  console.log(`  Total channels: ${allChannels.length}`);
+  console.log(`  City of Nashville: ${cityCategory?.name ?? 'NOT FOUND'}`);
+  console.log(`  Location channels: ${cityChannels.map((c) => c.name).join(', ') || 'none'}`);
+
+  // Log detected types for lore channels
+  for (const name of LORE_CHANNEL_NAMES) {
+    const ch = channelByName.get(name);
+    const kind = ch ? (ch.type === CH_FORUM ? 'forum' : 'text') : 'NOT FOUND';
+    console.log(`  #${name}: ${kind}`);
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Active PC roster
+  // ------------------------------------------------------------------
+  console.log('\n[2/7] Fetching active roster from web API…');
+  const activeRoster = await fetchActiveRoster(WEB_BASE, WEB_READ_TOKEN);
+  console.log(`  Active characters: ${activeRoster.length}`);
+
+  // ------------------------------------------------------------------
+  // 3. Location Database
+  // ------------------------------------------------------------------
+  console.log('\n[3/7] Populating Location Database…');
+  if (!cityChannels.length) {
+    console.log('  No city channels found — skipping.');
+  } else {
+    for (const ch of cityChannels) {
+      const locationName = toTitleCase(ch.name);
+      console.log(`  → ${locationName}`);
+      if (!DRY_RUN) {
+        await notionCall(() =>
+          notion.pages.create({
+            parent: { database_id: NOTION_DB.LOCATION_DB },
+            properties: {
+              'Location': { title: [{ text: { content: locationName } }] },
+              'Source': { select: { name: SOURCE_TAG } },
+              ...(ch.topic ? { 'Atmosphere Notes': { rich_text: [{ text: { content: truncate(ch.topic, 2000) } }] } } : {}),
+            },
+          }),
+        );
+      }
+    }
+    console.log(`  Created ${cityChannels.length} location entries.`);
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Hunting Sites (pins from City of Nashville channels)
+  // ------------------------------------------------------------------
+  console.log('\n[4/7] Populating Hunting Sites from City of Nashville pins…');
+  let huntingTotal = 0;
+  for (const ch of cityChannels) {
+    let pins: DiscordMessage[] = [];
+    try { pins = await fetchPins(rest, ch.id); await sleep(200); }
+    catch (err) { console.log(`  [warn] Pins fetch failed for #${ch.name}: ${err}`); continue; }
+
+    if (!pins.length) { console.log(`  #${ch.name}: no pins`); continue; }
+    console.log(`  #${ch.name}: ${pins.length} pin(s)`);
+
+    for (const pin of pins) {
+      if (!pin.content.trim()) continue;
+      const firstLine = pin.content.trim().split('\n')[0]
+        .replace(/^\*+|\*+$/g, '').replace(/^#+\s*/, '').trim();
+      const siteName = truncate(firstLine || `Pin by ${pin.author.username}`, 200);
+      const domain = mapDomain(toTitleCase(ch.name));
+      console.log(`    → ${siteName}`);
+      if (!DRY_RUN) {
+        await notionCall(() =>
+          notion.pages.create({
+            parent: { database_id: NOTION_DB.HUNTING_SITES },
+            properties: {
+              'Site Name': { title: [{ text: { content: siteName } }] },
+              'Description': { rich_text: [{ text: { content: truncate(pin.content, 2000) } }] },
+              'Source': { select: { name: SOURCE_TAG } },
+              ...(domain ? { 'Domain': { select: { name: domain } } } : {}),
+            },
+          }),
+        );
+      }
+      huntingTotal++;
+    }
+  }
+  console.log(`  Created ${huntingTotal} hunting site entries.`);
+
+  // ------------------------------------------------------------------
+  // 5. SPC Tracker (#spc-profiles — text or forum)
+  // ------------------------------------------------------------------
+  console.log('\n[5/7] Populating SPC Tracker from #spc-profiles…');
+  const spcChannel = channelByName.get('spc-profiles');
+  if (!spcChannel) {
+    console.log('  #spc-profiles not found — skipping.');
+  } else if (spcChannel.type === CH_FORUM) {
+    // Forum: each thread = one SPC (thread name = SPC name)
+    console.log('  Detected as forum channel — reading threads.');
+    const threads = await fetchForumThreads(rest, GUILD_ID, spcChannel.id);
+    console.log(`  Threads found: ${threads.length}`);
+    let count = 0;
+    for (const thread of threads.slice(0, MSG_LIMIT)) {
+      const name = truncate(thread.name, 200);
+      console.log(`  → ${name}`);
+      if (!DRY_RUN) {
+        const messages = await fetchAllMessages(rest, thread.id, 50);
+        await sleep(200);
+        const bodyContent = messages.map((m) => m.content).filter(Boolean).join('\n\n');
+        const spcType = inferSpcType(thread.name);
+        const page = await notionCall(() =>
+          notion.pages.create({
+            parent: { database_id: NOTION_DB.SPC_TRACKER },
+            properties: {
+              'Name': { title: [{ text: { content: name } }] },
+              'Status': { select: { name: 'Active' } },
+              'Source': { select: { name: SOURCE_TAG } },
+              ...(spcType ? { 'Type': { select: { name: spcType } } } : {}),
+              'Relationship Notes': { rich_text: [{ text: { content: truncate(bodyContent, 2000) } }] },
+            },
+          }),
+        );
+        await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
+      }
+      count++;
+    }
+    console.log(`  Created ${count} SPC entries.`);
+  } else {
+    // Text channel: each message = one SPC (first line = name)
+    const messages = await fetchAllMessages(rest, spcChannel.id, MSG_LIMIT);
+    console.log(`  Messages: ${messages.length}`);
+    let count = 0;
+    for (const msg of messages) {
+      if (!msg.content.trim()) continue;
+      const firstLine = msg.content.trim().split('\n')[0]
+        .replace(/^\*+|\*+$/g, '').replace(/^#+\s*/, '').trim();
+      const name = truncate(firstLine || `SPC by ${msg.author.username}`, 200);
+      const spcType = inferSpcType(msg.content.split('\n')[0]);
+      console.log(`  → ${name}`);
+      if (!DRY_RUN) {
+        const page = await notionCall(() =>
+          notion.pages.create({
+            parent: { database_id: NOTION_DB.SPC_TRACKER },
+            properties: {
+              'Name': { title: [{ text: { content: name } }] },
+              'Status': { select: { name: 'Active' } },
+              'Source': { select: { name: SOURCE_TAG } },
+              ...(spcType ? { 'Type': { select: { name: spcType } } } : {}),
+              'Relationship Notes': { rich_text: [{ text: { content: truncate(msg.content, 2000) } }] },
+            },
+          }),
+        );
+        await appendBodyBlocks(notion, page.id, textToBlocks(msg.content));
+      }
+      count++;
+    }
+    console.log(`  Created ${count} SPC entries.`);
+  }
+
+  // ------------------------------------------------------------------
+  // 6. PC Tracker (active roster + player names)
+  // ------------------------------------------------------------------
+  console.log('\n[6/7] Populating PC Tracker…');
+  if (!activeRoster.length) {
+    console.log('  No active characters found — skipping.');
+  } else {
+    const playerNameCache = new Map<string, string>();
+    for (const { name, discordId, clan, sect } of activeRoster) {
+      let playerName = '';
+      if (discordId) {
+        if (!playerNameCache.has(discordId)) {
+          const member = await fetchGuildMember(rest, GUILD_ID, discordId);
+          await sleep(100);
+          playerName = member?.nick ?? member?.user?.global_name ?? member?.user?.username ?? '';
+          playerNameCache.set(discordId, playerName);
+        } else {
+          playerName = playerNameCache.get(discordId) ?? '';
+        }
+      }
+      const coterie = CHAR_TO_COTERIE.get(name.toLowerCase()) ?? null;
+      console.log(`  → ${name}${playerName ? ` (${playerName})` : ''}${coterie ? ` [${coterie}]` : ''}`);
+      if (!DRY_RUN) {
+        await notionCall(() =>
+          notion.pages.create({
+            parent: { database_id: NOTION_DB.PC_TRACKER },
+            properties: {
+              'Character Name': { title: [{ text: { content: name } }] },
+              'Source': { select: { name: SOURCE_TAG } },
+              ...(playerName ? { 'Player': { rich_text: [{ text: { content: playerName } }] } } : {}),
+              ...(clan ? { 'Clan': { select: { name: clan } } } : {}),
+              ...(sect ? { 'Sect': { select: { name: sect } } } : {}),
+              ...(coterie ? { 'Coterie': { rich_text: [{ text: { content: coterie } }] } } : {}),
+            },
+          }),
+        );
+      }
+    }
+    console.log(`  Created ${activeRoster.length} PC entries.`);
+  }
+
+  // ------------------------------------------------------------------
+  // 7. Session & Post Log (lore channels)
+  //    Text channels → one archive entry, all messages as body
+  //    Forum channels → one entry per thread/post
+  // ------------------------------------------------------------------
+  console.log('\n[7/7] Populating Session & Post Log…');
+
+  for (const chanName of LORE_CHANNEL_NAMES) {
+    const ch = channelByName.get(chanName);
+    if (!ch) { console.log(`  [warn] #${chanName} not found — skipping.`); continue; }
+
+    if (ch.type === CH_FORUM) {
+      // ---- Forum: one Notion entry per thread ----
+      let threads: DiscordThread[] = [];
+      try {
+        threads = await fetchForumThreads(rest, GUILD_ID, ch.id);
+      } catch (err) {
+        console.log(`  [warn] Could not fetch threads from #${chanName}: ${err}`);
+        continue;
+      }
+      console.log(`  #${chanName} (forum): ${threads.length} post(s)`);
+
+      for (const thread of threads.slice(0, MSG_LIMIT)) {
+        const title = truncate(thread.name, 200);
+        const postDate = thread.thread_metadata?.archive_timestamp?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
+        console.log(`    → ${title}`);
+
+        if (!DRY_RUN) {
+          const messages = await fetchAllMessages(rest, thread.id, 100);
+          await sleep(200);
+          const preview = truncate(messages[0]?.content ?? '', 500);
+          const sessionProps = {
+            'Session/Post Title': { title: [{ text: { content: title } }] },
+            'Status': { select: { name: 'Complete' } },
+            'Source': { select: { name: SOURCE_TAG } },
+            'Summary': { rich_text: [{ text: { content: preview } }] },
+            'Date': { date: { start: postDate } },
+          };
+          const page = await notionCall(() =>
+            notion.pages.create({ parent: { database_id: NOTION_DB.SESSION_LOG }, properties: sessionProps }),
+          );
+          await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
+        }
+      }
+    } else {
+      // ---- Text channel: one archive entry ----
+      let messages: DiscordMessage[] = [];
+      try {
+        messages = await fetchAllMessages(rest, ch.id, MSG_LIMIT);
+      } catch (err) {
+        console.log(`  [warn] Could not read #${chanName}: ${err}`);
+        continue;
+      }
+      if (!messages.length) { console.log(`  #${chanName}: no messages`); continue; }
+
+      const mostRecentDate = messages[messages.length - 1].timestamp.slice(0, 10);
+      const preview = truncate(messages[messages.length - 1].content, 500);
+      const title = `#${chanName} archive`;
+      console.log(`  → ${title} (${messages.length} messages, most recent: ${mostRecentDate})`);
+
+      if (!DRY_RUN) {
+        const sessionProps = {
+          'Session/Post Title': { title: [{ text: { content: title } }] },
+          'Status': { select: { name: 'Complete' } },
+          'Source': { select: { name: SOURCE_TAG } },
+          'Summary': { rich_text: [{ text: { content: preview } }] },
+          'Date': { date: { start: mostRecentDate } },
+        };
+        const page = await notionCall(() =>
+          notion.pages.create({ parent: { database_id: NOTION_DB.SESSION_LOG }, properties: sessionProps }),
+        );
+        await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
+      }
+    }
+  }
+
+  console.log(`\nDone!${DRY_RUN ? ' (dry-run: nothing written to Notion)' : ''}`);
+}
+
+// ---------------------------------------------------------------------------
+// Domain name normalisation
+// ---------------------------------------------------------------------------
+
+const DOMAIN_OPTIONS = [
+  'Madison', 'North Nashville', 'West Nashville', 'Bordeaux', 'East Nashville',
+  'Downtown', 'Midtown', 'South Nashville', 'Donelson', 'Sylvan Park',
+  'Hillwood', 'Green Hills', 'Bellevue', 'Hermitage', 'Percy Priest Lake',
+  'City Sewers', 'Metro Area',
+];
+
+function mapDomain(name: string): string | null {
+  const lower = name.toLowerCase();
+  for (const opt of DOMAIN_OPTIONS) {
+    if (lower.includes(opt.toLowerCase())) return opt;
+  }
+  return null;
+}
+

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -22,6 +22,7 @@ export interface BotConfigResponse {
   passageOfTimeEnabled: boolean | null;
   huntConsequenceEnabled: boolean | null;
   restartRequested: boolean | null;
+  notionSyncRequested: boolean | null;
   passageOfTimeIntervalMs: number | null;
   reviewNotifierIntervalMs: number | null;
   submissionNotifierIntervalMs: number | null;
@@ -59,9 +60,23 @@ export interface TrackerAdapter {
   getHealthReport(requester: RequesterContext): Promise<AdapterHealthReport>;
   getBotConfig(): Promise<BotConfigResponse>;
   ackBotRestart(): Promise<void>;
+  ackNotionSync(status: 'running' | 'success' | 'error', error?: string): Promise<void>;
   postHeartbeat(liveState?: Record<string, boolean>): Promise<void>;
   getAllReminderPrefs(): Promise<Record<string, { optOut: boolean; snoozeUntilEpoch: number }>>;
   setReminderPref(discordId: string, prefs: { optOut: boolean; snoozeUntilEpoch: number }): Promise<void>;
+  triggerSheetsReconcile(): Promise<SheetsReconcileSummary>;
+}
+
+export interface SheetsReconcileSummary {
+  started_at: string;
+  finished_at?: string;
+  claims_appended: number;
+  claims_status_updated: number;
+  spends_appended: number;
+  spends_status_updated: number;
+  ledger_appended: number;
+  characters_appended: number;
+  errors: string[];
 }
 
 const summarySchema = z.object({
@@ -538,6 +553,16 @@ export class WebAppAdapter implements TrackerAdapter {
     if (!res.ok) throw new Error(`bot-restart-ack POST failed: ${res.status}`);
   }
 
+  async ackNotionSync(status: 'running' | 'success' | 'error', error?: string): Promise<void> {
+    const url = `${this.baseUrl}/api/notion-sync-ack`;
+    const res = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status, ...(error ? { error } : {}) }),
+    });
+    if (!res.ok) throw new Error(`notion-sync-ack POST failed: ${res.status}`);
+  }
+
   async postHeartbeat(liveState?: Record<string, boolean>): Promise<void> {
     const url = `${this.baseUrl}/api/bot-heartbeat`;
     const res = await this.fetchWithTimeout(url, {
@@ -577,6 +602,16 @@ export class WebAppAdapter implements TrackerAdapter {
     } catch {
       // best-effort
     }
+  }
+
+  async triggerSheetsReconcile(): Promise<SheetsReconcileSummary> {
+    const url = `${this.baseUrl}/api/sheets/reconcile`;
+    const res = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      headers: this.writeAuthHeaders(),
+    });
+    if (!res.ok) throw new Error(`sheets/reconcile POST failed: ${res.status}`);
+    return res.json() as Promise<SheetsReconcileSummary>;
   }
 
   private async post(path: string, body: unknown, successMessage: string) {

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -1,10 +1,12 @@
 import { liveConfig } from '../liveConfig';
 import { logEvent } from '../logger';
 import type { TrackerAdapter } from './adapter';
+import { runNotionSync } from '../scripts/discord-notion-sync';
 
 export class ConfigSyncWorker {
   private readonly adapter: TrackerAdapter;
   private readonly intervalMs: number;
+  private notionSyncRunning = false;
 
   constructor(adapter: TrackerAdapter, intervalMs = 60_000) {
     this.adapter = adapter;
@@ -37,8 +39,46 @@ export class ConfigSyncWorker {
         }
         process.exit(0);
       }
+
+      if (cfg.notionSyncRequested && !this.notionSyncRunning) {
+        void this.runNotionSyncBackground();
+      }
     } catch (err) {
       logEvent('warn', 'config_sync_failed', { error: String(err) });
+    }
+  }
+
+  private async runNotionSyncBackground(): Promise<void> {
+    this.notionSyncRunning = true;
+    logEvent('info', 'notion_sync_starting', {});
+    try {
+      await this.adapter.ackNotionSync('running');
+    } catch (err) {
+      logEvent('warn', 'notion_sync_ack_running_failed', { error: String(err) });
+      this.notionSyncRunning = false;
+      return;
+    }
+    try {
+      const result = await runNotionSync({
+        botToken: process.env.BOT_TOKEN ?? '',
+        guildId: process.env.DISCORD_GUILD_ID ?? process.env.TEST_GUILD_ID ?? '',
+        notionToken: process.env.NOTION_TOKEN ?? '',
+        webBase: process.env.WEB_APP_BASE_URL,
+        webReadToken: process.env.WEB_APP_API_READ_TOKEN ?? process.env.WEB_APP_API_TOKEN,
+        msgLimit: Number.parseInt(process.env.NOTION_SYNC_MSG_LIMIT ?? '200', 10),
+      });
+      if (result.success) {
+        logEvent('info', 'notion_sync_completed', {});
+        await this.adapter.ackNotionSync('success');
+      } else {
+        logEvent('warn', 'notion_sync_failed', { error: result.error });
+        await this.adapter.ackNotionSync('error', result.error);
+      }
+    } catch (err) {
+      logEvent('warn', 'notion_sync_error', { error: String(err) });
+      try { await this.adapter.ackNotionSync('error', String(err)); } catch { /* ignore */ }
+    } finally {
+      this.notionSyncRunning = false;
     }
   }
 

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -1,5 +1,6 @@
 import { liveConfig } from '../liveConfig';
 import { logEvent } from '../logger';
+import { config } from '../config';
 import type { TrackerAdapter } from './adapter';
 import { runNotionSync } from '../scripts/discord-notion-sync';
 
@@ -60,12 +61,12 @@ export class ConfigSyncWorker {
     }
     try {
       const result = await runNotionSync({
-        botToken: process.env.BOT_TOKEN ?? '',
-        guildId: process.env.DISCORD_GUILD_ID ?? process.env.TEST_GUILD_ID ?? '',
-        notionToken: process.env.NOTION_TOKEN ?? '',
-        webBase: process.env.WEB_APP_BASE_URL,
-        webReadToken: process.env.WEB_APP_API_READ_TOKEN ?? process.env.WEB_APP_API_TOKEN,
-        msgLimit: Number.parseInt(process.env.NOTION_SYNC_MSG_LIMIT ?? '200', 10),
+        botToken: config.botToken,
+        guildId: config.discordGuildId,
+        notionToken: config.notionToken,
+        webBase: config.webAppBaseUrl,
+        webReadToken: config.webAppApiReadToken ?? config.webAppApiToken,
+        msgLimit: config.notionSyncMsgLimit,
       });
       if (result.success) {
         logEvent('info', 'notion_sync_completed', {});

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -335,6 +335,8 @@ def active_roster():
                 {
                     'name': c.character_name,
                     'discordId': str(c.player_discord).strip() if c.player_discord else None,
+                    'clan': c.clan or None,
+                    'sect': c.sect or None,
                 }
                 for c in characters
             ]
@@ -609,6 +611,7 @@ def bot_config():
         'BOT_PASSAGE_OF_TIME_ENABLED': 'passageOfTimeEnabled',
         'BOT_HUNT_CONSEQUENCE_ENABLED': 'huntConsequenceEnabled',
         'BOT_RESTART_REQUESTED': 'restartRequested',
+        'BOT_NOTION_SYNC_REQUESTED': 'notionSyncRequested',
     }
     INT_KEYS = {
         'BOT_PASSAGE_OF_TIME_INTERVAL_MS': 'passageOfTimeIntervalMs',
@@ -979,3 +982,62 @@ def set_reminder_pref(discord_id):
     snooze_until_epoch = int(data.get('snoozeUntilEpoch', 0))
     db_service.set_reminder_pref(discord_id, opt_out, snooze_until_epoch)
     return jsonify({'ok': True})
+
+
+@bp.route('/notion-sync-ack', methods=['POST'])
+@require_bot_scope('write')
+@_limit('30 per minute')
+def notion_sync_ack():
+    """Bot calls this to report Notion sync status."""
+    from datetime import datetime, timezone
+    from app.db import AppSetting, db
+    data = request.get_json(silent=True) or {}
+    status = data.get('status')
+    if status not in ('running', 'success', 'error'):
+        return jsonify({'error': 'status must be running, success, or error'}), 400
+    now = datetime.now(timezone.utc).isoformat()
+
+    def upsert(key, value):
+        rec = AppSetting.query.get(key)
+        if rec:
+            rec.value = value
+            rec.updated_at = datetime.now(timezone.utc)
+            rec.updated_by = 'bot'
+        else:
+            db.session.add(AppSetting(key=key, value=value, updated_by='bot'))
+
+    if status == 'running':
+        req = AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED')
+        if req:
+            db.session.delete(req)
+        upsert('BOT_NOTION_SYNC_STATUS', 'running')
+        upsert('BOT_NOTION_SYNC_STARTED_AT', now)
+    elif status == 'success':
+        upsert('BOT_NOTION_SYNC_STATUS', 'success')
+        upsert('BOT_NOTION_SYNC_FINISHED_AT', now)
+    else:
+        upsert('BOT_NOTION_SYNC_STATUS', 'error')
+        upsert('BOT_NOTION_SYNC_FINISHED_AT', now)
+        upsert('BOT_NOTION_SYNC_ERROR', data.get('error', 'unknown error'))
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/sheets/reconcile', methods=['POST'])
+@require_bot_scope('write')
+@_limit('5 per hour')
+def sheets_reconcile():
+    """Trigger a full Sheets reconciliation diff/repair.
+
+    Compares DB state to Google Sheets across all four data types (claims,
+    spends, ledger, characters) and appends/updates any gaps. Returns a
+    summary of what was changed. Intended to be called by the bot once
+    nightly.
+    """
+    if sheets_sync is None:
+        return jsonify({'error': 'Sheets sync not configured'}), 503
+    try:
+        summary = sheets_sync.reconcile(db_service)
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+    return jsonify(summary)

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -358,6 +358,20 @@ def index():
 
     _restart_pending = 'BOT_RESTART_REQUESTED' in overrides and overrides['BOT_RESTART_REQUESTED'].value.lower() in ('true', '1', 'yes')
 
+    # ── Notion sync status ─────────────────────────────────────────────────
+    _notion_sync_requested = 'BOT_NOTION_SYNC_REQUESTED' in overrides and overrides['BOT_NOTION_SYNC_REQUESTED'].value.lower() in ('true', '1', 'yes')
+    _notion_status_rec = AppSetting.query.get('BOT_NOTION_SYNC_STATUS')
+    _notion_started_rec = AppSetting.query.get('BOT_NOTION_SYNC_STARTED_AT')
+    _notion_finished_rec = AppSetting.query.get('BOT_NOTION_SYNC_FINISHED_AT')
+    _notion_error_rec = AppSetting.query.get('BOT_NOTION_SYNC_ERROR')
+    notion_sync = {
+        'requested': _notion_sync_requested,
+        'status': _notion_status_rec.value if _notion_status_rec else None,
+        'started_at': _notion_started_rec.value if _notion_started_rec else None,
+        'finished_at': _notion_finished_rec.value if _notion_finished_rec else None,
+        'error': _notion_error_rec.value if _notion_error_rec else None,
+    }
+
     return render_template(
         'settings/index.html',
         web_flags=web_flags,
@@ -370,7 +384,25 @@ def index():
         bot_heartbeat_age=bot_heartbeat_age,
         bot_heartbeat_ts=bot_heartbeat_ts,
         bot_restart_pending=_restart_pending,
+        notion_sync=notion_sync,
     )
+
+
+@bp.route('/request-notion-sync', methods=['POST'])
+@require_staff
+def request_notion_sync():
+    if not is_settings_admin():
+        flash('You do not have permission to run the Notion sync.', 'danger')
+        return redirect(url_for('settings.index'))
+
+    updated_by = (
+        session.get('discord_name')
+        or session.get('staff_user')
+        or session.get('discord_id', 'unknown')
+    )
+    set_app_setting('BOT_NOTION_SYNC_REQUESTED', 'true', updated_by)
+    flash('Notion sync queued. The bot will start it within ~60 seconds.', 'success')
+    return redirect(url_for('settings.index'))
 
 
 @bp.route('/request-restart', methods=['POST'])

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -183,6 +183,60 @@
     </div>
   </div>
 
+  {# ═══ Bot — Notion Sync ═══ #}
+  <div class="card bg-dark border-secondary mb-4">
+    <div class="card-header border-secondary d-flex align-items-center justify-content-between">
+      <h6 class="mb-0 text-light"><i class="bi bi-database-up"></i> Notion Sync</h6>
+      {% if can_edit %}
+        <form method="POST" action="{{ url_for('settings.request_notion_sync') }}" class="mb-0">
+          {% if notion_sync.requested or notion_sync.status == 'running' %}
+            <button type="submit" class="btn btn-sm btn-info" disabled>
+              <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+              {% if notion_sync.status == 'running' %}Running…{% else %}Queued…{% endif %}
+            </button>
+          {% else %}
+            <button type="submit" class="btn btn-sm btn-outline-info"
+              onclick="return confirm('Run Discord → Notion sync? This may take several minutes.')">
+              <i class="bi bi-arrow-repeat"></i> Run Notion Sync
+            </button>
+          {% endif %}
+        </form>
+      {% endif %}
+    </div>
+    <div class="card-body">
+      <p class="text-muted small mb-2">
+        Reads Discord channels and populates the Nashville by Night Notion page
+        (PC Tracker, SPC Tracker, Location DB, Hunting Sites, Session &amp; Post Log).
+        Requires <code>NOTION_TOKEN</code> and <code>DISCORD_GUILD_ID</code> in the bot's <code>.env</code>.
+      </p>
+      {% if notion_sync.status == 'running' %}
+        <span class="badge bg-info text-dark"><i class="bi bi-arrow-repeat me-1"></i>Running</span>
+        {% if notion_sync.started_at %}
+          <small class="text-muted ms-2">Started {{ notion_sync.started_at[:19] | replace('T', ' ') }} UTC</small>
+        {% endif %}
+      {% elif notion_sync.status == 'success' %}
+        <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Success</span>
+        {% if notion_sync.finished_at %}
+          <small class="text-muted ms-2">Completed {{ notion_sync.finished_at[:19] | replace('T', ' ') }} UTC</small>
+        {% endif %}
+      {% elif notion_sync.status == 'error' %}
+        <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Error</span>
+        {% if notion_sync.error %}
+          <small class="text-danger ms-2">{{ notion_sync.error }}</small>
+        {% endif %}
+        {% if notion_sync.started_at %}
+          <small class="text-muted ms-2">(started {{ notion_sync.started_at[:19] | replace('T', ' ') }} UTC)</small>
+        {% endif %}
+      {% elif notion_sync.requested %}
+        <span class="badge bg-secondary">Queued</span>
+        <small class="text-muted ms-2">Waiting for the bot to pick it up…</small>
+      {% else %}
+        <span class="badge bg-secondary">Never run</span>
+        <small class="text-muted ms-2">Click <strong>Run Notion Sync</strong> to populate the Notion page from Discord.</small>
+      {% endif %}
+    </div>
+  </div>
+
   {# ═══ Bot — Channel IDs ═══ #}
   <h5 class="text-muted text-uppercase small mb-2 mt-4">Bot — Channel IDs</h5>
   <p class="text-muted small mb-2">


### PR DESCRIPTION
## Summary
- New one-time/recurring sync script that reads Discord channels and populates the Nashville by Night Notion wiki databases
- Web → bot signaling via existing AppSetting flag pattern (same as restart-requested)
- Admin UI trigger with live status display in the settings page
- Active roster API extended with `clan` and `sect` fields

## What gets synced
- **PC Tracker**: name, player Discord handle, clan, sect, coterie
- **SPC Tracker**: name, status, type (inferred from thread name), body content
- **Location DB**: City of Nashville channels
- **Hunting Sites**: pinned messages from location channels
- **Session & Post Log**: lore channels (text archives + forum threads with images)

## Flags
- `npm run notion-sync` — full sync
- `npm run notion-sync:dry-run` — preview only
- `npm run notion-sync:cleanup` — archive pre-import Notion entries (those without `Source=discord-sync`)

## Test plan
- [ ] `npm run notion-sync:dry-run` completes without errors
- [ ] Settings page shows Notion Sync card with trigger button
- [ ] Button triggers sync and status updates (Queued → Running → Success/Error)
- [ ] Active roster API returns `clan` and `sect` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)