### PR TITLE
Add auto-deploy workflow for web on merge to main

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,13 +1,12 @@
 name: Deploy Web to Cloud Run
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
-      - '.github/workflows/deploy-web.yml'
+  # Trigger after CI completes on main — only deploy when CI passes
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  # Manual trigger (e.g. hotfix deploy without a code change)
   workflow_dispatch:
     inputs:
       reason:
@@ -20,18 +19,35 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Only run on the canonical repo (not forks), and only after CI passes on push
-    if: github.repository == 'jkomg/mcbn-xp-tracker'
+    # For workflow_run: only deploy when CI actually passed.
+    # For workflow_dispatch: always run.
+    if: |
+      github.repository == 'jkomg/mcbn-xp-tracker' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
 
     env:
-      PROJECT_ID: mcbn-xp-tracker
       REGION: us-central1
       SERVICE_NAME: mcbn-xp-tracker
-      IMAGE: us-central1-docker.pkg.dev/mcbn-xp-tracker/mcbn-repo/mcbn-xp-tracker:latest
+      REGISTRY: us-central1-docker.pkg.dev/mcbn-xp-tracker/mcbn-repo/mcbn-xp-tracker
 
     steps:
+      # workflow_run events check out the workflow repo, not the triggering commit.
+      # Resolve the correct SHA so we build exactly what passed CI.
+      - name: Resolve deploy SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.sha.outputs.sha }}
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -49,16 +65,19 @@ jobs:
           docker build \
             --platform linux/amd64 \
             -f apps/web/Dockerfile \
-            -t ${{ env.IMAGE }} \
+            -t ${{ env.REGISTRY }}:${{ steps.sha.outputs.sha }} \
+            -t ${{ env.REGISTRY }}:latest \
             .
 
       - name: Push image to Artifact Registry
