### PR TITLE
feat: Chronicle Wiki blueprint at /wiki

### DIFF
--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -120,6 +120,7 @@ def create_app():
     from .blueprints.api import bp as api_bp
     from .blueprints.local_status import bp as local_status_bp
     from .blueprints.settings import bp as settings_bp
+    from .blueprints.wiki import bp as wiki_bp
 
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(claims_bp, url_prefix='/claims')
@@ -131,6 +132,7 @@ def create_app():
     app.register_blueprint(api_bp, url_prefix='/api')
     app.register_blueprint(local_status_bp)
     app.register_blueprint(settings_bp, url_prefix='/settings')
+    app.register_blueprint(wiki_bp, url_prefix='/wiki')
     csrf.exempt(api_bp)
 
     # Inject auth helpers into all templates

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1023,6 +1023,51 @@ def notion_sync_ack():
     return jsonify({'ok': True})
 
 
+@bp.route('/wiki/page', methods=['POST'])
+@require_bot_scope('write')
+@_limit('120 per minute')
+def upsert_wiki_page():
+    """Create or update a wiki page (used by the Notion/Discord sync script)."""
+    from datetime import datetime, timezone
+    from app.db import db, WikiPage
+    data = request.get_json(silent=True) or {}
+    slug = (data.get('slug') or '').strip()
+    title = (data.get('title') or '').strip()
+    if not slug or not title:
+        return jsonify({'error': 'slug and title are required'}), 400
+
+    p = WikiPage.query.filter_by(slug=slug).first()
+    if p:
+        p.title = title
+        if 'body_markdown' in data:
+            p.body_markdown = data['body_markdown']
+        if 'category' in data:
+            p.category = data['category']
+        if 'cover_image_url' in data:
+            p.cover_image_url = data['cover_image_url']
+        if 'published' in data:
+            p.published = bool(data['published'])
+        p.source = data.get('source', p.source)
+        p.updated_by = data.get('updated_by', 'api-sync')
+        p.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return jsonify({'status': 'updated', 'slug': slug})
+
+    p = WikiPage(
+        slug=slug,
+        title=title,
+        body_markdown=data.get('body_markdown', ''),
+        category=data.get('category', ''),
+        cover_image_url=data.get('cover_image_url', ''),
+        source=data.get('source', 'api-sync'),
+        published=bool(data.get('published', True)),
+        updated_by=data.get('updated_by', 'api-sync'),
+    )
+    db.session.add(p)
+    db.session.commit()
+    return jsonify({'status': 'created', 'slug': slug}), 201
+
+
 @bp.route('/sheets/reconcile', methods=['POST'])
 @require_bot_scope('write')
 @_limit('5 per hour')

--- a/apps/web/app/blueprints/audit.py
+++ b/apps/web/app/blueprints/audit.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from flask import Blueprint, render_template, request
 from app import db_service
-import app.sheets_sync as _sheets_sync_mod
+from app.sheets_sync import get_recent_sync_errors as _get_recent_sync_errors
 from app.auth import require_staff
 
 bp = Blueprint('audit', __name__)
@@ -148,7 +148,7 @@ def errors():
         event_counts[key] = event_counts.get(key, 0) + 1
 
     # Merge in-memory (real-time, current session) and DB (historical) sync errors
-    rt_errors = _sheets_sync_mod.get_recent_sync_errors()
+    rt_errors = _get_recent_sync_errors()
     db_errors = db_service.get_recent_sync_errors(limit=100)
     # Deduplicate: prefer DB entries (they have an id); RT entries not yet flushed are additions
     db_keys = {(e['timestamp'], e['operation'], e['error']) for e in db_errors}

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import html as _html_mod
 import re
 from datetime import datetime, timezone
+from html.parser import HTMLParser
 
 import markdown as md_lib
+from markupsafe import Markup
 from flask import (
     Blueprint, render_template, request, redirect, url_for, flash, abort,
 )
@@ -23,6 +26,9 @@ CATEGORIES: list[tuple[str, str, str]] = [
 ]
 CATEGORY_DISPLAY: dict[str, str] = {s: n for s, n, _ in CATEGORIES}
 
+# Slugs reserved by static wiki routes — these can never be used as page slugs.
+_RESERVED_SLUGS = frozenset({'new', 'edit', 'category'})
+
 
 @bp.context_processor
 def _wiki_context():
@@ -36,20 +42,92 @@ def _slugify(text: str) -> str:
     return re.sub(r'-+', '-', text).strip('-')
 
 
