### PR TITLE
Wire Chronicle Wiki upserts into discord-notion-sync

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -126,3 +126,7 @@ NOTION_TOKEN=
 
 # Max messages to archive per lore channel (default: 200)
 NOTION_SYNC_MSG_LIMIT=200
+
+# Chronicle Wiki: if set, locations/characters/lore are also pushed to the
+# wiki via POST /api/wiki/page. Uses the same write token as the bot.
+# WEB_APP_API_WRITE_TOKEN is defined above — no extra var needed.

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -257,6 +257,17 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, '');
 }
 
+/** Prefix slug with category abbreviation to prevent cross-category collisions. */
+function wikiSlug(category: string, name: string): string {
+  const prefixes: Record<string, string> = {
+    locations: 'loc',
+    characters: 'char',
+    lore: 'lore',
+  };
+  const prefix = prefixes[category] ?? category;
+  return `${prefix}-${slugify(name)}`;
+}
+
 function messagesToMarkdown(messages: DiscordMessage[]): string {
   return messages
     .filter((m) => m.content.trim())
@@ -639,7 +650,7 @@ async function main(opts: NotionSyncOptions) {
           }),
         );
         await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
-          slug: slugify(locationName),
+          slug: wikiSlug('locations', locationName),
           title: locationName,
           category: 'locations',
           body_markdown: ch.topic ?? '',
@@ -725,7 +736,7 @@ async function main(opts: NotionSyncOptions) {
         );
         await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
         await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
-          slug: slugify(name),
+          slug: wikiSlug('characters', name),
           title: name,
           category: 'characters',
           body_markdown: messagesToMarkdown(messages),
@@ -763,7 +774,7 @@ async function main(opts: NotionSyncOptions) {
         );
         await appendBodyBlocks(notion, page.id, textToBlocks(msg.content));
         await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
-          slug: slugify(name),
+          slug: wikiSlug('characters', name),
           title: name,
           category: 'characters',
           body_markdown: msg.content.trim(),
@@ -818,7 +829,7 @@ async function main(opts: NotionSyncOptions) {
           playerName && `**Player:** ${playerName}`,
         ].filter(Boolean) as string[];
         await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
-          slug: slugify(name),
+          slug: wikiSlug('characters', name),
           title: name,
           category: 'characters',
           body_markdown: bodyParts.join('\n\n'),
@@ -877,7 +888,7 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
           await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
-            slug: slugify(title),
+            slug: wikiSlug('lore', title),
             title,
             category: 'lore',
             body_markdown: messagesToMarkdown(messages),
@@ -915,7 +926,7 @@ async function main(opts: NotionSyncOptions) {
         );
         await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
         await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
-          slug: `${slugify(chanName)}-archive`,
+          slug: wikiSlug('lore', `${chanName} archive`),
           title,
           category: 'lore',
           body_markdown: messagesToMarkdown(messages),

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -50,6 +50,8 @@ export interface NotionSyncOptions {
   notionToken: string;
   webBase?: string;
   webReadToken?: string;
+  /** Write token for Chronicle Wiki upsert API (WEB_APP_API_WRITE_TOKEN). */
+  webWriteToken?: string;
   msgLimit?: number;
   dryRun?: boolean;
   /** If true, archive all Notion pages that were NOT created by this sync before importing. */
@@ -110,6 +112,7 @@ if (require.main === module) {
     notionToken: process.env.NOTION_TOKEN ?? '',
     webBase: process.env.WEB_APP_BASE_URL,
     webReadToken: process.env.WEB_APP_API_READ_TOKEN ?? process.env.WEB_APP_API_TOKEN,
+    webWriteToken: process.env.WEB_APP_API_WRITE_TOKEN,
     msgLimit: Number.parseInt(process.env.NOTION_SYNC_MSG_LIMIT ?? '200', 10),
     dryRun: process.argv.includes('--dry-run'),
     cleanup: process.argv.includes('--cleanup'),
@@ -238,6 +241,55 @@ function heading3Block(content: string): object {
     type: 'heading_3',
     heading_3: { rich_text: [{ type: 'text', text: { content } }] },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Chronicle Wiki helpers
+// ---------------------------------------------------------------------------
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function messagesToMarkdown(messages: DiscordMessage[]): string {
+  return messages
+    .filter((m) => m.content.trim())
+    .map((m) => {
+      const author = m.author.global_name ?? m.author.username;
+      const date = m.timestamp.slice(0, 10);
+      return `### ${author} · ${date}\n\n${m.content.trim()}`;
+    })
+    .join('\n\n---\n\n');
+}
+
+interface WikiPageData {
+  slug: string;
+  title: string;
+  body_markdown?: string;
+  category?: string;
+  cover_image_url?: string;
+  published?: boolean;
+}
+
+async function wikiUpsert(webBase: string, writeToken: string, data: WikiPageData, dryRun: boolean): Promise<void> {
+  if (dryRun || !writeToken) return;
+  try {
+    const res = await fetch(`${webBase}/api/wiki/page`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${writeToken}` },
+      body: JSON.stringify(data),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) console.log(`  [wiki warn] upsert "${data.slug}" → HTTP ${res.status}`);
+  } catch (err) {
+    console.log(`  [wiki warn] upsert "${data.slug}" failed: ${err}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -497,6 +549,12 @@ async function main(opts: NotionSyncOptions) {
   const CLEANUP = opts.cleanup ?? false;
   const WEB_BASE = (opts.webBase ?? 'http://127.0.0.1:5001').replace(/\/+$/, '');
   const WEB_READ_TOKEN = opts.webReadToken ?? '';
+  const WEB_WRITE_TOKEN = opts.webWriteToken ?? '';
+  if (WEB_WRITE_TOKEN) {
+    console.log('  Wiki sync enabled — pages will be upserted to Chronicle Wiki.');
+  } else {
+    console.log('  Wiki sync disabled — set WEB_APP_API_WRITE_TOKEN to enable.');
+  }
 
   const flags = [DRY_RUN && 'DRY RUN', CLEANUP && 'CLEANUP'].filter(Boolean).join(' + ');
   console.log(`discord-notion-sync${flags ? ` [${flags}]` : ''}`);
@@ -580,6 +638,13 @@ async function main(opts: NotionSyncOptions) {
             },
           }),
         );
+        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+          slug: slugify(locationName),
+          title: locationName,
+          category: 'locations',
+          body_markdown: ch.topic ?? '',
+          published: true,
+        }, DRY_RUN);
       }
     }
     console.log(`  Created ${cityChannels.length} location entries.`);
