### PR TITLE
Feat: deceased/retired character status

### DIFF
--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -90,6 +90,7 @@ const LORE_CHANNEL_NAMES = [
   'hecata-notices',
   'backgrounds',          // forum
   'children-of-the-night', // forum
+  'retired',               // forum — processed as retired character wiki pages
   'spc-profiles',
 ];
 
@@ -349,6 +350,28 @@ interface WikiPageData {
   category?: string;
   cover_image_url?: string;
   published?: boolean;
+}
+
+async function wikiSetCharacterStatus(
+  webBase: string,
+  writeToken: string,
+  characterName: string,
+  status: 'active' | 'deceased' | 'retired',
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun || !writeToken) return;
+  try {
+    const res = await fetch(`${webBase}/api/character/${encodeURIComponent(characterName)}/status`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${writeToken}` },
+      body: JSON.stringify({ status }),
+    });
+    if (!res.ok && res.status !== 404) {
+      console.log(`  [warn] Failed to set status for ${characterName}: ${res.status}`);
+    }
+  } catch (err) {
+    console.log(`  [warn] wikiSetCharacterStatus error for ${characterName}: ${err}`);
+  }
 }
 
 async function wikiUpsert(webBase: string, writeToken: string, data: WikiPageData, dryRun: boolean): Promise<void> {
@@ -1029,6 +1052,43 @@ async function main(opts: NotionSyncOptions) {
     }, DRY_RUN);
   }
   console.log(`  Created ${FACTIONS.length} faction pages.`);
+
+  // ------------------------------------------------------------------
+  // 6.7 Retired characters from #retired forum
+  //     Each forum thread = one retired PC profile.
+  //     Upserts a character wiki page (same as step 6) and marks the
+  //     DbCharacter status as 'retired' via PUT /api/character/<name>/status.
+  // ------------------------------------------------------------------
+  console.log('\n[6.7/7] Processing retired characters from #retired…');
+  const retiredCh = channelByName.get('retired');
+  if (!retiredCh || retiredCh.type !== CH_FORUM) {
+    console.log('  #retired forum channel not found — skipping.');
+  } else {
+    let retiredThreads: DiscordThread[] = [];
+    try { retiredThreads = await fetchForumThreads(rest, GUILD_ID, retiredCh.id); }
+    catch (err) { console.log(`  [warn] Could not fetch #retired threads: ${err}`); }
+
+    let retiredCount = 0;
+    for (const thread of retiredThreads) {
+      const name = thread.name.trim();
+      const msgs = await fetchAllMessages(rest, thread.id, 50);
+      await sleep(150);
+      const image = firstImage(msgs);
+      const bodyMarkdown = messagesToMarkdown(msgs);
+      console.log(`  → ${name}`);
+      await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+        slug: wikiSlug('characters', name),
+        title: name,
+        category: 'characters',
+        body_markdown: bodyMarkdown,
+        cover_image_url: image ?? undefined,
+        published: true,
+      }, DRY_RUN);
+      await wikiSetCharacterStatus(WEB_BASE, WEB_WRITE_TOKEN, name, 'retired', DRY_RUN);
+      retiredCount++;
+    }
+    console.log(`  Processed ${retiredCount} retired character(s).`);
+  }
 
   // ------------------------------------------------------------------
   // 7. Session & Post Log (lore channels)

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1068,6 +1068,28 @@ def upsert_wiki_page():
     return jsonify({'status': 'created', 'slug': slug}), 201
 
 
