### PR TITLE
gitignore: cover .env.* variants and apps/web/data/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Environment
 .env
 **/.env
+**/.env.*
 venv/
 .venv/
 **/venv/
@@ -32,6 +33,7 @@ Thumbs.db
 .run/
 apps/bot/data/*.json
 !apps/bot/data/.gitkeep
+apps/web/data/
 
 # Google Cloud SDK (installed locally, not part of the project)
 google-cloud-sdk/


### PR DESCRIPTION
## Summary

- `.env.production` (and any other `.env.*` variant) was untracked but not ignored — added `**/.env.*`
- `apps/web/data/` (local SQLite directory) was untracked but not ignored — added entry for it

Neither file contains secrets that would have been committed accidentally, but the gap meant they showed up in `git status` noise and could have been staged accidentally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)