-def _render_md(text: str) -> str:
-    return md_lib.markdown(
+_ALLOWED_TAGS = frozenset({
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'p', 'br', 'hr',
+    'ul', 'ol', 'li',
+    'strong', 'em', 'del', 's',
+    'a', 'img',
+    'blockquote', 'pre', 'code',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+    'div', 'span',
+})
+_ALLOWED_ATTRS: dict[str, list[str]] = {
+    'a':   ['href', 'title', 'rel'],
+    'img': ['src', 'alt', 'title', 'width', 'height'],
+    '*':   ['class', 'id'],
+}
+_VOID_TAGS = frozenset({'br', 'hr', 'img'})
+_URL_ATTRS = frozenset({'href', 'src'})
+_JS_RE = re.compile(r'^\s*javascript:', re.I)
+
+
+class _HtmlSanitizer(HTMLParser):
+    """Allow-list HTML sanitizer using stdlib HTMLParser."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._out: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag not in _ALLOWED_TAGS:
+            return
+        allowed = _ALLOWED_ATTRS.get(tag, []) + _ALLOWED_ATTRS['*']
+        safe = ''
+        for name, value in attrs:
+            name = name.lower()
+            if name not in allowed:
+                continue
+            value = value or ''
+            if name in _URL_ATTRS and _JS_RE.match(value):
+                continue
+            safe += f' {name}="{_html_mod.escape(value)}"'
+        if tag in _VOID_TAGS:
+            self._out.append(f'<{tag}{safe}>')
+        else:
+            self._out.append(f'<{tag}{safe}>')
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in _ALLOWED_TAGS and tag not in _VOID_TAGS:
+            self._out.append(f'</{tag}>')
+
+    def handle_data(self, data: str) -> None:
+        self._out.append(_html_mod.escape(data))
+
+    def handle_entityref(self, name: str) -> None:
+        self._out.append(f'&{name};')
+
+    def handle_charref(self, name: str) -> None:
+        self._out.append(f'&#{name};')
+
+    def get_output(self) -> str:
+        return ''.join(self._out)
+
+
+def _sanitize(html_str: str) -> str:
+    san = _HtmlSanitizer()
+    san.feed(html_str)
+    return san.get_output()
+
+
+def _render_md(text: str) -> Markup:
+    raw_html = md_lib.markdown(
         text or '',
         extensions=['extra', 'toc', 'nl2br'],
         output_format='html',
     )
+    return Markup(_sanitize(raw_html))
 
 
 def _unique_slug(base: str) -> str:
-    slug = base
+    # Start from -1 suffix if the base itself is reserved
+    slug = f'{base}-1' if base in _RESERVED_SLUGS else base
     i = 1
     while WikiPage.query.filter_by(slug=slug).first():
-        slug = f'{base}-{i}'
         i += 1
+        slug = f'{base}-{i}'
     return slug
 
 

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -63,15 +63,23 @@ _JS_RE = re.compile(r'^\s*javascript:', re.I)
 
 
 class _HtmlSanitizer(HTMLParser):
-    """Allow-list HTML sanitizer using stdlib HTMLParser."""
+    """Allow-list HTML sanitizer using stdlib HTMLParser.
+
+    Tags not in _ALLOWED_TAGS are dropped along with all their content
+    (tracked via _skip_depth so nested disallowed tags work correctly).
+    """
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
         self._out: list[str] = []
+        self._skip_depth: int = 0  # >0 means we're inside a disallowed tag
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
         if tag not in _ALLOWED_TAGS:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
             return
         allowed = _ALLOWED_ATTRS.get(tag, []) + _ALLOWED_ATTRS['*']
         safe = ''
@@ -83,24 +91,30 @@ class _HtmlSanitizer(HTMLParser):
             if name in _URL_ATTRS and _JS_RE.match(value):
                 continue
             safe += f' {name}="{_html_mod.escape(value)}"'
-        if tag in _VOID_TAGS:
-            self._out.append(f'<{tag}{safe}>')
-        else:
-            self._out.append(f'<{tag}{safe}>')
+        self._out.append(f'<{tag}{safe}>')
 
     def handle_endtag(self, tag: str) -> None:
         tag = tag.lower()
-        if tag in _ALLOWED_TAGS and tag not in _VOID_TAGS:
+        if tag not in _ALLOWED_TAGS:
+            if self._skip_depth:
+                self._skip_depth -= 1
+            return
+        if self._skip_depth:
+            return
+        if tag not in _VOID_TAGS:
             self._out.append(f'</{tag}>')
 
     def handle_data(self, data: str) -> None:
-        self._out.append(_html_mod.escape(data))
+        if not self._skip_depth:
+            self._out.append(_html_mod.escape(data))
 
     def handle_entityref(self, name: str) -> None:
-        self._out.append(f'&{name};')
+        if not self._skip_depth:
+            self._out.append(f'&{name};')
 
     def handle_charref(self, name: str) -> None:
-        self._out.append(f'&#{name};')
+        if not self._skip_depth:
+            self._out.append(f'&#{name};')
 
     def get_output(self) -> str:
         return ''.join(self._out)

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -1,0 +1,136 @@
+"""Chronicle Wiki — public-facing lore and location pages."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import markdown as md_lib
+from flask import (
+    Blueprint, render_template, request, redirect, url_for, flash, abort,
+)
+from app.auth import require_staff, get_staff_user, is_staff as _is_staff
+from app.db import db, WikiPage
+
+bp = Blueprint('wiki', __name__)
+
+CATEGORIES: list[tuple[str, str, str]] = [
+    ('locations',   'Locations',   'bi-geo-alt-fill'),
+    ('characters',  'Characters',  'bi-person-fill'),
+    ('coteries',    'Coteries',    'bi-people-fill'),
+    ('factions',    'Factions',    'bi-shield-fill'),
+    ('lore',        'Lore',        'bi-book-fill'),
+]
+CATEGORY_DISPLAY: dict[str, str] = {s: n for s, n, _ in CATEGORIES}
+
+
+@bp.context_processor
+def _wiki_context():
+    return {'wiki_categories': CATEGORIES, 'wiki_category_display': CATEGORY_DISPLAY}
+
+
+def _slugify(text: str) -> str:
+    text = text.lower().strip()
+    text = re.sub(r'[^\w\s-]', '', text)
+    text = re.sub(r'[\s_]+', '-', text)
+    return re.sub(r'-+', '-', text).strip('-')
+
+
+def _render_md(text: str) -> str:
+    return md_lib.markdown(
+        text or '',
+        extensions=['extra', 'toc', 'nl2br'],
+        output_format='html',
+    )
+
+
+def _unique_slug(base: str) -> str:
+    slug = base
+    i = 1
+    while WikiPage.query.filter_by(slug=slug).first():
+        slug = f'{base}-{i}'
+        i += 1
+    return slug
+
+
+# ── Public routes ─────────────────────────────────────────────────────────────
+
+@bp.route('/')
+def index():
+    recent = (WikiPage.query
+              .filter_by(published=True)
+              .order_by(WikiPage.updated_at.desc())
+              .limit(8)
+              .all())
+    counts = {s: WikiPage.query.filter_by(category=s, published=True).count()
+              for s, _, _ in CATEGORIES}
+    return render_template('wiki/index.html', recent=recent, counts=counts)
+
+
+@bp.route('/category/<category>')
+def category(category):
+    if category not in CATEGORY_DISPLAY:
+        abort(404)
+    pages = (WikiPage.query
+             .filter_by(category=category, published=True)
+             .order_by(WikiPage.title.asc())
+             .all())
+    return render_template('wiki/category.html',
+                           active_category=category,
+                           category_name=CATEGORY_DISPLAY[category],
+                           pages=pages)
+
+
+@bp.route('/<slug>')
+def page(slug):
+    p = WikiPage.query.filter_by(slug=slug).first_or_404()
+    if not p.published and not _is_staff():
+        abort(404)
+    body_html = _render_md(p.body_markdown)
+    return render_template('wiki/page.html', page=p, body_html=body_html)
+
+
+# ── Staff routes ───────────────────────────────────────────────────────────────
+
+@bp.route('/new', methods=['GET', 'POST'])
+@require_staff
+def new_page():
+    if request.method == 'POST':
+        title = request.form.get('title', '').strip()
+        if not title:
+            flash('Title is required.', 'danger')
+            return redirect(url_for('wiki.new_page'))
+        slug = _unique_slug(_slugify(title))
+        p = WikiPage(
+            slug=slug,
+            title=title,
+            body_markdown=request.form.get('body_markdown', ''),
+            category=request.form.get('category', '').strip(),
+            cover_image_url=request.form.get('cover_image_url', '').strip(),
+            published=request.form.get('published') == '1',
+            source='manual',
+            updated_by=get_staff_user(),
+        )
+        db.session.add(p)
+        db.session.commit()
+        flash(f'Page "{title}" created.', 'success')
+        return redirect(url_for('wiki.page', slug=slug))
+    return render_template('wiki/edit.html', page=None)
+
+
+@bp.route('/edit/<slug>', methods=['GET', 'POST'])
+@require_staff
+def edit_page(slug):
+    p = WikiPage.query.filter_by(slug=slug).first_or_404()
+    if request.method == 'POST':
+        p.title = request.form.get('title', p.title).strip() or p.title
+        p.category = request.form.get('category', p.category).strip()
+        p.body_markdown = request.form.get('body_markdown', '')
+        p.cover_image_url = request.form.get('cover_image_url', '').strip()
+        p.published = request.form.get('published') == '1'
+        p.updated_by = get_staff_user()
+        p.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        flash(f'Page "{p.title}" saved.', 'success')
+        return redirect(url_for('wiki.page', slug=slug))
+    return render_template('wiki/edit.html', page=p)

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -134,6 +134,21 @@ class DbSheetsSyncError(db.Model):
     details = db.Column(Text, default='')
 
 
+class WikiPage(db.Model):
+    __tablename__ = 'wiki_pages'
+    id = db.Column(Integer, primary_key=True)
+    slug = db.Column(String(200), nullable=False, unique=True, index=True)
+    title = db.Column(String(300), nullable=False)
+    body_markdown = db.Column(Text, default='')
+    category = db.Column(String(100), default='', index=True)
+    cover_image_url = db.Column(Text, default='')
+    source = db.Column(String(50), default='')
+    published = db.Column(Boolean, default=True, index=True)
+    created_at = db.Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_by = db.Column(String(100), default='')
+
+
 class DbReminderPreference(db.Model):
     __tablename__ = 'reminder_preferences'
     discord_id = db.Column(String(30), primary_key=True)

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -892,6 +892,529 @@ tr.has-clan-color {
     color: #89b4fa;
 }
 
+/* ── Wiki ────────────────────────────────────────────────────────── */
+
+.wiki-body {
+    background-color: #12121f;
+}
+
+/* Navbar */
+.wiki-navbar {
+    background:
+        linear-gradient(rgba(10, 10, 20, 0.94), rgba(16, 21, 40, 0.97)),
+        url('/static/images/music.png');
+    background-size: cover;
+    background-position: center 42%;
+    border-bottom: 1px solid rgba(197, 165, 90, 0.2) !important;
+    padding: 0.6rem 0;
+}
+
+.wiki-brand {
+    font-family: 'Cinzel', serif;
+    font-size: 1rem;
+    letter-spacing: 0.06em;
+    color: #e0e0e0 !important;
+}
+
+.wiki-nav-link {
+    color: #9898b0 !important;
+    font-size: 0.88rem;
+    padding: 0.35rem 0.75rem !important;
+    border-radius: 4px;
+    transition: color 0.15s, background 0.15s;
+}
+
+.wiki-nav-link:hover {
+    color: #e0e0e0 !important;
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.wiki-nav-active {
+    color: var(--vtm-gold) !important;
+    background: rgba(197, 165, 90, 0.1) !important;
+}
+
+.wiki-btn-new {
+    background: rgba(139, 0, 0, 0.5);
+    border: 1px solid rgba(139, 0, 0, 0.8);
+    color: #e8a0a0 !important;
+    font-size: 0.82rem;
+}
+
+.wiki-btn-new:hover {
+    background: var(--vtm-red);
+    color: #fff !important;
+}
+
+.wiki-btn-login {
+    background: rgba(88, 101, 242, 0.25);
+    border: 1px solid rgba(88, 101, 242, 0.55);
+    color: #b9bcf8 !important;
+    font-size: 0.82rem;
+}
+
+.wiki-btn-login:hover {
+    background: #5865f2;
+    color: #fff !important;
+}
+
+.wiki-btn-edit {
+    background: rgba(197, 165, 90, 0.15);
+    border: 1px solid rgba(197, 165, 90, 0.4);
+    color: var(--vtm-gold);
+    width: 100%;
+    padding: 0.4rem;
+}
+
+.wiki-btn-edit:hover {
+    background: rgba(197, 165, 90, 0.25);
+    color: #e8d585;
+}
+
+.wiki-btn-save {
+    background: var(--vtm-red);
+    border: 1px solid #a00000;
+    color: #fff;
+    padding: 0.5rem 1.5rem;
+}
+
+.wiki-btn-save:hover {
+    background: var(--vtm-red-light);
+    color: #fff;
+}
+
+/* Hero sections */
+.wiki-index-hero {
+    background:
+        linear-gradient(rgba(10, 10, 20, 0.55), rgba(18, 18, 31, 1)),
+        url('/static/images/music.png');
+    background-size: cover;
+    background-position: center 40%;
+    padding: 4.5rem 0 3rem;
+    margin-bottom: 0;
+    border-bottom: 1px solid rgba(197, 165, 90, 0.15);
+}
+
+.wiki-index-title {
+    font-family: 'Cinzel', serif;
+    font-size: 2.8rem;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.4rem;
+}
+
+.wiki-index-subtitle {
+    color: var(--vtm-gold);
+    font-size: 0.9rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    opacity: 0.85;
+    margin: 0;
+}
+
+.wiki-cat-hero {
+    background:
+        linear-gradient(rgba(10, 10, 20, 0.6), rgba(18, 18, 31, 1)),
+        url('/static/images/music.png');
+    background-size: cover;
+    background-position: center 40%;
+    padding: 2.5rem 0 1.75rem;
+    border-bottom: 1px solid rgba(197, 165, 90, 0.12);
+    margin-bottom: 0;
+}
+
+.wiki-cat-hero-icon {
+    font-size: 2.2rem;
+    color: var(--vtm-gold);
+    opacity: 0.8;
+}
+
+.wiki-cat-hero-title {
+    font-family: 'Cinzel', serif;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.wiki-cat-hero-count {
+    font-size: 0.85rem;
+    margin: 0;
+}
+
+.wiki-page-hero {
+    position: relative;
+    background:
+        linear-gradient(rgba(10, 10, 20, 0.55), rgba(18, 18, 31, 1)),
+        var(--cover-url, url('/static/images/music.png'));
+    background-size: cover;
+    background-position: center 40%;
+    padding: 3rem 0 2rem;
+    border-bottom: 1px solid rgba(197, 165, 90, 0.12);
+    margin-bottom: 0;
+}
+
+.wiki-page-hero--plain {
+    background:
+        linear-gradient(rgba(10, 10, 20, 0.7), rgba(18, 18, 31, 1)),
+        url('/static/images/music.png');
+    padding: 2rem 0 1.5rem;
+}
+
+.wiki-page-title {
+    font-family: 'Cinzel', serif;
+    font-size: 2.2rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+/* Breadcrumbs */
+.wiki-breadcrumb {
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+}
+
+.wiki-breadcrumb .breadcrumb-item a {
+    color: var(--vtm-gold);
+    opacity: 0.8;
+    text-decoration: none;
+}
+
+.wiki-breadcrumb .breadcrumb-item a:hover { opacity: 1; }
+
+.wiki-breadcrumb .breadcrumb-item.active { color: #888; }
+
+.wiki-breadcrumb .breadcrumb-item + .breadcrumb-item::before { color: #555; }
+
+/* Section heading */
+.wiki-section-heading {
+    font-family: 'Cinzel', serif;
+    font-size: 1.1rem;
+    color: var(--vtm-gold);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid rgba(197, 165, 90, 0.2);
+}
+
+/* Category cards (index) */
+.wiki-category-card {
+    background: #16213e;
+    border: 1px solid rgba(197, 165, 90, 0.12);
+    border-top: 3px solid var(--vtm-red);
+    border-radius: 8px;
+    padding: 1.25rem 1rem;
+    transition: border-top-color 0.15s, transform 0.15s, box-shadow 0.15s;
+    display: block;
+    color: inherit;
+    height: 100%;
+}
+
+.wiki-category-card:hover {
+    border-top-color: var(--vtm-gold);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+    color: inherit;
+}
+
+.wiki-category-card .cat-icon {
+    font-size: 1.75rem;
+    color: var(--vtm-gold);
+    opacity: 0.75;
+    margin-bottom: 0.6rem;
+    display: block;
+}
+
+.wiki-category-card h3 {
+    font-size: 0.95rem;
+    color: #ddd;
+    margin: 0 0 0.2rem;
+}
+
+.wiki-category-card .count {
+    font-size: 0.75rem;
+    color: #666;
+}
+
+/* Page cards (grid) */
+.wiki-page-card {
+    background: #16213e;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 8px;
+    overflow: hidden;
+    display: block;
+    color: inherit;
+    height: 100%;
+    transition: border-color 0.15s, transform 0.12s;
+}
+
+.wiki-page-card:hover {
+    border-color: rgba(197, 165, 90, 0.35);
+    transform: translateY(-2px);
+    color: inherit;
+}
+
+.wiki-card-cover {
+    height: 100px;
+    background-size: cover;
+    background-position: center 40%;
+    filter: brightness(0.75);
+}
+
+.wiki-card-body {
+    padding: 0.875rem 1rem;
+}
+
+.wiki-card-body h5 {
+    font-family: 'Cinzel', serif;
+    font-size: 0.9rem;
+    color: #e0e0e0;
+    margin: 0 0 0.3rem;
+    line-height: 1.3;
+}
+
+.wiki-card-body .meta {
+    font-size: 0.75rem;
+    color: #666;
+}
+
+/* Category badge */
+.wiki-cat-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--vtm-gold);
+    background: rgba(197, 165, 90, 0.1);
+    border: 1px solid rgba(197, 165, 90, 0.25);
+    border-radius: 3px;
+    padding: 0.1em 0.5em;
+    margin-bottom: 0.4rem;
+    text-decoration: none;
+}
+
+a.wiki-cat-badge:hover {
+    background: rgba(197, 165, 90, 0.2);
+}
+
+/* Separator */
+.wiki-sep {
+    border: none;
+    height: 1px;
+    background: linear-gradient(to right, transparent, rgba(197, 165, 90, 0.3), transparent);
+    margin: 2.5rem 0;
+}
+
+/* Article body */
+.wiki-article {
+    font-size: 0.97rem;
+    line-height: 1.8;
+    color: #c8c8d8;
+}
+
+.wiki-article h1 {
+    font-size: 1.9rem;
+    color: #fff;
+    margin-bottom: 0.5rem;
+    margin-top: 2rem;
+}
+
+.wiki-article h2 {
+    font-size: 1.3rem;
+    color: var(--vtm-gold);
+    border-bottom: 1px solid rgba(197, 165, 90, 0.25);
+    padding-bottom: 0.35rem;
+    margin-top: 2.25rem;
+    margin-bottom: 0.9rem;
+}
+
+.wiki-article h3 {
+    font-size: 1.05rem;
+    color: #d4c5a0;
+    margin-top: 1.75rem;
+    margin-bottom: 0.6rem;
+}
+
+.wiki-article h4, .wiki-article h5, .wiki-article h6 {
+    color: #bbb;
+    margin-top: 1.25rem;
+}
+
+.wiki-article p { margin-bottom: 1rem; }
+
+.wiki-article a {
+    color: var(--vtm-gold);
+    text-decoration: underline;
+    text-decoration-color: rgba(197, 165, 90, 0.4);
+}
+
+.wiki-article a:hover {
+    color: #e8d585;
+    text-decoration-color: rgba(197, 165, 90, 0.8);
+}
+
+.wiki-article blockquote {
+    border-left: 3px solid var(--vtm-red);
+    padding: 0.75rem 1.25rem;
+    background: rgba(139, 0, 0, 0.08);
+    margin: 1.25rem 0;
+    font-style: italic;
+    color: #aaa;
+    border-radius: 0 4px 4px 0;
+}
+
+.wiki-article ul, .wiki-article ol {
+    color: #c0c0d0;
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.wiki-article li { margin-bottom: 0.35rem; }
+
+.wiki-article hr {
+    border: none;
+    border-top: 1px solid rgba(197, 165, 90, 0.2);
+    margin: 2rem 0;
+}
+
+.wiki-article table {
+    width: 100%;
+    margin: 1.25rem 0;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.wiki-article table th {
+    color: var(--vtm-gold);
+    border-bottom: 2px solid rgba(197, 165, 90, 0.3);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    background: rgba(197, 165, 90, 0.05);
+}
+
+.wiki-article table td {
+    padding: 0.45rem 0.75rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    color: #c0c0d0;
+}
+
+.wiki-article code {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    padding: 0.15em 0.4em;
+    font-size: 0.85em;
+    color: #a8d8a8;
+}
+
+.wiki-article pre code {
+    display: block;
+    padding: 1rem;
+    overflow-x: auto;
+    line-height: 1.6;
+}
+
+.wiki-article img {
+    max-width: 100%;
+    border-radius: 6px;
+    margin: 0.75rem 0;
+}
+
+/* Sidebar panel */
+.wiki-sidebar-panel {
+    position: sticky;
+    top: 1rem;
+}
+
+.wiki-meta-card {
+    background: #16213e;
+    border: 1px solid rgba(197, 165, 90, 0.15);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.wiki-meta-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    font-size: 0.82rem;
+}
+
+.wiki-meta-row:last-child { border-bottom: none; }
+
+.wiki-meta-label {
+    color: #666;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    min-width: 60px;
+    flex-shrink: 0;
+}
+
+.wiki-meta-value { color: #c0c0d0; }
+
+.wiki-sidebar-heading {
+    font-family: 'Cinzel', serif;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--vtm-gold);
+    margin-bottom: 0.75rem;
+    opacity: 0.85;
+}
+
+.wiki-sidebar-link {
+    display: block;
+    padding: 0.35rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    color: #8888a8;
+    text-decoration: none;
+    transition: color 0.12s, background 0.12s;
+}
+
+.wiki-sidebar-link:hover { color: #e0e0e0; background: rgba(255, 255, 255, 0.05); }
+.wiki-sidebar-link--active { color: var(--vtm-gold) !important; background: rgba(197, 165, 90, 0.08) !important; }
+
+/* Edit form */
+.wiki-form-label {
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #888;
+    margin-bottom: 0.35rem;
+}
+
+.wiki-form-input {
+    background: #0d1117 !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    color: #e0e0e0 !important;
+    border-radius: 6px;
+}
+
+.wiki-form-input:focus {
+    border-color: rgba(197, 165, 90, 0.5) !important;
+    box-shadow: 0 0 0 2px rgba(197, 165, 90, 0.1) !important;
+    color: #e0e0e0 !important;
+    background: #0d1117 !important;
+}
+
+.wiki-cover-preview {
+    max-height: 160px;
+    border-radius: 6px;
+    opacity: 0.85;
+}
+
+/* Footer */
+.wiki-footer {
+    border-top: 1px solid rgba(197, 165, 90, 0.12);
+    background: rgba(0, 0, 0, 0.25);
+}
+
 /* ── Responsive — mobile (<768px) ───────────────────────────────── */
 @media (max-width: 767.98px) {
     /* Player: compact XP summary cards */

--- a/apps/web/app/templates/base.html
+++ b/apps/web/app/templates/base.html
@@ -136,6 +136,12 @@
                             <i class="bi bi-person-circle"></i> <span>Player Portal</span>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.endpoint and request.endpoint.startswith('wiki.') %}active{% endif %}"
+                           href="{{ url_for('wiki.index') }}">
+                            <i class="bi bi-journal-richtext"></i> <span>Chronicle Wiki</span>
+                        </a>
+                    </li>
                 </ul>
                 <div class="p-3 mt-auto">
                     <small class="text-muted">Logged in as</small><br>

--- a/apps/web/app/templates/player/base.html
+++ b/apps/web/app/templates/player/base.html
@@ -52,8 +52,12 @@
 
     <footer class="container mt-5 mb-3 text-center">
         <small class="text-muted">
-            Music City by Night — Vampire: The Masquerade V5
+            <a href="https://discord.gg/WuU2xkHdmp" class="text-muted text-decoration-none" target="_blank" rel="noopener">
+                Music City by Night — Vampire: The Masquerade V5
+            </a>
         </small>
+        <br>
+        <small class="text-muted" style="opacity: 0.45;">created by jkomg</small>
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -81,10 +81,13 @@
     <footer class="wiki-footer mt-5">
         <div class="container-xl py-3 px-3 px-md-4">
             <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
-                <small class="text-muted">
-                    <i class="bi bi-droplet-fill text-danger me-1"></i>
-                    Music City by Night — Vampire: The Masquerade V5
-                </small>
+                <div>
+                    <a href="https://discord.gg/WuU2xkHdmp" class="text-muted text-decoration-none small" target="_blank" rel="noopener">
+                        <i class="bi bi-droplet-fill text-danger me-1"></i>
+                        Music City by Night — Vampire: The Masquerade V5
+                    </a>
+                    <span class="text-muted ms-2" style="opacity: 0.4; font-size: 0.75rem;">created by jkomg</span>
+                </div>
                 <div class="d-flex gap-3">
                     <a href="{{ url_for('wiki.index') }}" class="text-muted text-decoration-none small">
                         <i class="bi bi-journal-richtext me-1"></i>Wiki Home

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{% block title %}Chronicle Wiki — Music City by Night{% endblock %}</title>
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+    {% block head %}{% endblock %}
+</head>
+<body class="wiki-body">
+
+    <!-- Wiki Navbar -->
+    <nav class="navbar navbar-expand-md navbar-dark wiki-navbar sticky-top">
+        <div class="container-xl">
+            <a class="navbar-brand wiki-brand d-flex align-items-center gap-2" href="{{ url_for('wiki.index') }}">
+                <i class="bi bi-droplet-fill text-danger"></i>
+                <span>Chronicle Wiki</span>
+            </a>
+            <button class="navbar-toggler border-0" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#wikiNav" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="wikiNav">
+                <ul class="navbar-nav me-auto">
+                    {% for cat_slug, cat_name, cat_icon in wiki_categories %}
+                    <li class="nav-item">
+                        <a class="nav-link wiki-nav-link {% if active_category is defined and active_category == cat_slug %}wiki-nav-active{% endif %}"
+                           href="{{ url_for('wiki.category', category=cat_slug) }}">
+                            <i class="bi {{ cat_icon }} me-1"></i>{{ cat_name }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <div class="d-flex align-items-center gap-2 mt-2 mt-md-0">
+                    {% if is_staff %}
+                    <a href="{{ url_for('wiki.new_page') }}" class="btn btn-sm wiki-btn-new"
+                       title="New wiki page">
+                        <i class="bi bi-plus-circle me-1"></i><span class="d-none d-sm-inline">New Page</span>
+                    </a>
+                    <a href="{{ url_for('dashboard.index') }}" class="btn btn-sm btn-outline-secondary"
+                       title="Staff dashboard">
+                        <i class="bi bi-speedometer2"></i>
+                    </a>
+                    {% elif is_logged_in %}
+                    <a href="{{ url_for('player.my_characters') }}" class="btn btn-sm btn-outline-secondary"
+                       title="Player portal">
+                        <i class="bi bi-person-circle"></i>
+                    </a>
+                    {% else %}
+                    <a href="{{ url_for('dashboard.login') }}" class="btn btn-sm wiki-btn-login">
+                        <i class="bi bi-discord me-1"></i>Sign In
+                    </a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    {% block wiki_hero %}{% endblock %}
+
+    <div class="container-xl py-4 px-3 px-md-4">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+        {% for cat, message in messages %}
+        <div class="alert alert-{{ cat }} alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+        {% endfor %}
+        {% endif %}
+        {% endwith %}
+
+        {% block content %}{% endblock %}
+    </div>
+
+    <footer class="wiki-footer mt-5">
+        <div class="container-xl py-3 px-3 px-md-4">
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+                <small class="text-muted">
+                    <i class="bi bi-droplet-fill text-danger me-1"></i>
+                    Music City by Night — Vampire: The Masquerade V5
+                </small>
+                <div class="d-flex gap-3">
+                    <a href="{{ url_for('wiki.index') }}" class="text-muted text-decoration-none small">
+                        <i class="bi bi-journal-richtext me-1"></i>Wiki Home
+                    </a>
+                    <a href="{{ url_for('player.my_characters') }}" class="text-muted text-decoration-none small">
+                        <i class="bi bi-person-circle me-1"></i>Player Portal
+                    </a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const token = document.querySelector('meta[name="csrf-token"]')?.content;
+        if (!token) return;
+        document.querySelectorAll('form[method="POST"], form[method="post"]').forEach(function (form) {
+          if (form.querySelector('input[name="csrf_token"]')) return;
+          const input = document.createElement('input');
+          input.type = 'hidden'; input.name = 'csrf_token'; input.value = token;
+          form.prepend(input);
+        });
+      });
+    </script>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/apps/web/app/templates/wiki/category.html
+++ b/apps/web/app/templates/wiki/category.html
@@ -1,0 +1,70 @@
+{% extends "wiki/base.html" %}
+
+{% block title %}{{ category_name }} — Chronicle Wiki{% endblock %}
+
+{% block wiki_hero %}
+<div class="wiki-cat-hero">
+    <div class="container-xl px-3 px-md-4">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb wiki-breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
+                <li class="breadcrumb-item active">{{ category_name }}</li>
+            </ol>
+        </nav>
+        {% for cat_slug, cat_name, cat_icon in wiki_categories %}
+        {% if cat_slug == active_category %}
+        <div class="d-flex align-items-center gap-3 mb-1">
+            <i class="bi {{ cat_icon }} wiki-cat-hero-icon"></i>
+            <h1 class="wiki-cat-hero-title mb-0">{{ category_name }}</h1>
+        </div>
+        {% endif %}
+        {% endfor %}
+        <p class="wiki-cat-hero-count text-muted mt-1">
+            {{ pages | length }} page{{ 's' if pages | length != 1 }}
+        </p>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+
+{% if is_staff %}
+<div class="d-flex justify-content-end mb-4">
+    <a href="{{ url_for('wiki.new_page') }}" class="btn btn-sm wiki-btn-new">
+        <i class="bi bi-plus-circle me-1"></i>New Page
+    </a>
+</div>
+{% endif %}
+
+{% if pages %}
+<div class="row g-3">
+    {% for p in pages %}
+    <div class="col-md-6 col-lg-4">
+        <a href="{{ url_for('wiki.page', slug=p.slug) }}" class="wiki-page-card text-decoration-none">
+            {% if p.cover_image_url %}
+            <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');"></div>
+            {% endif %}
+            <div class="wiki-card-body">
+                <h5>{{ p.title }}</h5>
+                <div class="meta">
+                    <i class="bi bi-clock me-1"></i>
+                    {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}
+                    {% if not p.published %}
+                    <span class="badge bg-secondary ms-1">Draft</span>
+                    {% endif %}
+                </div>
+            </div>
+        </a>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<div class="empty-state">
+    <i class="bi bi-journal-richtext"></i>
+    <p>No pages yet in {{ category_name }}.
+    {% if is_staff %}<a href="{{ url_for('wiki.new_page') }}">Write the first one.</a>{% endif %}
+    </p>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/apps/web/app/templates/wiki/edit.html
+++ b/apps/web/app/templates/wiki/edit.html
@@ -1,0 +1,182 @@
+{% extends "wiki/base.html" %}
+
+{% block title %}{% if page %}Edit: {{ page.title }}{% else %}New Wiki Page{% endif %} — Chronicle Wiki{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+<style>
+    .EasyMDEContainer .CodeMirror {
+        background: #0d1117;
+        color: #e0e0e0;
+        border: 1px solid rgba(255,255,255,0.1);
+        border-radius: 0 0 6px 6px;
+        font-size: 0.9rem;
+        min-height: 420px;
+    }
+    .EasyMDEContainer .editor-toolbar {
+        background: #161b22;
+        border: 1px solid rgba(255,255,255,0.1);
+        border-bottom: none;
+        border-radius: 6px 6px 0 0;
+    }
+    .EasyMDEContainer .editor-toolbar button {
+        color: #9ca3af !important;
+    }
+    .EasyMDEContainer .editor-toolbar button:hover,
+    .EasyMDEContainer .editor-toolbar button.active {
+        color: #c5a55a !important;
+        background: rgba(197,165,90,0.1);
+    }
+    .EasyMDEContainer .editor-toolbar i.separator {
+        border-color: rgba(255,255,255,0.1);
+    }
+    .editor-preview, .editor-preview-side {
+        background: #1a1a2e !important;
+        color: #e0e0e0 !important;
+    }
+</style>
+{% endblock %}
+
+{% block wiki_hero %}
+<div class="wiki-page-hero wiki-page-hero--plain">
+    <div class="container-xl px-3 px-md-4">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb wiki-breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
+                {% if page %}
+                <li class="breadcrumb-item">
+                    <a href="{{ url_for('wiki.page', slug=page.slug) }}">{{ page.title }}</a>
+                </li>
+                <li class="breadcrumb-item active">Edit</li>
+                {% else %}
+                <li class="breadcrumb-item active">New Page</li>
+                {% endif %}
+            </ol>
+        </nav>
+        <h1 class="wiki-page-title">
+            {% if page %}Edit: {{ page.title }}{% else %}New Wiki Page{% endif %}
+        </h1>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-xl-10">
+        <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+            <div class="row g-3 mb-4">
+                <!-- Title -->
+                <div class="col-md-8">
+                    <label class="form-label wiki-form-label" for="title">Page Title</label>
+                    <input type="text" class="form-control wiki-form-input" id="title" name="title"
+                           value="{{ page.title if page else '' }}"
+                           placeholder="e.g. The Elysium at the Hermitage Hotel"
+                           required>
+                </div>
+
+                <!-- Category -->
+                <div class="col-md-4">
+                    <label class="form-label wiki-form-label" for="category">Category</label>
+                    <select class="form-select wiki-form-input" id="category" name="category">
+                        <option value="">— Uncategorised —</option>
+                        {% for cat_slug, cat_name, _ in wiki_categories %}
+                        <option value="{{ cat_slug }}"
+                            {% if page and page.category == cat_slug %}selected{% endif %}>
+                            {{ cat_name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <!-- Cover Image URL -->
+                <div class="col-12">
+                    <label class="form-label wiki-form-label" for="cover_image_url">
+                        Cover Image URL <span class="text-muted">(optional)</span>
+                    </label>
+                    <input type="url" class="form-control wiki-form-input" id="cover_image_url" name="cover_image_url"
+                           value="{{ page.cover_image_url if page else '' }}"
+                           placeholder="https://...">
+                    {% if page and page.cover_image_url %}
+                    <div class="mt-2">
+                        <img src="{{ page.cover_image_url }}" alt="Cover preview"
+                             class="wiki-cover-preview">
+                    </div>
+                    {% endif %}
+                </div>
+
+                <!-- Published toggle -->
+                <div class="col-12">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="published" name="published" value="1"
+                               {% if page is none or page.published %}checked{% endif %}>
+                        <label class="form-check-label text-light" for="published">
+                            Published <span class="text-muted">(uncheck to save as draft)</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Body -->
+            <div class="mb-4">
+                <label class="form-label wiki-form-label" for="body_markdown">Content</label>
+                <textarea id="body_markdown" name="body_markdown" class="d-none">{{ page.body_markdown if page else '' }}</textarea>
+            </div>
+
+            <div class="d-flex gap-2 justify-content-end">
+                {% if page %}
+                <a href="{{ url_for('wiki.page', slug=page.slug) }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-lg me-1"></i>Cancel
+                </a>
+                {% else %}
+                <a href="{{ url_for('wiki.index') }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-lg me-1"></i>Cancel
+                </a>
+                {% endif %}
+                <button type="submit" class="btn wiki-btn-save">
+                    <i class="bi bi-check-lg me-1"></i>
+                    {% if page %}Save Changes{% else %}Create Page{% endif %}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script>
+    const easyMDE = new EasyMDE({
+        element: document.getElementById('body_markdown'),
+        spellChecker: false,
+        autosave: { enabled: true, uniqueId: 'wiki-editor-{{ page.slug if page else "new" }}' },
+        toolbar: [
+            'bold', 'italic', 'strikethrough', '|',
+            'heading-1', 'heading-2', 'heading-3', '|',
+            'quote', 'unordered-list', 'ordered-list', '|',
+            'link', 'image', 'table', 'horizontal-rule', '|',
+            'preview', 'side-by-side', 'fullscreen', '|',
+            'guide',
+        ],
+        renderingConfig: { codeSyntaxHighlighting: false },
+        placeholder: 'Write your page content in Markdown...',
+        status: ['autosave', 'lines', 'words'],
+    });
+    // Cover image live preview
+    const coverInput = document.getElementById('cover_image_url');
+    coverInput.addEventListener('change', function () {
+        let preview = document.querySelector('.wiki-cover-preview');
+        if (this.value) {
+            if (!preview) {
+                preview = document.createElement('img');
+                preview.className = 'wiki-cover-preview mt-2 d-block';
+                this.parentNode.appendChild(preview);
+            }
+            preview.src = this.value;
+        } else if (preview) {
+            preview.remove();
+        }
+    });
+</script>
+{% endblock %}

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -1,0 +1,67 @@
+{% extends "wiki/base.html" %}
+
+{% block title %}Chronicle Wiki — Music City by Night{% endblock %}
+
+{% block wiki_hero %}
+<div class="wiki-index-hero">
+    <div class="container-xl px-3 px-md-4">
+        <h1 class="wiki-index-title">Chronicle Wiki</h1>
+        <p class="wiki-index-subtitle">The Requiem of Music City — Lore, Locations &amp; Kindred</p>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+
+<!-- Category Cards -->
+<section class="mb-5">
+    <h2 class="wiki-section-heading mb-4">Browse by Category</h2>
+    <div class="row g-3">
+        {% for cat_slug, cat_name, cat_icon in wiki_categories %}
+        <div class="col-6 col-md-4 col-lg-2">
+            <a href="{{ url_for('wiki.category', category=cat_slug) }}" class="wiki-category-card text-decoration-none">
+                <div class="cat-icon"><i class="bi {{ cat_icon }}"></i></div>
+                <h3>{{ cat_name }}</h3>
+                <div class="count">{{ counts.get(cat_slug, 0) }} page{{ 's' if counts.get(cat_slug, 0) != 1 }}</div>
+            </a>
+        </div>
+        {% endfor %}
+    </div>
+</section>
+
+<hr class="wiki-sep">
+
+<!-- Recent Pages -->
+{% if recent %}
+<section class="mb-4">
+    <h2 class="wiki-section-heading mb-4">Recently Updated</h2>
+    <div class="row g-3">
+        {% for p in recent %}
+        <div class="col-md-6 col-lg-4">
+            <a href="{{ url_for('wiki.page', slug=p.slug) }}" class="wiki-page-card text-decoration-none">
+                {% if p.cover_image_url %}
+                <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');"></div>
+                {% endif %}
+                <div class="wiki-card-body">
+                    {% if p.category %}
+                    <span class="wiki-cat-badge">{{ wiki_category_display.get(p.category, p.category) }}</span>
+                    {% endif %}
+                    <h5>{{ p.title }}</h5>
+                    <div class="meta">
+                        <i class="bi bi-clock me-1"></i>
+                        {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}
+                    </div>
+                </div>
+            </a>
+        </div>
+        {% endfor %}
+    </div>
+</section>
+{% else %}
+<div class="empty-state">
+    <i class="bi bi-journal-richtext"></i>
+    <p>The chronicle has yet to be written. {% if is_staff %}<a href="{{ url_for('wiki.new_page') }}">Create the first page.</a>{% endif %}</p>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -1,0 +1,129 @@
+{% extends "wiki/base.html" %}
+
+{% block title %}{{ page.title }} — Chronicle Wiki{% endblock %}
+
+{% block wiki_hero %}
+{% if page.cover_image_url %}
+<div class="wiki-page-hero" style="--cover-url: url('{{ page.cover_image_url }}');">
+    <div class="wiki-page-hero-overlay"></div>
+    <div class="container-xl px-3 px-md-4 position-relative">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb wiki-breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
+                {% if page.category %}
+                <li class="breadcrumb-item">
+                    <a href="{{ url_for('wiki.category', category=page.category) }}">
+                        {{ wiki_category_display.get(page.category, page.category) }}
+                    </a>
+                </li>
+                {% endif %}
+                <li class="breadcrumb-item active">{{ page.title }}</li>
+            </ol>
+        </nav>
+        <h1 class="wiki-page-title">{{ page.title }}</h1>
+    </div>
+</div>
+{% else %}
+<div class="wiki-page-hero wiki-page-hero--plain">
+    <div class="container-xl px-3 px-md-4">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb wiki-breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
+                {% if page.category %}
+                <li class="breadcrumb-item">
+                    <a href="{{ url_for('wiki.category', category=page.category) }}">
+                        {{ wiki_category_display.get(page.category, page.category) }}
+                    </a>
+                </li>
+                {% endif %}
+                <li class="breadcrumb-item active">{{ page.title }}</li>
+            </ol>
+        </nav>
+        <h1 class="wiki-page-title">{{ page.title }}</h1>
+    </div>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="row g-4">
+
+    <!-- Article -->
+    <div class="col-lg-9">
+        {% if not page.published %}
+        <div class="alert alert-secondary d-flex align-items-center gap-2 mb-4">
+            <i class="bi bi-eye-slash-fill"></i>
+            <span>This page is a <strong>draft</strong> — only staff can see it.</span>
+        </div>
+        {% endif %}
+
+        <article class="wiki-article">
+            {{ body_html | safe }}
+        </article>
+    </div>
+
+    <!-- Sidebar -->
+    <div class="col-lg-3">
+        <aside class="wiki-sidebar-panel">
+
+            <!-- Page meta -->
+            <div class="wiki-meta-card mb-3">
+                {% if page.category %}
+                <div class="wiki-meta-row">
+                    <span class="wiki-meta-label">Category</span>
+                    <a href="{{ url_for('wiki.category', category=page.category) }}"
+                       class="wiki-cat-badge">
+                        {{ wiki_category_display.get(page.category, page.category) }}
+                    </a>
+                </div>
+                {% endif %}
+                {% if page.updated_at %}
+                <div class="wiki-meta-row">
+                    <span class="wiki-meta-label">Updated</span>
+                    <span class="wiki-meta-value">{{ page.updated_at.strftime('%b %d, %Y') }}</span>
+                </div>
+                {% endif %}
+                {% if page.updated_by %}
+                <div class="wiki-meta-row">
+                    <span class="wiki-meta-label">By</span>
+                    <span class="wiki-meta-value">{{ page.updated_by }}</span>
+                </div>
+                {% endif %}
+                {% if page.source and page.source != 'manual' %}
+                <div class="wiki-meta-row">
+                    <span class="wiki-meta-label">Source</span>
+                    <span class="wiki-meta-value text-muted">{{ page.source }}</span>
+                </div>
+                {% endif %}
+            </div>
+
+            {% if is_staff %}
+            <!-- Staff actions -->
+            <div class="d-grid gap-2 mb-3">
+                <a href="{{ url_for('wiki.edit_page', slug=page.slug) }}"
+                   class="btn btn-sm wiki-btn-edit">
+                    <i class="bi bi-pencil-square me-1"></i>Edit Page
+                </a>
+            </div>
+            {% endif %}
+
+            <!-- Category nav -->
+            <div class="wiki-meta-card">
+                <h6 class="wiki-sidebar-heading">Browse</h6>
+                <ul class="list-unstyled mb-0">
+                    {% for cat_slug, cat_name, cat_icon in wiki_categories %}
+                    <li class="mb-1">
+                        <a href="{{ url_for('wiki.category', category=cat_slug) }}"
+                           class="wiki-sidebar-link {% if page.category == cat_slug %}wiki-sidebar-link--active{% endif %}">
+                            <i class="bi {{ cat_icon }} me-2 opacity-75"></i>{{ cat_name }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+
+        </aside>
+    </div>
+
+</div>
+{% endblock %}

--- a/apps/web/migrations/versions/d4f1e9c23a8b_add_wiki_pages_table.py
+++ b/apps/web/migrations/versions/d4f1e9c23a8b_add_wiki_pages_table.py
@@ -1,0 +1,43 @@
+"""add wiki_pages table
+
+Revision ID: d4f1e9c23a8b
+Revises: c3e5f8a12b7d
+Create Date: 2026-04-14
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd4f1e9c23a8b'
+down_revision = 'c3e5f8a12b7d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'wiki_pages',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('slug', sa.String(200), nullable=False),
+        sa.Column('title', sa.String(300), nullable=False),
+        sa.Column('body_markdown', sa.Text(), nullable=True, server_default=''),
+        sa.Column('category', sa.String(100), nullable=True, server_default=''),
+        sa.Column('cover_image_url', sa.Text(), nullable=True, server_default=''),
+        sa.Column('source', sa.String(50), nullable=True, server_default=''),
+        sa.Column('published', sa.Boolean(), nullable=True, server_default='1'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_by', sa.String(100), nullable=True, server_default=''),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_wiki_pages_slug', 'wiki_pages', ['slug'], unique=True)
+    op.create_index('ix_wiki_pages_category', 'wiki_pages', ['category'], unique=False)
+    op.create_index('ix_wiki_pages_published', 'wiki_pages', ['published'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_wiki_pages_published', table_name='wiki_pages')
+    op.drop_index('ix_wiki_pages_category', table_name='wiki_pages')
+    op.drop_index('ix_wiki_pages_slug', table_name='wiki_pages')
+    op.drop_table('wiki_pages')

--- a/apps/web/requirements-lock.txt
+++ b/apps/web/requirements-lock.txt
@@ -58,6 +58,8 @@ limits==5.8.0
     # via flask-limiter
 mako==1.3.10
     # via alembic
+markdown==3.10.2
+    # via mcbn-xp-tracker (wiki blueprint)
 markupsafe==3.0.3
     # via
     #   flask

--- a/apps/web/requirements.txt
+++ b/apps/web/requirements.txt
@@ -10,3 +10,4 @@ python-dotenv==1.*
 gunicorn==25.*
 pytest==9.*
 pytest-cov==7.*
+Markdown==3.*

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -3,13 +3,12 @@
 from pathlib import Path
 from flask import Flask, Blueprint
 from flask_wtf.csrf import CSRFProtect
-
-_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
-_STATIC_DIR   = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
-
 from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _unique_slug, _RESERVED_SLUGS
 from app.blueprints.api import bp as api_bp
 from app.db import db, WikiPage
+
+_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
+_STATIC_DIR   = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
 
 
 def _stub_bp(name: str, prefix: str, routes: dict) -> Blueprint:

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -1,0 +1,196 @@
+"""Tests for the Chronicle Wiki blueprint and /api/wiki/page endpoint."""
+
+from pathlib import Path
+from flask import Flask, Blueprint
+from flask_wtf.csrf import CSRFProtect
+
+_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
+_STATIC_DIR   = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
+
+from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _unique_slug, _RESERVED_SLUGS
+from app.blueprints.api import bp as api_bp
+from app.db import db, WikiPage
+
+
+def _stub_bp(name: str, prefix: str, routes: dict) -> Blueprint:
+    """Build a minimal stub blueprint so templates can call url_for()."""
+    bp = Blueprint(name, __name__)
+    for rule, fn_name in routes.items():
+        bp.add_url_rule(rule, fn_name, lambda **_: ('', 200))
+    return bp
+
+
+def _app():
+    app = Flask(__name__, template_folder=_TEMPLATE_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test-secret'
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['WEB_APP_API_TOKEN'] = 'test-token'
+    app.config['WEB_APP_API_READ_TOKEN'] = 'read-token'
+    app.config['WEB_APP_API_WRITE_TOKEN'] = 'write-token'
+    app.config['BOT_API_REPLAY_PROTECTION_ENABLED'] = False
+    app.config['ALLOWED_DISCORD_IDS'] = set()
+    db.init_app(app)
+    CSRFProtect(app)
+    # Stub blueprints referenced by wiki templates
+    dash = _stub_bp('dashboard', '/', {'/': 'index', '/login': 'login', '/logout': 'logout'})
+    player = _stub_bp('player', '/player', {'/player/': 'my_characters'})
+    app.register_blueprint(dash)
+    app.register_blueprint(player)
+    app.register_blueprint(wiki_bp, url_prefix='/wiki')
+    app.register_blueprint(api_bp, url_prefix='/api')
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+# ── Unit tests ────────────────────────────────────────────────────────────────
+
+def test_slugify_basic():
+    assert _slugify('Nashville Overview') == 'nashville-overview'
+
+
+def test_slugify_special_chars():
+    assert _slugify("The Elysium — Hermitage Hotel!") == 'the-elysium-hermitage-hotel'
+
+
+def test_render_md_basic():
+    result = str(_render_md('## Hello\n\n**bold**'))
+    assert '<h2' in result
+    assert '<strong>bold</strong>' in result
+
+
+def test_render_md_strips_script():
+    result = str(_render_md('<script>alert(1)</script>\n\nSafe'))
+    assert '<script>' not in result
+    assert 'alert' not in result
+
+
+def test_render_md_strips_event_handlers():
+    result = str(_render_md('<a href="x" onclick="evil()">click</a>'))
+    assert 'onclick' not in result
+
+
+def test_render_md_blocks_javascript_href():
+    result = str(_render_md('[click](javascript:alert(1))'))
+    assert 'javascript:' not in result
+
+
+def test_reserved_slugs():
+    assert 'new' in _RESERVED_SLUGS
+    assert 'edit' in _RESERVED_SLUGS
+    assert 'category' in _RESERVED_SLUGS
+
+
+# ── Route tests ───────────────────────────────────────────────────────────────
+
+def test_wiki_index_empty():
+    app = _app()
+    with app.test_client() as client:
+        res = client.get('/wiki/')
+        assert res.status_code == 200
+        assert b'Chronicle Wiki' in res.data
+
+
+def test_wiki_category_valid():
+    app = _app()
+    with app.test_client() as client:
+        res = client.get('/wiki/category/locations')
+        assert res.status_code == 200
+
+
+def test_wiki_category_invalid():
+    app = _app()
+    with app.test_client() as client:
+        res = client.get('/wiki/category/nonexistent')
+        assert res.status_code == 404
+
+
+def test_wiki_page_not_found():
+    app = _app()
+    with app.test_client() as client:
+        res = client.get('/wiki/no-such-page')
+        assert res.status_code == 404
+
+
+def test_wiki_page_published():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='test-page', title='Test', body_markdown='# Hello', published=True)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/test-page')
+        assert res.status_code == 200
+        assert b'Test' in res.data
+
+
+def test_wiki_draft_hidden_from_public():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='draft-page', title='Draft', body_markdown='secret', published=False)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/draft-page')
+        assert res.status_code == 404
+
+
+def test_wiki_new_requires_staff():
+    app = _app()
+    with app.test_client() as client:
+        res = client.get('/wiki/new')
+        # redirects to login when not authenticated
+        assert res.status_code in (302, 401)
+
+
+# ── API upsert tests ──────────────────────────────────────────────────────────
+
+def test_api_wiki_page_create():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post(
+            '/api/wiki/page',
+            json={'slug': 'nashville', 'title': 'Nashville', 'body_markdown': '# City', 'category': 'locations'},
+            headers={'Authorization': 'Bearer write-token'},
+        )
+        assert res.status_code == 201
+        assert res.get_json()['status'] == 'created'
+
+
+def test_api_wiki_page_update():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='existing', title='Old Title', published=True)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.post(
+            '/api/wiki/page',
+            json={'slug': 'existing', 'title': 'New Title'},
+            headers={'Authorization': 'Bearer write-token'},
+        )
+        assert res.status_code == 200
+        assert res.get_json()['status'] == 'updated'
+    with app.app_context():
+        assert WikiPage.query.filter_by(slug='existing').first().title == 'New Title'
+
+
+def test_api_wiki_page_requires_auth():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post('/api/wiki/page', json={'slug': 'x', 'title': 'X'})
+        assert res.status_code == 401
+
+
+def test_api_wiki_page_missing_fields():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post(
+            '/api/wiki/page',
+            json={'slug': 'only-slug'},
+            headers={'Authorization': 'Bearer write-token'},
+        )
+        assert res.status_code == 400

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from flask import Flask, Blueprint
 from flask_wtf.csrf import CSRFProtect
-from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _unique_slug, _RESERVED_SLUGS
+from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _RESERVED_SLUGS
 from app.blueprints.api import bp as api_bp
 from app.db import db, WikiPage
 

--- a/docs/RELEASE_2026-04-14_WIKI_BLUEPRINT.md
+++ b/docs/RELEASE_2026-04-14_WIKI_BLUEPRINT.md
@@ -1,0 +1,102 @@
+# Release: 2026-04-14 — Chronicle Wiki
+
+## Overview
+
+Adds a public-facing **Chronicle Wiki** at `mcbn.jkomg.us/wiki` built directly into the existing Flask web app. No new infrastructure — uses the same Cloud Run service and Turso database already powering the XP tracker.
+
+The wiki is the player-facing source of truth for lore: locations, characters, coteries, factions, and in-universe history. Staff (STs) manage content through an authenticated editor. Players browse read-only. Discord bot sync can upsert pages programmatically via API.
+
+---
+
+## What's New
+
+### `apps/web` — Chronicle Wiki blueprint (`/wiki`)
+
+**`app/db.py` — `WikiPage` model**
+
+New `wiki_pages` table:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `slug` | `String(200)` | URL-safe identifier, unique |
+| `title` | `String(300)` | Page display title |
+| `body_markdown` | `Text` | Content in Markdown |
+| `category` | `String(100)` | One of: `locations`, `characters`, `coteries`, `factions`, `lore` |
+| `cover_image_url` | `Text` | Optional hero/cover image |
+| `source` | `String(50)` | `manual`, `api-sync`, `discord-sync`, etc. |
+| `published` | `Boolean` | Drafts hidden from public, visible to staff |
+| `created_at` / `updated_at` | `DateTime` | Timestamps |
+| `updated_by` | `String(100)` | Staff name or sync source |
+
+Migration: `d4f1e9c23a8b_add_wiki_pages_table.py`
+
+**`app/blueprints/wiki.py` — Routes**
+
+| Method | URL | Auth | Description |
+|--------|-----|------|-------------|
+| `GET` | `/wiki/` | Public | Index — category cards + recently updated pages |
+| `GET` | `/wiki/category/<cat>` | Public | All pages in a category |
+| `GET` | `/wiki/<slug>` | Public\* | Read a page (\*drafts require staff) |
+| `GET/POST` | `/wiki/new` | Staff | Create a new page |
+| `GET/POST` | `/wiki/edit/<slug>` | Staff | Edit an existing page |
+
+**`app/blueprints/api.py` — `POST /api/wiki/page`**
+
+Write-token authenticated endpoint for bot/script upserting of pages. Accepts `slug`, `title`, `body_markdown`, `category`, `cover_image_url`, `published`, `source`, `updated_by`. Returns `{"status": "created"}` (201) or `{"status": "updated"}` (200).
+
+**Templates (`app/templates/wiki/`)**
+
+Five templates sharing a dedicated `wiki/base.html` public layout — separate from the staff sidebar layout:
+
+- `index.html` — atmospheric hero (music.png) + 2×3 category card grid + recent pages
+- `category.html` — category hero + card grid of pages
+- `page.html` — rendered Markdown article with right sidebar (metadata, edit button for staff, category nav)
+- `edit.html` — [EasyMDE](https://easymde.vercel.app/) Markdown editor with side-by-side preview, title/category/cover fields, published toggle
+
+**`app/static/css/style.css` — Wiki design system**
+
+250+ lines of wiki-specific CSS extending the existing VTM design language:
+
+- `wiki-navbar` — frosted music.png background, gold category nav links
+- `wiki-index-hero` / `wiki-cat-hero` / `wiki-page-hero` — atmospheric music.png hero banners with gradient fade
+- `wiki-article` — readable Markdown typography: gold `h2` separators, crimson blockquotes, styled tables, inline code
+- `wiki-category-card` — category grid cards with top border color on hover
+- `wiki-page-card` — page cards with optional cover thumbnail
+- `wiki-meta-card` / `wiki-sidebar-panel` — right-sidebar metadata panel
+- EasyMDE dark theme overrides for the editor
+
+All using existing variables: `--vtm-red: #8b0000`, `--vtm-gold: #c5a55a`, Cinzel serif headings, `#1a1a2e` background.
+
+**Staff sidebar** (`app/templates/base.html`)
+
+Chronicle Wiki link added to the player-facing section of the staff nav.
+
+**`requirements.txt`**
+
+Added `Markdown==3.*` for server-side Markdown → HTML rendering (used in `wiki.page` route).
+
+---
+
+## Deploy
+
+```bash
+cd apps/web
+flask db upgrade        # creates wiki_pages table on Turso
+./deploy.sh
+```
+
+For local Docker dev, rebuild to pick up the new `Markdown` dependency:
+
+```bash
+./scripts/bootstrap-local.sh web-only
+```
+
+---
+
+## Future
+
+- Locations first: map the city, hunting sites, Elysium, etc.
+- Characters / coteries: structured template with player-written summaries
+- Bot sync: `discord-notion-sync` can be extended to upsert pages here via `POST /api/wiki/page`
+- Heat system integration (future): surface whispers/rumors on location pages
+- Page history (`WikiPageRevision` table) if versioning becomes needed

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -69,7 +69,7 @@ case "${ACTION}" in
     if [[ "${PROFILE}" == "web+bot" ]]; then
       reconcile_named_container "lasombra-bot"
     fi
-    docker compose -f "${COMPOSE_FILE}" up -d --build
+    docker compose -f "${COMPOSE_FILE}" up -d --build --remove-orphans
     docker compose -f "${COMPOSE_FILE}" ps
     ;;
   down)


### PR DESCRIPTION
## Summary

- Adds a public-facing **Chronicle Wiki** at `mcbn.jkomg.us/wiki` built directly into the Flask app (no new infrastructure)
- Uses existing Turso DB with a new `wiki_pages` table (migration included)
- Staff can create/edit pages via EasyMDE Markdown editor; players read-only
- Bot sync integration via `POST /api/wiki/page` upsert endpoint

## Changes

**New:**
- `WikiPage` SQLAlchemy model + Alembic migration (`d4f1e9c23a8b`)
- `/wiki` blueprint: index, category, page view, new, edit routes
- 5 wiki templates with full VTM gothic design system (Cinzel, `--vtm-red`, `--vtm-gold`, `music.png` heroes)
- `POST /api/wiki/page` API endpoint (write-token auth)
- `Markdown==3.*` Python dependency for server-side rendering

**Modified:**
- Staff sidebar: Chronicle Wiki nav link added
- `api.py`: wiki upsert endpoint

## Deploy steps
```bash
cd apps/web
flask db upgrade   # creates wiki_pages table on Turso
./deploy.sh
```

## Test plan

- [ ] `GET /wiki` — renders index with category cards (empty state if no pages)
- [ ] `GET /wiki/category/locations` — category listing
- [ ] Staff: `GET /wiki/new` — EasyMDE editor loads, page saves with slug
- [ ] Staff: `GET /wiki/edit/<slug>` — pre-fills, saves updates
- [ ] `GET /wiki/<slug>` — renders Markdown, shows cover image if set
- [ ] Draft page (`published=False`) — hidden from public, visible to staff
- [ ] `POST /api/wiki/page` with write token — creates then updates page
- [ ] Migration runs clean: `flask db upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)