@@ -659,6 +724,14 @@ async function main(opts: NotionSyncOptions) {
           }),
         );
         await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
+        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+          slug: slugify(name),
+          title: name,
+          category: 'characters',
+          body_markdown: messagesToMarkdown(messages),
+          cover_image_url: cover ?? undefined,
+          published: true,
+        }, DRY_RUN);
       }
       count++;
     }
@@ -689,6 +762,13 @@ async function main(opts: NotionSyncOptions) {
           }),
         );
         await appendBodyBlocks(notion, page.id, textToBlocks(msg.content));
+        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+          slug: slugify(name),
+          title: name,
+          category: 'characters',
+          body_markdown: msg.content.trim(),
+          published: true,
+        }, DRY_RUN);
       }
       count++;
     }
@@ -731,6 +811,19 @@ async function main(opts: NotionSyncOptions) {
             },
           }),
         );
+        const bodyParts = [
+          clan && `**Clan:** ${clan}`,
+          sect && `**Sect:** ${sect}`,
+          coterie && `**Coterie:** ${coterie}`,
+          playerName && `**Player:** ${playerName}`,
+        ].filter(Boolean) as string[];
+        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+          slug: slugify(name),
+          title: name,
+          category: 'characters',
+          body_markdown: bodyParts.join('\n\n'),
+          published: true,
+        }, DRY_RUN);
       }
     }
     console.log(`  Created ${activeRoster.length} PC entries.`);
@@ -783,6 +876,14 @@ async function main(opts: NotionSyncOptions) {
             }),
           );
           await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
+          await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+            slug: slugify(title),
+            title,
+            category: 'lore',
+            body_markdown: messagesToMarkdown(messages),
+            cover_image_url: cover ?? undefined,
+            published: true,
+          }, DRY_RUN);
         }
       }
     } else {
@@ -813,6 +914,13 @@ async function main(opts: NotionSyncOptions) {
           notion.pages.create({ parent: { database_id: NOTION_DB.SESSION_LOG }, properties: sessionProps }),
         );
         await appendBodyBlocks(notion, page.id, messagesToBlocks(messages));
+        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+          slug: `${slugify(chanName)}-archive`,
+          title,
+          category: 'lore',
+          body_markdown: messagesToMarkdown(messages),
+          published: true,
+        }, DRY_RUN);
       }
     }
   }

--- a/apps/web/requirements-lock.txt
+++ b/apps/web/requirements-lock.txt
@@ -58,6 +58,8 @@ limits==5.8.0
     # via flask-limiter
 mako==1.3.10
     # via alembic
+markdown==3.10.2
+    # via mcbn-xp-tracker (wiki blueprint)
 markupsafe==3.0.3
     # via
     #   flask


### PR DESCRIPTION
## Summary

- Adds `webWriteToken` to `NotionSyncOptions` (reads `WEB_APP_API_WRITE_TOKEN` from env)
- Adds `slugify()`, `messagesToMarkdown()`, and `wikiUpsert()` helpers
- Steps 3/5/6/7 of the sync now call `POST /api/wiki/page` alongside each Notion write:
  - **Locations** (city channels) → `category: locations`
  - **SPCs** (#spc-profiles) → `category: characters`, full message body as markdown
  - **PCs** (active roster) → `category: characters`, stub with clan/sect/coterie/player
  - **Lore** (forum threads + text channel archives) → `category: lore`
- Wiki sync is opt-in — silently skipped when `WEB_APP_API_WRITE_TOKEN` is unset
- Upserts are idempotent; re-running updates existing wiki pages

## Test plan

- [ ] Add `WEB_APP_API_WRITE_TOKEN` to `apps/bot/.env`
- [ ] Run `npx tsx src/scripts/discord-notion-sync.ts --dry-run` — should print "Wiki sync enabled" but write nothing
- [ ] Run live and check `/wiki/category/locations`, `/wiki/category/characters`, `/wiki/category/lore` for imported content
- [ ] Re-run and confirm pages are updated (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)