+@bp.route('/character/<name>/status', methods=['PUT'])
+@require_bot_scope('write')
+@_limit('120 per minute')
+def set_character_status(name):
+    """Set a character's status (active/deceased/retired) via the sync script."""
+    from app.db import db, DbCharacter
+    from sqlalchemy import func as _func
+    data = request.get_json(silent=True) or {}
+    new_status = data.get('status', '').strip().lower()
+    if new_status not in ('active', 'deceased', 'retired'):
+        return jsonify({'error': 'status must be active, deceased, or retired'}), 400
+    row = DbCharacter.query.filter(
+        _func.lower(DbCharacter.character_name) == name.lower()
+    ).first()
+    if not row:
+        return jsonify({'error': 'character not found'}), 404
+    row.status = new_status
+    row.active = (new_status == 'active')
+    db.session.commit()
+    return jsonify({'status': 'updated', 'character': row.character_name, 'new_status': new_status})
+
+
 @bp.route('/wiki/page/<slug>', methods=['DELETE'])
 @require_bot_scope('write')
 @_limit('120 per minute')

--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -580,7 +580,7 @@ def activate(name):
     if not char:
         abort(404)
 
-    db_service.update_character(name, {'active': 'TRUE'})
+    db_service.set_character_status(name, 'active')
 
     staff = get_staff_user()
     db_service.log_action(
@@ -594,6 +594,33 @@ def activate(name):
             staff_user=staff, action_type='activate_character',
             target=name, details=f'Re-activated {name}',
         )
+
+
+@bp.route('/<name>/set-status', methods=['POST'])
+@require_staff
+def set_status(name):
+    """Set a character's status to deceased or retired."""
+    char = db_service.get_character(name)
+    if not char:
+        abort(404)
+    new_status = request.form.get('status', '').strip()
+    if new_status not in ('active', 'deceased', 'retired'):
+        flash('Invalid status.', 'danger')
+        return redirect(url_for('roster.detail', name=name))
+
+    db_service.set_character_status(name, new_status)
+
+    staff = get_staff_user()
+    db_service.log_action(
+        staff_user=staff,
+        action_type='set_character_status',
+        target=name,
+        details=f'Set status to {new_status}',
+    )
+
+    labels = {'active': 'reactivated', 'deceased': 'marked as deceased', 'retired': 'marked as retired'}
+    flash(f'{name} has been {labels[new_status]}.', 'warning' if new_status != 'active' else 'success')
+    return redirect(url_for('roster.detail', name=name))
 
     flash(f'{name} has been re-activated.', 'success')
     return redirect(url_for('roster.detail', name=name))

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -232,10 +232,30 @@ def category(category):
              .filter_by(category=category, published=True)
              .order_by(WikiPage.title.asc())
              .all())
+    # For the characters category, look up status for each page from DbCharacter
+    char_statuses: dict[str, str] = {}
+    if category == 'characters':
+        names = [p.title for p in pages]
+        if names:
+            rows = DbCharacter.query.filter(
+                db.func.lower(DbCharacter.character_name).in_(
+                    [n.lower() for n in names]
+                )
+            ).all()
+            for r in rows:
+                s = r.status or ('active' if r.active else 'retired')
+                char_statuses[r.character_name.lower()] = s
+        # Sort: active first, then retired, then deceased — all alphabetically within group
+        _order = {'active': 0, 'retired': 1, 'deceased': 2}
+        pages = sorted(pages, key=lambda p: (
+            _order.get(char_statuses.get(p.title.lower(), 'active'), 0),
+            p.title.lower()
+        ))
     return render_template('wiki/category.html',
                            active_category=category,
                            category_name=CATEGORY_DISPLAY[category],
-                           pages=pages)
+                           pages=pages,
+                           char_statuses=char_statuses)
 
 
 def _xp_snapshot(character_name: str) -> tuple[dict | None, list]:
@@ -293,11 +313,17 @@ def page(slug):
     if not p.published and not _is_staff():
         abort(404)
     body_html = _render_md(p.body_markdown)
-    xp_snapshot, approved_spends = None, []
+    xp_snapshot, approved_spends, char_status = None, [], None
     if p.category == 'characters':
         xp_snapshot, approved_spends = _xp_snapshot(p.title)
