### PR TITLE
Add wiki full-text search

### DIFF
--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -27,7 +27,7 @@ CATEGORIES: list[tuple[str, str, str]] = [
 CATEGORY_DISPLAY: dict[str, str] = {s: n for s, n, _ in CATEGORIES}
 
 # Slugs reserved by static wiki routes — these can never be used as page slugs.
-_RESERVED_SLUGS = frozenset({'new', 'edit', 'category'})
+_RESERVED_SLUGS = frozenset({'new', 'edit', 'category', 'search'})
 
 
 @bp.context_processor
@@ -157,6 +157,54 @@ def index():
     counts = {s: WikiPage.query.filter_by(category=s, published=True).count()
               for s, _, _ in CATEGORIES}
     return render_template('wiki/index.html', recent=recent, counts=counts)
+
+
+@bp.route('/search')
+def search():
+    q = request.args.get('q', '').strip()
+    results = []
+    if q:
+        visible = [WikiPage.published == True]  # noqa: E712
+        if _is_staff():
+            visible = []
+        pattern = f'%{q}%'
+        pages = (WikiPage.query
+                 .filter(*visible)
+                 .filter(
+                     db.or_(
+                         WikiPage.title.ilike(pattern),
+                         WikiPage.body_markdown.ilike(pattern),
+                     )
+                 )
+                 .order_by(WikiPage.title.asc())
+                 .limit(50)
+                 .all())
+        for p in pages:
+            results.append({
+                'page': p,
+                'excerpt': _excerpt(p.body_markdown or '', q),
+                'title_match': q.lower() in p.title.lower(),
+            })
+        results.sort(key=lambda r: (not r['title_match'], r['page'].title.lower()))
+    return render_template('wiki/search.html', q=q, results=results)
+
+
+def _excerpt(body: str, query: str, context: int = 160) -> str:
+    """Return a plain-text excerpt around the first match of query in body."""
+    # Strip markdown syntax for a cleaner snippet
+    plain = re.sub(r'[#*_`\[\]!]', '', body).replace('\n', ' ')
+    lower = plain.lower()
+    idx = lower.find(query.lower())
+    if idx == -1:
+        return plain[:context].strip() + ('…' if len(plain) > context else '')
+    start = max(0, idx - context // 2)
+    end = min(len(plain), idx + len(query) + context // 2)
+    snippet = plain[start:end].strip()
+    if start > 0:
+        snippet = '…' + snippet
+    if end < len(plain):
+        snippet = snippet + '…'
+    return snippet
 
 
 @bp.route('/category/<category>')

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1481,3 +1481,95 @@ a.wiki-cat-badge:hover {
         font-size: 2.5rem;
     }
 }
+
+/* ── Wiki Search ──────────────────────────────────────────────────────────── */
+
+/* Navbar search box */
+.wiki-nav-search { width: 200px; }
+
+.wiki-nav-search-input {
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #e0e0e0;
+    font-size: 0.82rem;
+}
+
+.wiki-nav-search-input:focus {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(197, 165, 90, 0.4);
+    color: #e0e0e0;
+    box-shadow: 0 0 0 2px rgba(197, 165, 90, 0.15);
+}
+
+.wiki-nav-search-input::placeholder { color: #666; }
+
+.wiki-nav-search-btn {
+    background: rgba(197, 165, 90, 0.15);
+    border: 1px solid rgba(197, 165, 90, 0.25);
+    color: var(--vtm-gold);
+    font-size: 0.82rem;
+}
+
+.wiki-nav-search-btn:hover {
+    background: rgba(197, 165, 90, 0.25);
+    color: var(--vtm-gold);
+}
+
+/* Search page form */
+.wiki-search-bar .wiki-search-input {
+    background: #16213e;
+    border: 1px solid rgba(197, 165, 90, 0.2);
+    color: #e0e0e0;
+    font-size: 1rem;
+    padding: 0.6rem 1rem;
+}
+
+.wiki-search-bar .wiki-search-input:focus {
+    background: #16213e;
+    border-color: rgba(197, 165, 90, 0.5);
+    color: #e0e0e0;
+    box-shadow: 0 0 0 3px rgba(197, 165, 90, 0.12);
+}
+
+.wiki-btn-search {
+    background: rgba(197, 165, 90, 0.15);
+    border: 1px solid rgba(197, 165, 90, 0.3);
+    color: var(--vtm-gold);
+    font-size: 0.9rem;
+    padding: 0.6rem 1.2rem;
+}
+
+.wiki-btn-search:hover {
+    background: rgba(197, 165, 90, 0.25);
+    color: var(--vtm-gold);
+}
+
+/* Search results */
+.wiki-search-results { display: flex; flex-direction: column; gap: 0.5rem; }
+
+.wiki-search-result {
+    display: block;
+    padding: 1rem 1.1rem;
+    background: #16213e;
+    border: 1px solid rgba(197, 165, 90, 0.12);
+    border-radius: 8px;
+    transition: border-color 0.12s, background 0.12s;
+}
+
+.wiki-search-result:hover {
+    background: #1a2a52;
+    border-color: rgba(197, 165, 90, 0.35);
+}
+
+.wiki-search-result-title {
+    font-family: 'Cinzel', serif;
+    font-size: 1rem;
+    color: #e8dfc0;
+}
+
+.wiki-search-result-excerpt {
+    font-size: 0.83rem;
+    color: #8888a8;
+    margin-top: 0.3rem;
+    line-height: 1.5;
+}

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -36,6 +36,16 @@
                     </li>
                     {% endfor %}
                 </ul>
+                <form class="d-flex me-2 mt-2 mt-md-0" method="get" action="{{ url_for('wiki.search') }}" role="search">
+                    <div class="input-group input-group-sm wiki-nav-search">
+                        <input type="search" name="q" class="form-control wiki-nav-search-input"
+                               placeholder="Search wiki…" autocomplete="off"
+                               value="{{ request.args.get('q', '') if request.endpoint == 'wiki.search' else '' }}">
+                        <button type="submit" class="btn wiki-nav-search-btn" aria-label="Search">
+                            <i class="bi bi-search"></i>
+                        </button>
+                    </div>
+                </form>
                 <div class="d-flex align-items-center gap-2 mt-2 mt-md-0">
                     {% if is_staff %}
                     <a href="{{ url_for('wiki.new_page') }}" class="btn btn-sm wiki-btn-new"

--- a/apps/web/app/templates/wiki/search.html
+++ b/apps/web/app/templates/wiki/search.html
@@ -1,0 +1,74 @@
+{% extends "wiki/base.html" %}
+
+{% block title %}{% if q %}Search: {{ q }}{% else %}Search{% endif %} — Chronicle Wiki{% endblock %}
+
+{% block wiki_hero %}
+<div class="wiki-page-hero wiki-page-hero--plain">
+    <div class="container-xl px-3 px-md-4">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb wiki-breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('wiki.index') }}">Wiki</a></li>
+                <li class="breadcrumb-item active">Search</li>
+            </ol>
+        </nav>
+        <h1 class="wiki-page-title">Search</h1>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+
+        <!-- Search form -->
+        <form method="get" action="{{ url_for('wiki.search') }}" class="mb-4">
+            <div class="input-group wiki-search-bar">
+                <input type="search" name="q" value="{{ q }}" class="form-control wiki-search-input"
+                       placeholder="Search pages…" autofocus autocomplete="off">
+                <button type="submit" class="btn wiki-btn-search">
+                    <i class="bi bi-search me-1"></i>Search
+                </button>
+            </div>
+        </form>
+
+        {% if q %}
+            {% if results %}
+            <p class="text-muted small mb-3">
+                {{ results|length }} result{{ 's' if results|length != 1 }} for <strong>{{ q }}</strong>
+            </p>
+            <div class="wiki-search-results">
+                {% for r in results %}
+                <a href="{{ url_for('wiki.page', slug=r.page.slug) }}" class="wiki-search-result text-decoration-none">
+                    <div class="d-flex align-items-start gap-2 mb-1">
+                        <h5 class="wiki-search-result-title mb-0">{{ r.page.title }}</h5>
+                        {% if r.page.category %}
+                        <span class="wiki-cat-badge flex-shrink-0">
+                            {{ wiki_category_display.get(r.page.category, r.page.category) }}
+                        </span>
+                        {% endif %}
+                        {% if not r.page.published %}
+                        <span class="badge bg-secondary flex-shrink-0">Draft</span>
+                        {% endif %}
+                    </div>
+                    {% if r.excerpt %}
+                    <p class="wiki-search-result-excerpt mb-0">{{ r.excerpt }}</p>
+                    {% endif %}
+                </a>
+                {% endfor %}
+            </div>
+            {% else %}
+            <div class="empty-state">
+                <i class="bi bi-search"></i>
+                <p>No pages found for <strong>{{ q }}</strong>.</p>
+            </div>
+            {% endif %}
+        {% else %}
+        <div class="empty-state">
+            <i class="bi bi-search"></i>
+            <p>Enter a search term above to find wiki pages.</p>
+        </div>
+        {% endif %}
+
+    </div>
+</div>
+{% endblock %}

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from flask import Flask, Blueprint
 from flask_wtf.csrf import CSRFProtect
-from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _RESERVED_SLUGS
+from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _RESERVED_SLUGS, _excerpt
 from app.blueprints.api import bp as api_bp
 from app.db import db, WikiPage
 
@@ -81,6 +81,26 @@ def test_reserved_slugs():
     assert 'new' in _RESERVED_SLUGS
     assert 'edit' in _RESERVED_SLUGS
     assert 'category' in _RESERVED_SLUGS
+    assert 'search' in _RESERVED_SLUGS
+
+
+def test_excerpt_match():
+    body = 'The Camarilla controls the Elysium in downtown Nashville.'
+    result = _excerpt(body, 'Elysium')
+    assert 'Elysium' in result
+
+
+def test_excerpt_no_match():
+    body = 'Nothing relevant here.'
+    result = _excerpt(body, 'vampire')
+    assert result  # still returns something
+
+
+def test_excerpt_ellipsis():
+    body = 'x ' * 200 + 'TARGET' + ' x' * 200
+    result = _excerpt(body, 'TARGET')
+    assert 'TARGET' in result
+    assert result.startswith('…')
 
 
 # ── Route tests ───────────────────────────────────────────────────────────────
@@ -135,6 +155,53 @@ def test_wiki_draft_hidden_from_public():
     with app.test_client() as client:
         res = client.get('/wiki/draft-page')
         assert res.status_code == 404
+
+
+def test_wiki_search_empty_query():
+    app = _app()
+    with app.test_client() as client:
+        res = client.get('/wiki/search')
+        assert res.status_code == 200
+
+
+def test_wiki_search_finds_by_title():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='nashville-overview', title='Nashville Overview',
+                     body_markdown='A city of music.', published=True)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/search?q=Nashville')
+        assert res.status_code == 200
+        assert b'Nashville Overview' in res.data
+
+
+def test_wiki_search_finds_by_body():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='elysium-page', title='The Elysium',
+                     body_markdown='The kindred gather at the Elysium each full moon.',
+                     published=True)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/search?q=kindred')
+        assert res.status_code == 200
+        assert b'The Elysium' in res.data
+
+
+def test_wiki_search_hides_drafts():
+    app = _app()
+    with app.app_context():
+        p = WikiPage(slug='secret-page', title='Secret Draft',
+                     body_markdown='hidden content', published=False)
+        db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/search?q=hidden')
+        assert res.status_code == 200
+        assert b'Secret Draft' not in res.data
 
 
 def test_wiki_new_requires_staff():


### PR DESCRIPTION
## Summary

- `GET /wiki/search?q=` — searches title and body across all published pages (staff see drafts too); title matches float to the top; capped at 50 results
- `_excerpt()` helper strips markdown syntax and returns a context window around the first match with `…` trimming
- Search results page with title, category badge, draft indicator, and body excerpt
- Compact search box added to the wiki navbar on every wiki page; pre-fills the query when already on the search page
- `search` added to `_RESERVED_SLUGS` so it can never be used as a page slug

## Test plan
- [ ] Merge, deploy (auto-deploy will fire), run sync to populate content
- [ ] Search for a character name — should appear under Characters
- [ ] Search for body text (e.g. a clan name) — should return relevant pages
- [ ] Search for something that doesn't exist — should show empty state
- [ ] Confirm draft pages don't appear in results when not logged in as staff

🤖 Generated with [Claude Code](https://claude.com/claude-code)