-        run: docker push ${{ env.IMAGE }}
+        run: |
+          docker push ${{ env.REGISTRY }}:${{ steps.sha.outputs.sha }}
+          docker push ${{ env.REGISTRY }}:latest
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy ${{ env.SERVICE_NAME }} \
-            --image ${{ env.IMAGE }} \
+            --image ${{ env.REGISTRY }}:${{ steps.sha.outputs.sha }} \
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,97 @@
+name: Deploy Web to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/**'
+      - 'packages/**'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual deploy'
+        required: false
+        default: 'manual trigger'
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Only run on the canonical repo (not forks), and only after CI passes on push
+    if: github.repository == 'jkomg/mcbn-xp-tracker'
+
+    env:
+      PROJECT_ID: mcbn-xp-tracker
+      REGION: us-central1
+      SERVICE_NAME: mcbn-xp-tracker
+      IMAGE: us-central1-docker.pkg.dev/mcbn-xp-tracker/mcbn-repo/mcbn-xp-tracker:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build image (linux/amd64 for Cloud Run)
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            -f apps/web/Dockerfile \
+            -t ${{ env.IMAGE }} \
+            .
+
+      - name: Push image to Artifact Registry
+        run: docker push ${{ env.IMAGE }}
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE }} \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --memory 256Mi \
+            --cpu 1 \
+            --min-instances 0 \
+            --max-instances 2 \
+            --set-env-vars "FLASK_DEBUG=false" \
+            --set-env-vars "SPREADSHEET_ID=${{ secrets.SPREADSHEET_ID }}" \
+            --set-env-vars "SHEETS_CACHE_TTL=30" \
+            --set-env-vars "AUTO_CREATE_PERIODS_ENABLED=true" \
+            --set-env-vars "BOT_API_REPLAY_PROTECTION_ENABLED=true" \
+            --set-env-vars "DISCORD_REDIRECT_URI=https://mcbn.jkomg.us/auth/callback" \
+            --update-secrets "FLASK_SECRET_KEY=mcbn-flask-secret:latest" \
+            --update-secrets "GOOGLE_CREDENTIALS_JSON=mcbn-google-creds:latest" \
+            --update-secrets "DISCORD_CLIENT_ID=mcbn-discord-client-id:latest" \
+            --update-secrets "DISCORD_CLIENT_SECRET=mcbn-discord-client-secret:latest" \
+            --update-secrets "ALLOWED_DISCORD_IDS=mcbn-discord-allowed-ids:latest" \
+            --update-secrets "SETTINGS_ADMIN_DISCORD_IDS=mcbn-settings-admin-ids:latest" \
+            --update-secrets "WEB_APP_API_TOKEN=mcbn-web-app-api-token:latest" \
+            --update-secrets "WEB_APP_API_READ_TOKEN=mcbn-web-app-api-read-token:latest" \
+            --update-secrets "WEB_APP_API_WRITE_TOKEN=mcbn-web-app-api-write-token:latest" \
+            --update-secrets "DATABASE_URL=mcbn-database-url:latest" \
+            --update-secrets "TURSO_AUTH_TOKEN=mcbn-turso-auth-token:latest"
+
+      - name: Route 100% traffic to latest revision
+        run: |
+          gcloud run services update-traffic ${{ env.SERVICE_NAME }} \
+            --region ${{ env.REGION }} \
+            --to-latest
+
+      - name: Print deployed URL
+        run: |
+          gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region ${{ env.REGION }} \
+            --format="value(status.url)"

--- a/apps/web/app/templates/audit/errors.html
+++ b/apps/web/app/templates/audit/errors.html
@@ -9,7 +9,7 @@
 <div class="card mb-4 border-warning">
     <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
         <span><i class="bi bi-cloud-slash"></i> <strong>Sheets Sync Errors</strong>
-            <small class="fw-normal ms-1">(in-memory, resets on restart)</small>
+            <small class="fw-normal ms-1">(DB-persisted + current session)</small>
         </span>
         <span class="badge bg-dark">{{ sync_errors|length }}</span>
     </div>


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-web.yml` — triggers on push to `main` when `apps/web/**` or `packages/**` changes (path-filtered, same logic as CI)
- Also triggerable manually via `workflow_dispatch` with an optional reason field
- Build step uses `linux/amd64` for Cloud Run compatibility
- All secrets pulled from GCP Secret Manager via `--update-secrets`; only `GCP_SA_KEY` and `SPREADSHEET_ID` need to be GitHub repo secrets
- Bonus: fixes stale "(in-memory, resets on restart)" label on the audit/errors Sheets Sync Errors panel — data now comes from both in-memory buffer and DB

## One-time setup required before this workflow runs

Add two secrets to the GitHub repo (`Settings → Secrets and variables → Actions`):

| Secret | Value |
|--------|-------|
| `GCP_SA_KEY` | JSON key for a GCP service account with roles: `Cloud Run Admin`, `Artifact Registry Writer`, `Service Account User`, `Secret Manager Secret Accessor` |
| `SPREADSHEET_ID` | The Google Sheets spreadsheet ID (same value as in your local `.env`) |

The service account can be created with:
```bash
gcloud iam service-accounts create github-deployer \
  --display-name "GitHub Actions Deployer"

# Grant required roles
for role in run.admin artifactregistry.writer iam.serviceAccountUser secretmanager.secretAccessor; do
  gcloud projects add-iam-policy-binding mcbn-xp-tracker \
    --member="serviceAccount:github-deployer@mcbn-xp-tracker.iam.gserviceaccount.com" \
    --role="roles/$role"
done

# Create and download key
gcloud iam service-accounts keys create /tmp/sa-key.json \
  --iam-account=github-deployer@mcbn-xp-tracker.iam.gserviceaccount.com
# Paste contents of /tmp/sa-key.json as the GCP_SA_KEY secret
```

## Test plan
- [ ] Add `GCP_SA_KEY` and `SPREADSHEET_ID` secrets to the repo
- [ ] Merge this PR — workflow should trigger automatically
- [ ] Check Actions tab; deploy should complete and print the Cloud Run URL
- [ ] Verify `workflow_dispatch` works from Actions tab for manual deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)