### PR TITLE
Fix: run db migrations on container startup

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -13,5 +13,6 @@ COPY packages/ ./packages/
 # Cloud Run sets PORT env var (default 8080)
 ENV PORT=8080
 
-# Run with gunicorn (production WSGI server)
-CMD exec gunicorn --bind :$PORT --workers 2 --threads 4 --timeout 120 "app:create_app()"
+# entrypoint: run migrations then start gunicorn
+RUN chmod +x entrypoint.sh
+CMD ["./entrypoint.sh"]

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "[entrypoint] Running database migrations…"
+flask --app app:create_app db upgrade
+
+echo "[entrypoint] Starting gunicorn…"
+exec gunicorn --bind ":${PORT:-8080}" --workers 2 --threads 4 --timeout 120 "app:create_app()"


### PR DESCRIPTION
Follow-up to #139 — the entrypoint change that runs `flask db upgrade` before gunicorn was pushed after that PR merged.

Adds `entrypoint.sh` which runs migrations then starts gunicorn. Ensures the `status` column from #139 is applied to Turso on next deploy, and all future migrations run automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)