+        char_row = DbCharacter.query.filter(
+            db.func.lower(DbCharacter.character_name) == p.title.lower()
+        ).first()
+        if char_row:
+            char_status = char_row.status or ('active' if char_row.active else 'retired')
     return render_template('wiki/page.html', page=p, body_html=body_html,
-                           xp_snapshot=xp_snapshot, approved_spends=approved_spends)
+                           xp_snapshot=xp_snapshot, approved_spends=approved_spends,
+                           char_status=char_status)
 
 
 # ── Staff routes ───────────────────────────────────────────────────────────────

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -18,6 +18,7 @@ class DbCharacter(db.Model):
     age_category = db.Column(String(50), default='')
     sect = db.Column(String(50), default='')
     active = db.Column(Boolean, default=True, index=True)
+    status = db.Column(String(20), default='active', index=True)  # active | deceased | retired
     creation_xp = db.Column(Integer, default=0)
     enemy = db.Column(String(200), default='')
     date_added = db.Column(String(20), default='')

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -99,6 +99,7 @@ def _row_to_character(row: DbCharacter) -> Character:
         age_category=row.age_category or '',
         sect=row.sect or '',
         active=bool(row.active),
+        status=row.status or 'active',
         creation_xp=row.creation_xp or 0,
         enemy=row.enemy or '',
         date_added=row.date_added or '',
@@ -268,8 +269,17 @@ class DBService:
             'player_discord_name': discord_name,
         })
 
+    def set_character_status(self, name: str, status: str) -> None:
+        """Set character status (active/deceased/retired) and sync active flag."""
+        if status not in ('active', 'deceased', 'retired'):
+            raise ValueError(f'Invalid status: {status}')
+        self.update_character(name, {
+            'status': status,
+            'active': 'TRUE' if status == 'active' else 'FALSE',
+        })
+
     def deactivate_character(self, name: str) -> None:
