### PR TITLE
Wiki cross-links, factions sync, and staff delete

### DIFF
--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -520,6 +520,18 @@ for (const [coterie, members] of Object.entries(COTERIE_MEMBERS)) {
   for (const m of members) CHAR_TO_COTERIE.set(m, coterie);
 }
 
+interface FactionDef {
+  name: string;
+  sectAliases: string[];  // matches c.sect.toLowerCase()
+  loreChannels: string[]; // channel names whose archive pages link under Lore
+}
+const FACTIONS: FactionDef[] = [
+  { name: 'Camarilla', sectAliases: ['camarilla'],         loreChannels: ['camarilla-decrees'] },
+  { name: 'Anarchs',   sectAliases: ['anarch'],            loreChannels: ['anarch-mandates'] },
+  { name: 'Voivode',   sectAliases: ['hecata'],            loreChannels: ['hecata-notices'] },
+  { name: 'Autark',    sectAliases: ['autarkis'],          loreChannels: [] },
+];
+
 // SPC type keywords: if thread/message name contains keyword → Type tag
 const SPC_TYPE_KEYWORDS: { keyword: string; tag: string }[] = [
   { keyword: 'haven',      tag: 'Haven' },
@@ -917,7 +929,7 @@ async function main(opts: NotionSyncOptions) {
   // ------------------------------------------------------------------
   console.log('\n[6.5/7] Populating Coteries wiki pages…');
   for (const [coterieName, members] of Object.entries(COTERIE_MEMBERS)) {
-    const memberList = members.map((m) => `- ${toTitleCase(m)}`).join('\n');
+    const memberList = members.map((m) => `- [${toTitleCase(m)}](/wiki/${wikiSlug('characters', m)})`).join('\n');
     const body = `## Members\n\n${memberList}`;
     console.log(`  → ${coterieName} (${members.length} members)`);
     await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
@@ -929,6 +941,36 @@ async function main(opts: NotionSyncOptions) {
     }, DRY_RUN);
   }
   console.log(`  Created ${Object.keys(COTERIE_MEMBERS).length} coterie pages.`);
+
+  // ------------------------------------------------------------------
+  // 6.6 Factions wiki pages (built from active roster sect field)
+  // ------------------------------------------------------------------
+  console.log('\n[6.6/7] Populating Factions wiki pages…');
+  for (const faction of FACTIONS) {
+    const factionMembers = activeRoster.filter(
+      (c) => c.sect && faction.sectAliases.includes(c.sect.toLowerCase()),
+    );
+    const memberLines = factionMembers.map((c) => {
+      const coterie = CHAR_TO_COTERIE.get(c.name.toLowerCase());
+      return `- [${c.name}](/wiki/${wikiSlug('characters', c.name)})${c.clan ? ` — ${c.clan}` : ''}${coterie ? ` *(${coterie})*` : ''}`;
+    });
+    const loreLinks = faction.loreChannels.map(
+      (ch) => `- [#${ch} archive](/wiki/${wikiSlug('lore', `${ch} archive`)})`,
+    );
+    const bodyParts: string[] = [];
+    if (memberLines.length) bodyParts.push(`## Members\n\n${memberLines.join('\n')}`);
+    if (loreLinks.length) bodyParts.push(`## Lore\n\n${loreLinks.join('\n')}`);
+    const bodyMarkdown = bodyParts.join('\n\n') || '_No members found._';
+    console.log(`  → ${faction.name} (${factionMembers.length} members)`);
+    await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+      slug: wikiSlug('factions', faction.name),
+      title: faction.name,
+      category: 'factions',
+      body_markdown: bodyMarkdown,
+      published: true,
+    }, DRY_RUN);
+  }
+  console.log(`  Created ${FACTIONS.length} faction pages.`);
 
   // ------------------------------------------------------------------
   // 7. Session & Post Log (lore channels)

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -226,3 +226,14 @@ def edit_page(slug):
         flash(f'Page "{p.title}" saved.', 'success')
         return redirect(url_for('wiki.page', slug=slug))
     return render_template('wiki/edit.html', page=p)
+
+
+@bp.route('/delete/<slug>', methods=['POST'])
+@require_staff
+def delete_page(slug):
+    p = WikiPage.query.filter_by(slug=slug).first_or_404()
+    title = p.title
+    db.session.delete(p)
+    db.session.commit()
+    flash(f'Page "{title}" deleted.', 'success')
+    return redirect(url_for('wiki.index'))

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -111,6 +111,13 @@
                    class="btn btn-sm wiki-btn-edit">
                     <i class="bi bi-pencil-square me-1"></i>Edit Page
                 </a>
+                <form method="post" action="{{ url_for('wiki.delete_page', slug=page.slug) }}"
+                      onsubmit="return confirm('Delete \u00ab{{ page.title }}\u00bb? This cannot be undone.');">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-sm btn-outline-danger w-100">
+                        <i class="bi bi-trash me-1"></i>Delete Page
+                    </button>
+                </form>
             </div>
             {% endif %}
 

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -145,6 +145,20 @@ def test_wiki_new_requires_staff():
         assert res.status_code in (302, 401)
 
 
+def test_wiki_delete_requires_staff():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='del-test', title='Delete Me', published=True)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.post('/wiki/delete/del-test')
+        assert res.status_code in (302, 401)
+    # Page must still exist — unauthenticated delete should not succeed
+    with app.app_context():
+        assert WikiPage.query.filter_by(slug='del-test').first() is not None
+
+
 # ── API upsert tests ──────────────────────────────────────────────────────────
 
 def test_api_wiki_page_create():


### PR DESCRIPTION
## Summary

- **Coteries**: member names in coterie pages are now markdown links to the associated character wiki page (`/wiki/char-*`)
- **Factions**: adds `FACTIONS` constant and sync step 6.6 — groups active roster by `sect` field (Camarilla / Anarch / Hecata / Autarkis), produces member lists with character page links and coterie notes, plus links to faction lore channel archives
- **Staff delete**: `POST /wiki/delete/<slug>` removes a page; delete button with JS confirm dialog added to the sidebar staff actions panel on every wiki page view

## Test plan
- [ ] Merge, deploy web, run sync — verify Factions category now has 4 pages with linked member lists
- [ ] Verify Coteries member names are clickable links to character pages
- [ ] As staff, visit any wiki page — confirm Delete button appears below Edit; confirm dialog fires before submit
- [ ] Delete a stale PC lore page (leftover from earlier syncs)
- [ ] Unauthenticated POST to `/wiki/delete/<slug>` should 302 to login (covered by new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)