### PR TITLE
Wiki: XP snapshot sidebar card on character pages

### DIFF
--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -13,7 +13,7 @@ from flask import (
     Blueprint, render_template, request, redirect, url_for, flash, abort,
 )
 from app.auth import require_staff, get_staff_user, is_staff as _is_staff
-from app.db import db, WikiPage
+from app.db import db, WikiPage, DbCharacter, DbSpendRequest
 
 bp = Blueprint('wiki', __name__)
 
@@ -238,13 +238,66 @@ def category(category):
                            pages=pages)
 
 
+def _xp_snapshot(character_name: str) -> tuple[dict | None, list]:
+    """Return (xp_totals_dict, approved_spends) for a character, or (None, [])."""
+    from sqlalchemy import func as _func
+    from app.db import DbLedgerEntry
+    char = DbCharacter.query.filter(
+        _func.lower(DbCharacter.character_name) == character_name.lower()
+    ).first()
+    if not char:
+        return None, []
+
+    creation_xp = char.creation_xp or 0
+
+    spend_total = db.session.query(
+        _func.coalesce(_func.sum(DbSpendRequest.verified_cost), 0)
+    ).filter(
+        _func.lower(DbSpendRequest.character_name) == character_name.lower(),
+        _func.lower(DbSpendRequest.status) == 'approved',
+    ).scalar()
+    total_spends = int(spend_total or 0)
+
+    ledger = db.session.query(
+        _func.coalesce(_func.sum(DbLedgerEntry.awarded), 0).label('awarded'),
+        _func.coalesce(_func.sum(DbLedgerEntry.spent), 0).label('spent'),
+    ).filter(
+        _func.lower(DbLedgerEntry.character_name) == character_name.lower()
+    ).first()
+    ledger_awarded = int(ledger.awarded or 0)
+    ledger_spent = int(ledger.spent or 0)
+
+    total_xp = creation_xp + ledger_awarded
+    balance = total_xp - total_spends - ledger_spent
+
+    totals = {
+        'total_xp': total_xp,
+        'total_spends': total_spends + ledger_spent,
+        'balance': balance,
+    }
+
+    approved_spends = (DbSpendRequest.query
+                       .filter(
+                           _func.lower(DbSpendRequest.character_name) == character_name.lower(),
+                           _func.lower(DbSpendRequest.status) == 'approved',
+                       )
+                       .order_by(DbSpendRequest.review_date.desc(), DbSpendRequest.id.desc())
+                       .all())
+
+    return totals, approved_spends
+
+
 @bp.route('/<slug>')
 def page(slug):
     p = WikiPage.query.filter_by(slug=slug).first_or_404()
     if not p.published and not _is_staff():
         abort(404)
     body_html = _render_md(p.body_markdown)
