### PR TITLE
Sanitize Discord markdown in wiki sync

### DIFF
--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -307,13 +307,37 @@ function wikiSlug(category: string, name: string): string {
   return `${prefix}-${slugify(name)}`;
 }
 
+/**
+ * Strip Discord-specific markdown extensions so content renders cleanly
+ * in standard Markdown (the wiki renderer).
+ *
+ * Handles:
+ *  - Spoilers: ||text|| → text  (reveal hidden content)
+ *  - Custom emoji: <:name:id> / <a:name:id> → removed
+ *  - User/role/channel mentions: <@id> <@!id> <#id> <@&id> → removed
+ *  - Timestamp tags: <t:123:F> → removed
+ *  - Unbalanced ** bold markers: if count is odd, close at end of block
+ */
+function sanitizeDiscordMarkdown(text: string): string {
+  let s = text
+    .replace(/\|\|([^|]*)\|\|/g, '$1')          // spoilers → plain text
+    .replace(/<a?:\w+:\d+>/g, '')                // custom emoji
+    .replace(/<[@#!&]?!?\d+>/g, '')              // mentions & channels
+    .replace(/<t:\d+(?::[tTdDfFR])?>/g, '');     // timestamp tags
+
+  // Close any unclosed bold markers (odd number of ** in the block)
+  if ((s.match(/\*\*/g) ?? []).length % 2 !== 0) s += '**';
+
+  return s.trim();
+}
+
 function messagesToMarkdown(messages: DiscordMessage[]): string {
   return messages
     .filter((m) => m.content.trim())
     .map((m) => {
       const author = m.author.global_name ?? m.author.username;
       const date = m.timestamp.slice(0, 10);
-      return `### ${author} · ${date}\n\n${m.content.trim()}`;
+      return `### ${author} · ${date}\n\n${sanitizeDiscordMarkdown(m.content.trim())}`;
     })
     .join('\n\n---\n\n');
 }


### PR DESCRIPTION
## Summary

Adds `sanitizeDiscordMarkdown()` applied to all Discord message content before it's written to wiki pages.

**Fixes:**
- `||53||` → `53` (spoiler tags rendering literally, e.g. Ace Faulkner's age)
- Unclosed `**bold` markers (e.g. Marcus) — closes if odd number of `**` in block
- Custom Discord emoji `<:name:id>` stripped
- User/channel/role mentions `<@id>` `<#id>` stripped
- Timestamp tags `<t:123:F>` stripped

## Test plan
- [ ] Merge, run sync, check Ace Faulkner — age should show as `53` not `||53||`
- [ ] Check Marcus — bold formatting should be closed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)