### PR TITLE
Add Discord notification on deploy success/failure

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -117,6 +117,7 @@ jobs:
 
       - name: Notify Discord
         if: always() && secrets.DISCORD_DEPLOY_WEBHOOK != ''
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
           STATUS: ${{ job.status }}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -114,3 +114,38 @@ jobs:
           gcloud run services describe ${{ env.SERVICE_NAME }} \
             --region ${{ env.REGION }} \
             --format="value(status.url)"
+
+      - name: Notify Discord
+        if: always() && secrets.DISCORD_DEPLOY_WEBHOOK != ''
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          STATUS: ${{ job.status }}
+          SHA: ${{ steps.sha.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TRIGGER: ${{ github.event_name }}
+        run: |
+          SHORT_SHA="${SHA:0:7}"
+          COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${SHA}"
+
+          if [ "$STATUS" = "success" ]; then
+            COLOR=3066993
+            ICON="✅"
+            TITLE="Web deployed"
+            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) is live on Cloud Run."
+          else
+            COLOR=15158332
+            ICON="❌"
+            TITLE="Deploy failed"
+            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) did not deploy. [View logs](${RUN_URL})."
+          fi
+
+          curl -s -X POST "$WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"${ICON} ${TITLE}\",
+                \"description\": \"${BODY}\",
+                \"color\": ${COLOR},
+                \"footer\": { \"text\": \"triggered by ${TRIGGER}\" }
+              }]
+            }"


### PR DESCRIPTION
## Summary

Adds a final step to the deploy workflow that posts a Discord embed after every run:
- ✅ **Success**: green embed with linked commit SHA and "is live on Cloud Run"
- ❌ **Failure**: red embed with linked commit SHA and a direct link to the Actions run log

Step is gated on `if: always()` so it fires even when earlier steps fail. Skipped silently if `DISCORD_DEPLOY_WEBHOOK` secret is not set.

## Setup

1. In your Discord server, go to the staff channel you want notifications in → **Edit Channel → Integrations → Webhooks → New Webhook**
2. Copy the webhook URL
3. Add it to GitHub: **Settings → Secrets and variables → Actions → New repository secret** → name: `DISCORD_DEPLOY_WEBHOOK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)