-    return render_template('wiki/page.html', page=p, body_html=body_html)
+    xp_snapshot, approved_spends = None, []
+    if p.category == 'characters':
+        xp_snapshot, approved_spends = _xp_snapshot(p.title)
+    return render_template('wiki/page.html', page=p, body_html=body_html,
+                           xp_snapshot=xp_snapshot, approved_spends=approved_spends)
 
 
 # ── Staff routes ───────────────────────────────────────────────────────────────

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1485,6 +1485,90 @@ a.wiki-cat-badge:hover {
 /* ── Wiki Search ──────────────────────────────────────────────────────────── */
 
 /* Navbar search box */
+/* ── Wiki XP snapshot ───────────────────────────────────────────────────── */
+
+.wiki-xp-stats {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.wiki-xp-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1;
+}
+
+.wiki-xp-val {
+    font-family: 'Cinzel', serif;
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: #d4c5a9;
+}
+
+.wiki-xp-lbl {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #666;
+    margin-top: 0.1rem;
+}
+
+.wiki-xp-toggle {
+    background: none;
+    border: none;
+    padding: 0.25rem 0;
+    font-size: 0.78rem;
+    color: #8888a8;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    text-align: left;
+}
+
+.wiki-xp-toggle:hover { color: var(--vtm-gold); }
+
+.wiki-xp-chevron {
+    font-size: 0.65rem;
+    transition: transform 0.2s;
+}
+
+.wiki-xp-toggle:not(.collapsed) .wiki-xp-chevron {
+    transform: rotate(90deg);
+}
+
+.wiki-xp-list {
+    list-style: none;
+    padding: 0.4rem 0 0;
+    margin: 0;
+}
+
+.wiki-xp-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.2rem 0;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    font-size: 0.8rem;
+}
+
+.wiki-xp-item:last-child { border-bottom: none; }
+
+.wiki-xp-trait { color: #b0a898; }
+
+.wiki-xp-cost {
+    color: #888;
+    white-space: nowrap;
+    margin-left: 0.5rem;
+    font-size: 0.75rem;
+}
+
+/* ── Wiki search ────────────────────────────────────────────────────────── */
+
 .wiki-nav-search { width: 200px; }
 
 .wiki-nav-search-input {

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -87,7 +87,7 @@
                         <span class="wiki-xp-lbl">Spent</span>
                     </div>
                     <div class="wiki-xp-stat">
-                        <span class="wiki-xp-val text-success">{{ xp_snapshot.balance }}</span>
+                        <span class="wiki-xp-val {{ 'text-danger' if xp_snapshot.balance < 0 else 'text-success' }}">{{ xp_snapshot.balance }}</span>
                         <span class="wiki-xp-lbl">Balance</span>
                     </div>
                 </div>

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -73,6 +73,46 @@
             </div>
             {% endif %}
 
+            {% if xp_snapshot %}
+            <!-- XP snapshot (characters only) -->
+            <div class="wiki-meta-card mb-3">
+                <h6 class="wiki-sidebar-heading">XP</h6>
+                <div class="wiki-xp-stats">
+                    <div class="wiki-xp-stat">
+                        <span class="wiki-xp-val">{{ xp_snapshot.total_xp }}</span>
+                        <span class="wiki-xp-lbl">Earned</span>
+                    </div>
+                    <div class="wiki-xp-stat">
+                        <span class="wiki-xp-val text-danger">{{ xp_snapshot.total_spends }}</span>
+                        <span class="wiki-xp-lbl">Spent</span>
+                    </div>
+                    <div class="wiki-xp-stat">
+                        <span class="wiki-xp-val text-success">{{ xp_snapshot.balance }}</span>
+                        <span class="wiki-xp-lbl">Balance</span>
+                    </div>
+                </div>
+                {% if approved_spends %}
+                <div class="mt-2">
+                    <button class="wiki-xp-toggle collapsed" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#wiki-xp-purchases"
+                            aria-expanded="false">
+                        <i class="bi bi-chevron-right wiki-xp-chevron me-1"></i>Purchases
+                    </button>
+                    <div class="collapse" id="wiki-xp-purchases">
+                        <ul class="wiki-xp-list">
+                            {% for s in approved_spends %}
+                            <li class="wiki-xp-item">
+                                <span class="wiki-xp-trait">{{ s.trait_name }}</span>
+                                <span class="wiki-xp-cost">{{ s.verified_cost }} XP</span>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+
             <!-- Page meta -->
             <div class="wiki-meta-card mb-3">
                 {% if page.category %}

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -5,7 +5,7 @@ from flask import Flask, Blueprint
 from flask_wtf.csrf import CSRFProtect
 from app.blueprints.wiki import bp as wiki_bp, _slugify, _render_md, _RESERVED_SLUGS, _excerpt
 from app.blueprints.api import bp as api_bp
-from app.db import db, WikiPage
+from app.db import db, WikiPage, DbCharacter, DbSpendRequest
 
 _TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
 _STATIC_DIR   = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
@@ -324,3 +324,81 @@ def test_api_wiki_page_delete_requires_auth():
     with app.test_client() as client:
         res = client.delete('/api/wiki/page/any-page')
         assert res.status_code == 401
+
+
+# ── XP snapshot tests ─────────────────────────────────────────────────────────
+
+def test_character_page_shows_xp_snapshot():
+    """Character wiki page renders XP stats when a matching DbCharacter exists."""
+    app = _app()
+    with app.app_context():
+        char = DbCharacter(character_name='Evander Cole', clan='Ventrue',
+                           creation_xp=10, active=True)
+        db.session.add(char)
+        page = WikiPage(slug='char-evander-cole', title='Evander Cole',
+                        category='characters', published=True)
+        db.session.add(page)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/char-evander-cole')
+        assert res.status_code == 200
+        assert b'Earned' in res.data
+        assert b'Spent' in res.data
+        assert b'Balance' in res.data
+
+
+def test_character_page_xp_snapshot_reflects_spends():
+    """Approved spend history appears in the collapsible Purchases list."""
+    app = _app()
+    with app.app_context():
+        char = DbCharacter(character_name='Evander Cole', clan='Ventrue',
+                           creation_xp=20, active=True)
+        db.session.add(char)
+        spend = DbSpendRequest(
+            character_name='Evander Cole',
+            spend_category='Discipline',
+            trait_name='Dominate',
+            current_dots=2, new_dots=3,
+            xp_cost=9, verified_cost=9,
+            status='Approved',
+        )
+        db.session.add(spend)
+        page = WikiPage(slug='char-evander-cole', title='Evander Cole',
+                        category='characters', published=True)
+        db.session.add(page)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/char-evander-cole')
+        assert res.status_code == 200
+        assert b'Dominate' in res.data
+        assert b'9 XP' in res.data
+
+
+def test_non_character_page_no_xp_snapshot():
+    """Non-character wiki pages do not render the XP card."""
+    app = _app()
+    with app.app_context():
+        page = WikiPage(slug='loc-elysium', title='The Elysium',
+                        category='locations', published=True,
+                        body_markdown='A place.')
+        db.session.add(page)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/loc-elysium')
+        assert res.status_code == 200
+        assert b'wiki-xp-stats' not in res.data
+
+
+def test_character_page_no_xp_when_unmatched():
+    """Character page with no matching DbCharacter renders without XP card."""
+    app = _app()
+    with app.app_context():
+        page = WikiPage(slug='char-ghost', title='Ghost Character',
+                        category='characters', published=True,
+                        body_markdown='No DB record.')
+        db.session.add(page)
+        db.session.commit()
+    with app.test_client() as client:
+        res = client.get('/wiki/char-ghost')
+        assert res.status_code == 200
+        assert b'wiki-xp-stats' not in res.data


### PR DESCRIPTION
## Summary

- Character wiki pages now show a live XP summary in the sidebar between the portrait and page meta
- Three stat boxes: **Earned / Spent / Balance** (same calculation as the player portal)
- Collapsible **Purchases** list of approved spend history — trait name and XP cost, newest first
- Only renders when `page.category == 'characters'` and a matching `DbCharacter` exists by name; all other pages are unaffected

## How it works

`_xp_snapshot(title)` in `wiki.py` queries `DbCharacter`, `DbSpendRequest`, and `DbLedgerEntry` using the same aggregation logic as `db_service.get_xp_totals()`. The page route passes `xp_snapshot` and `approved_spends` to the template.

## Test plan

- [ ] Character page with DB record shows Earned/Spent/Balance and purchase list
- [ ] Character page with no DB record renders without XP card
- [ ] Location/lore/etc pages render without XP card
- [ ] 36 wiki tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)