### PR TITLE
Fix Discord notify step workflow file error

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -116,7 +116,7 @@ jobs:
             --format="value(status.url)"
 
       - name: Notify Discord
-        if: always() && secrets.DISCORD_DEPLOY_WEBHOOK != ''
+        if: always()
         continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
@@ -125,6 +125,8 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER: ${{ github.event_name }}
         run: |
+          [ -z "$WEBHOOK" ] && exit 0
+
           SHORT_SHA="${SHA:0:7}"
           COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${SHA}"
 


### PR DESCRIPTION
## Fix

`secrets` context cannot be used in `if:` expressions — GitHub rejects the entire workflow file when it encounters `secrets.X != ''` there.

Moved the empty-webhook guard into the shell script: `[ -z "$WEBHOOK" ] && exit 0`. Step still has `continue-on-error: true` so a Discord outage can't affect the deploy status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)