### PR TITLE
Show character portrait in wiki sidebar

### DIFF
--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1328,6 +1328,20 @@ a.wiki-cat-badge:hover {
     top: 1rem;
 }
 
+.wiki-portrait-card {
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid rgba(197, 165, 90, 0.2);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.wiki-portrait-img {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+}
+
 .wiki-meta-card {
     background: #16213e;
     border: 1px solid rgba(197, 165, 90, 0.15);

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -66,6 +66,13 @@
     <div class="col-lg-3">
         <aside class="wiki-sidebar-panel">
 
+            {% if page.cover_image_url %}
+            <!-- Portrait / cover image -->
+            <div class="wiki-portrait-card mb-3">
+                <img src="{{ page.cover_image_url }}" alt="{{ page.title }}" class="wiki-portrait-img">
+            </div>
+            {% endif %}
+
             <!-- Page meta -->
             <div class="wiki-meta-card mb-3">
                 {% if page.category %}


### PR DESCRIPTION
## Summary

- Adds a portrait image card above the meta panel in the wiki page sidebar
- CSS for `.wiki-portrait-card` / `.wiki-portrait-img`: full-width, rounded corners, gold border, consistent with VTM dark theme
- Only renders when `page.cover_image_url` is set (no change for pages without a portrait)

## Test plan
- [ ] View a character wiki page that has a `cover_image_url` — portrait should appear at the top of the sidebar
- [ ] View a page without a cover image — sidebar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)