### PR TITLE
Auto-remove stale PC lore pages during sync

### DIFF
--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -342,6 +342,26 @@ async function wikiUpsert(webBase: string, writeToken: string, data: WikiPageDat
   }
 }
 
+async function wikiDelete(webBase: string, writeToken: string, slug: string, dryRun: boolean): Promise<void> {
+  if (dryRun || !writeToken) { console.log(`  [wiki dry-run] would delete "${slug}"`); return; }
+  try {
+    const res = await fetch(`${webBase}/api/wiki/page/${encodeURIComponent(slug)}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${writeToken}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (res.status === 404) {
+      console.log(`  [wiki] "${slug}" not found — already deleted or never created.`);
+    } else if (!res.ok) {
+      console.log(`  [wiki warn] delete "${slug}" → HTTP ${res.status}`);
+    } else {
+      console.log(`  [wiki] deleted "${slug}"`);
+    }
+  } catch (err) {
+    console.log(`  [wiki warn] delete "${slug}" failed: ${err}`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Discord REST helpers
 // ---------------------------------------------------------------------------
@@ -861,6 +881,20 @@ async function main(opts: NotionSyncOptions) {
   console.log('\n[5.5/7] Building PC profile map from #children-of-the-night…');
   const pcProfileMap = await buildPcProfileMap(rest, GUILD_ID, channelByName);
   console.log(`  Found profiles for ${pcProfileMap.size} character(s).`);
+
+  // ------------------------------------------------------------------
+  // 5.6 Remove stale lore pages created from #children-of-the-night
+  //     (these were created by earlier syncs before PC profiles were
+  //     merged into character pages — delete them by slug)
+  // ------------------------------------------------------------------
+  console.log('\n[5.6/7] Removing stale PC lore pages…');
+  let deletedCount = 0;
+  for (const threadName of pcProfileMap.keys()) {
+    const slug = wikiSlug('lore', threadName);
+    await wikiDelete(WEB_BASE, WEB_WRITE_TOKEN, slug, DRY_RUN);
+    deletedCount++;
+  }
+  console.log(`  Processed ${deletedCount} potential stale page(s).`);
 
   // ------------------------------------------------------------------
   // 6. PC Tracker (active roster + player names)

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1068,6 +1068,20 @@ def upsert_wiki_page():
     return jsonify({'status': 'created', 'slug': slug}), 201
 
 
+@bp.route('/wiki/page/<slug>', methods=['DELETE'])
+@require_bot_scope('write')
+@_limit('120 per minute')
+def delete_wiki_page(slug):
+    """Delete a wiki page by slug (used by the sync script for cleanup)."""
+    from app.db import db, WikiPage
+    p = WikiPage.query.filter_by(slug=slug).first()
+    if not p:
+        return jsonify({'status': 'not_found', 'slug': slug}), 404
+    db.session.delete(p)
+    db.session.commit()
+    return jsonify({'status': 'deleted', 'slug': slug})
+
+
 @bp.route('/sheets/reconcile', methods=['POST'])
 @require_bot_scope('write')
 @_limit('5 per hour')

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -207,3 +207,37 @@ def test_api_wiki_page_missing_fields():
             headers={'Authorization': 'Bearer write-token'},
         )
         assert res.status_code == 400
+
+
+def test_api_wiki_page_delete():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='to-delete', title='Bye', published=True)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.delete(
+            '/api/wiki/page/to-delete',
+            headers={'Authorization': 'Bearer write-token'},
+        )
+        assert res.status_code == 200
+        assert res.get_json()['status'] == 'deleted'
+    with app.app_context():
+        assert WikiPage.query.filter_by(slug='to-delete').first() is None
+
+
+def test_api_wiki_page_delete_not_found():
+    app = _app()
+    with app.test_client() as client:
+        res = client.delete(
+            '/api/wiki/page/ghost-page',
+            headers={'Authorization': 'Bearer write-token'},
+        )
+        assert res.status_code == 404
+
+
+def test_api_wiki_page_delete_requires_auth():
+    app = _app()
+    with app.test_client() as client:
+        res = client.delete('/api/wiki/page/any-page')
+        assert res.status_code == 401


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/wiki/page/<slug>` API endpoint (write-token auth, 404 = no-op)
- Adds `wikiDelete()` helper in the sync script (mirrors `wikiUpsert` pattern)
- **Sync step 5.6**: after building the PC profile map, iterates every `children-of-the-night` thread name and deletes its corresponding `lore-*` slug — cleaning up pages created by earlier syncs before PC profiles were merged into character pages
- Idempotent: 404s log as "already deleted" and move on; safe to run on every future sync

## Test plan
- [ ] Merge, deploy web
- [ ] Run sync — step 5.6 output should show deleted pages for each CoN thread name; verify Lore category no longer shows PC profile pages
- [ ] Re-run sync — step 5.6 should log "not found — already deleted" for all, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)