-        self.update_character(name, {'active': 'FALSE'})
+        self.update_character(name, {'active': 'FALSE', 'status': 'retired'})
 
     def delete_character(self, name: str) -> None:
         row = DbCharacter.query.filter(

--- a/apps/web/app/models.py
+++ b/apps/web/app/models.py
@@ -13,6 +13,7 @@ class Character:
     age_category: str = ''  # Fledgling, Neonate, Ancilla, Elder, Mortal
     sect: str = ''           # Camarilla, Anarch, Hecata, Autarkis
     active: bool = True
+    status: str = 'active'  # active | deceased | retired
     creation_xp: int = 0    # Audit baseline XP
     enemy: str = ''
     date_added: str = ''

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1342,6 +1342,74 @@ a.wiki-cat-badge:hover {
     object-fit: cover;
 }
 
+.wiki-portrait-card--faded .wiki-portrait-img {
+    filter: grayscale(60%) opacity(0.75);
+}
+
+.wiki-portrait-card { position: relative; }
+
+.wiki-status-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(20, 10, 10, 0.82);
+    color: #c0a0a0;
+    font-family: 'Cinzel', serif;
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-align: center;
+    padding: 0.35rem 0.5rem;
+}
+
+.wiki-status-overlay--retired {
+    color: #999;
+    background: rgba(20, 20, 30, 0.82);
+}
+
+.wiki-status-badge {
+    display: inline-block;
+    padding: 0.25rem 0.65rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-family: 'Cinzel', serif;
+    letter-spacing: 0.08em;
+}
+
+.wiki-status-badge--deceased {
+    background: rgba(80, 20, 20, 0.5);
+    color: #c0a0a0;
+    border: 1px solid rgba(150, 50, 50, 0.4);
+}
+
+.wiki-status-badge--retired {
+    background: rgba(40, 40, 50, 0.5);
+    color: #999;
+    border: 1px solid rgba(80, 80, 100, 0.4);
+}
+
+.wiki-page-card--inactive { opacity: 0.75; }
+
+.wiki-card-status-badge {
+    font-size: 0.65rem;
+    vertical-align: middle;
+    margin-left: 0.4rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-family: 'Cinzel', serif;
+    letter-spacing: 0.06em;
+}
+
+.wiki-card-status-badge--deceased {
+    background: rgba(80, 20, 20, 0.5);
+    color: #c0a0a0;
+}
+
+.wiki-card-status-badge--retired {
+    background: rgba(40, 40, 50, 0.5);
+    color: #888;
+}
+
 .wiki-meta-card {
     background: #16213e;
     border: 1px solid rgba(197, 165, 90, 0.15);

--- a/apps/web/app/templates/roster/detail.html
+++ b/apps/web/app/templates/roster/detail.html
@@ -16,7 +16,12 @@
       <div class="flex-grow-1">
         <div class="d-flex align-items-center gap-2 mb-1 flex-wrap">
           <h1 class="char-hero-name mb-0">{{ char.character_name }}</h1>
-          {% if char.active %}
+          {% set status = char.status or ('active' if char.active else 'retired') %}
+          {% if status == 'deceased' %}
+          <span class="badge bg-dark border border-secondary">&#9760; Deceased</span>
+          {% elif status == 'retired' %}
+          <span class="badge bg-secondary">Retired</span>
+          {% elif char.active %}
           <span class="badge bg-success">Active</span>
           {% else %}
           <span class="badge bg-secondary">Inactive</span>
@@ -80,21 +85,16 @@
       <a href="{{ url_for('roster.edit', name=char.character_name) }}" class="btn btn-sm btn-primary">
         <i class="bi bi-pencil"></i> Edit
       </a>
-      {% if char.active %}
-      <form method="POST" action="{{ url_for('roster.deactivate', name=char.character_name) }}" class="d-inline">
-        <button type="submit" class="btn btn-sm btn-outline-warning"
-                data-confirm="Are you sure you want to deactivate {{ char.character_name }}?">
-          <i class="bi bi-pause-circle"></i> Deactivate
-        </button>
+      <form method="POST" action="{{ url_for('roster.set_status', name=char.character_name) }}" class="d-inline">
+        {% set current_status = char.status or ('active' if char.active else 'retired') %}
+        <select name="status" class="form-select form-select-sm d-inline-block w-auto"
+                onchange="this.form.submit()"
+                title="Set character status">
+          <option value="active"   {% if current_status == 'active' %}selected{% endif %}>Active</option>
+          <option value="retired"  {% if current_status == 'retired' %}selected{% endif %}>Retired</option>
+          <option value="deceased" {% if current_status == 'deceased' %}selected{% endif %}>Deceased</option>
+        </select>
       </form>
-      {% else %}
-      <form method="POST" action="{{ url_for('roster.activate', name=char.character_name) }}" class="d-inline">
-        <button type="submit" class="btn btn-sm btn-outline-success"
-                data-confirm="Are you sure you want to re-activate {{ char.character_name }}?">
-          <i class="bi bi-play-circle"></i> Re-activate
-        </button>
-      </form>
-      {% endif %}
     </div>
   </div>
 

--- a/apps/web/app/templates/wiki/category.html
+++ b/apps/web/app/templates/wiki/category.html
@@ -39,13 +39,24 @@
 {% if pages %}
 <div class="row g-3">
     {% for p in pages %}
+    {% set cstatus = char_statuses.get(p.title.lower(), 'active') if char_statuses is defined else 'active' %}
     <div class="col-md-6 col-lg-4">
-        <a href="{{ url_for('wiki.page', slug=p.slug) }}" class="wiki-page-card text-decoration-none">
+        <a href="{{ url_for('wiki.page', slug=p.slug) }}"
+           class="wiki-page-card text-decoration-none {% if cstatus != 'active' %}wiki-page-card--inactive{% endif %}">
             {% if p.cover_image_url %}
-            <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');"></div>
+            <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');
+                 {% if cstatus != 'active' %}filter: grayscale(60%) opacity(0.7);{% endif %}">
+            </div>
             {% endif %}
             <div class="wiki-card-body">
-                <h5>{{ p.title }}</h5>
+                <h5>
+                    {{ p.title }}
+                    {% if cstatus == 'deceased' %}
+                    <span class="wiki-card-status-badge wiki-card-status-badge--deceased">&#9760; Deceased</span>
+                    {% elif cstatus == 'retired' %}
+                    <span class="wiki-card-status-badge wiki-card-status-badge--retired">Retired</span>
+                    {% endif %}
+                </h5>
                 <div class="meta">
                     <i class="bi bi-clock me-1"></i>
                     {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -68,12 +68,26 @@
 
             {% if page.cover_image_url %}
             <!-- Portrait / cover image -->
-            <div class="wiki-portrait-card mb-3">
+            <div class="wiki-portrait-card mb-3 {% if char_status and char_status != 'active' %}wiki-portrait-card--faded{% endif %}">
                 <img src="{{ page.cover_image_url }}" alt="{{ page.title }}" class="wiki-portrait-img">
+                {% if char_status == 'deceased' %}
+                <div class="wiki-status-overlay">&#9760; Deceased</div>
+                {% elif char_status == 'retired' %}
+                <div class="wiki-status-overlay wiki-status-overlay--retired">Retired</div>
+                {% endif %}
+            </div>
+            {% elif char_status and char_status != 'active' %}
+            <!-- Status badge when no portrait -->
+            <div class="mb-3">
+                {% if char_status == 'deceased' %}
+                <span class="wiki-status-badge wiki-status-badge--deceased">&#9760; Deceased</span>
+                {% elif char_status == 'retired' %}
+                <span class="wiki-status-badge wiki-status-badge--retired">Retired</span>
+                {% endif %}
             </div>
             {% endif %}
 
-            {% if xp_snapshot %}
+            {% if xp_snapshot and char_status == 'active' %}
             <!-- XP snapshot (characters only) -->
             <div class="wiki-meta-card mb-3">
                 <h6 class="wiki-sidebar-heading">XP</h6>

--- a/apps/web/migrations/versions/e5a2f8b31c9d_add_status_field_to_characters.py
+++ b/apps/web/migrations/versions/e5a2f8b31c9d_add_status_field_to_characters.py
@@ -1,0 +1,30 @@
+"""add status field to characters
+
+Revision ID: e5a2f8b31c9d
+Revises: d4f1e9c23a8b
+Create Date: 2026-04-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e5a2f8b31c9d'
+down_revision = 'd4f1e9c23a8b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('characters') as batch_op:
+        batch_op.add_column(
+            sa.Column('status', sa.String(20), nullable=True, server_default='active')
+        )
+        batch_op.create_index('ix_characters_status', ['status'])
+
+
+def downgrade():
+    with op.batch_alter_table('characters') as batch_op:
+        batch_op.drop_index('ix_characters_status')
+        batch_op.drop_column('status')


### PR DESCRIPTION
## Summary

- New `status` field on characters: `active` | `deceased` | `retired`
- Staff can change status via a dropdown on the character detail page (replaces the Deactivate/Re-activate buttons)
- Wiki character pages show a status badge (portrait overlay when there's an image, inline badge without)
- Deceased/retired characters sort to the bottom of the Characters category listing, with muted styling
- XP snapshot hidden for non-active characters
- Discord sync step 6.7 processes `#retired` forum → creates wiki pages + marks characters retired via API
- `PUT /api/character/<name>/status` endpoint for the sync script

## Migration

`e5a2f8b31c9d` — adds `status VARCHAR(20)` column with `server_default='active'` and an index. Run `flask db upgrade` on deploy (Cloud Run runs this automatically via `db.create_all()` on startup — but for Turso you'll want to run the migration manually or verify the column exists after first deploy).

## Test plan

- [ ] 102 web tests pass
- [ ] TypeScript compiles clean
- [ ] Set a character to Deceased — hero shows skull badge, wiki page shows overlay, XP card hidden
- [ ] Set to Retired — grey badge, sorts below active characters in wiki listing
- [ ] Set back to Active — XP card reappears, sorts normally
- [ ] Run sync — retired characters from `#retired` get wiki pages + status set

🤖 Generated with [Claude Code](https://claude.com/claude-code)