### PR TITLE
fix(web): add BOT_NOTION_SYNC_REQUESTED to EDITABLE_KEYS

### DIFF
--- a/apps/web/app/app_settings.py
+++ b/apps/web/app/app_settings.py
@@ -25,8 +25,9 @@ EDITABLE_KEYS = {
     'BOT_CLAIM_REMINDER_ENABLED',
     'BOT_PASSAGE_OF_TIME_ENABLED',
     'BOT_HUNT_CONSEQUENCE_ENABLED',
-    # Bot restart signal
+    # Bot restart / sync signals
     'BOT_RESTART_REQUESTED',
+    'BOT_NOTION_SYNC_REQUESTED',
     # Bot channel IDs (polled by bot via /api/bot-config; take effect after restart)
     'BOT_ANNOUNCEMENTS_CHANNEL_ID',
     # Bot tuning (polled by bot via /api/bot-config; take effect after restart)


### PR DESCRIPTION
## Summary

- `BOT_NOTION_SYNC_REQUESTED` was missing from `EDITABLE_KEYS` in `app_settings.py`
- Clicking "Request Notion Sync" in the settings UI called `set_app_setting` which raised `ValueError: Key 'BOT_NOTION_SYNC_REQUESTED' is not editable` → 500

One-line fix: add the key to the set.

## Test plan
- [ ] Click "Request Notion Sync" in settings — should flash success instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)