### PR TITLE
feat: DB-persisted error log + settings auto-refresh

### DIFF
--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from './services/passageOfTimeService';
 import { SheetsReconcileService } from './services/sheetsReconcileService';
 import { WikiSyncScheduler } from './services/wikiSyncScheduler';
+import { BotLogForwarder } from './services/botLogForwarder';
 
 const ASSETS_DIR = path.resolve(__dirname, '..', 'assets');
 import { errorToMessage, logEvent } from './logger';
@@ -180,6 +181,7 @@ void applyStartupConfigOverrides().then(() => {
 
   const configSyncWorker = new ConfigSyncWorker(adapter);
   const botHeartbeatService = new BotHeartbeatService(adapter);
+  const botLogForwarder = new BotLogForwarder(adapter);
 
   // Build hunt consequence config, respecting test mode
   const huntConsequenceCfg = {
@@ -201,6 +203,7 @@ void applyStartupConfigOverrides().then(() => {
     await registerCommands(client);
     configSyncWorker.start();
     botHeartbeatService.start();
+    botLogForwarder.start();
     reviewNotifier.start();
     autoPeriodCreator.start();
     autoPeriodCloser.start();

--- a/apps/bot/src/logger.ts
+++ b/apps/bot/src/logger.ts
@@ -1,5 +1,14 @@
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+/** In-memory buffer of warn/error entries, flushed periodically by BotLogForwarder. */
+const _warnErrorBuffer: Array<Record<string, unknown>> = [];
+const BUFFER_MAX = 100;
+
+/** Drain and return all buffered warn/error entries. */
+export function drainLogBuffer(): Array<Record<string, unknown>> {
+  return _warnErrorBuffer.splice(0, _warnErrorBuffer.length);
+}
+
 export function logEvent(level: LogLevel, event: string, context: Record<string, unknown> = {}) {
   const payload = {
     ts: new Date().toISOString(),
@@ -11,11 +20,15 @@ export function logEvent(level: LogLevel, event: string, context: Record<string,
   const line = JSON.stringify(payload);
   if (level === 'error') {
     console.error(line);
+    _warnErrorBuffer.push(payload);
+    if (_warnErrorBuffer.length > BUFFER_MAX) _warnErrorBuffer.shift();
     return;
   }
 
   if (level === 'warn') {
     console.warn(line);
+    _warnErrorBuffer.push(payload);
+    if (_warnErrorBuffer.length > BUFFER_MAX) _warnErrorBuffer.shift();
     return;
   }
 

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -61,6 +61,7 @@ export interface TrackerAdapter {
   getBotConfig(): Promise<BotConfigResponse>;
   ackBotRestart(): Promise<void>;
   ackNotionSync(status: 'running' | 'success' | 'error', error?: string): Promise<void>;
+  postBotLog(entries: Array<Record<string, unknown>>): Promise<void>;
   postHeartbeat(liveState?: Record<string, boolean>): Promise<void>;
   getAllReminderPrefs(): Promise<Record<string, { optOut: boolean; snoozeUntilEpoch: number }>>;
   setReminderPref(discordId: string, prefs: { optOut: boolean; snoozeUntilEpoch: number }): Promise<void>;
@@ -561,6 +562,16 @@ export class WebAppAdapter implements TrackerAdapter {
       body: JSON.stringify({ status, ...(error ? { error } : {}) }),
     });
     if (!res.ok) throw new Error(`notion-sync-ack POST failed: ${res.status}`);
+  }
+
+  async postBotLog(entries: Array<Record<string, unknown>>): Promise<void> {
+    const url = `${this.baseUrl}/api/bot-log`;
+    const res = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(entries),
+    });
+    if (!res.ok) throw new Error(`bot-log POST failed: ${res.status}`);
   }
 
   async postHeartbeat(liveState?: Record<string, boolean>): Promise<void> {

--- a/apps/bot/src/services/botLogForwarder.ts
+++ b/apps/bot/src/services/botLogForwarder.ts
@@ -1,0 +1,38 @@
+/**
+ * Forwards buffered warn/error log entries to the web app's /api/bot-log
+ * endpoint every 30 seconds so they appear in the Error Alerts page.
+ */
+
+import { drainLogBuffer } from '../logger';
+import type { TrackerAdapter } from './adapter';
+
+export class BotLogForwarder {
+  private readonly adapter: TrackerAdapter;
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(adapter: TrackerAdapter) {
+    this.adapter = adapter;
+  }
+
+  start() {
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.flush(), 30_000);
+    this.timer.unref();
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async flush(): Promise<void> {
+    const entries = drainLogBuffer();
+    if (!entries.length) return;
+    try {
+      await this.adapter.postBotLog(entries);
+    } catch {
+      // Silently drop on failure — we don't want logging to recurse into logging
+    }
+  }
+}

--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -177,7 +177,6 @@ def create_app():
 
     @app.errorhandler(Exception)
     def _handle_unhandled_exception(exc):
-        from flask import jsonify as _jsonify
         from .db import AppLogEntry, db as _db
         try:
             tb = _traceback.format_exc()

--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -177,6 +177,10 @@ def create_app():
 
     @app.errorhandler(Exception)
     def _handle_unhandled_exception(exc):
+        from werkzeug.exceptions import HTTPException
+        # Let HTTPException (404, 403, abort() calls, etc.) pass through unchanged
+        if isinstance(exc, HTTPException):
+            return exc
         from .db import AppLogEntry, db as _db
         try:
             tb = _traceback.format_exc()
@@ -193,7 +197,7 @@ def create_app():
             _db.session.commit()
         except Exception:
             pass
-        # Re-raise so Flask's default error handling (500 response) still applies
+        # Re-raise so Flask's default 500 handling still applies
         raise exc
 
     if app.config.get('LOCAL_STATUS_ENABLED', False):

--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -172,6 +172,31 @@ def create_app():
         _fh.setFormatter(_JsonFormatter())
         logging.getLogger().addHandler(_fh)
 
+    # Persist unhandled exceptions to AppLogEntry for the Error Alerts page
+    import traceback as _traceback
+
+    @app.errorhandler(Exception)
+    def _handle_unhandled_exception(exc):
+        from flask import jsonify as _jsonify
+        from .db import AppLogEntry, db as _db
+        try:
+            tb = _traceback.format_exc()
+            path = request.path if request else ''
+            entry = AppLogEntry(
+                ts=datetime.now(timezone.utc).isoformat(),
+                source='web',
+                level='error',
+                event='unhandled_exception',
+                message=f'{type(exc).__name__}: {exc}',
+                details=f'{path}\n\n{tb}'[:4000],
+            )
+            _db.session.add(entry)
+            _db.session.commit()
+        except Exception:
+            pass
+        # Re-raise so Flask's default error handling (500 response) still applies
+        raise exc
+
     if app.config.get('LOCAL_STATUS_ENABLED', False):
         access_log_file = Path(app.config.get('LOCAL_STATUS_ACCESS_LOG_FILE', '.run/logs/access.log'))
         if not access_log_file.is_absolute():

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1023,6 +1023,42 @@ def notion_sync_ack():
     return jsonify({'ok': True})
 
 
+@bp.route('/bot-log', methods=['POST'])
+@require_bot_scope('write')
+@_limit('120 per minute')
+def bot_log():
+    """Bot forwards its warn/error log entries here for persistent storage."""
+    from datetime import datetime, timezone
+    from app.db import AppLogEntry, db
+    entries = request.get_json(silent=True) or []
+    if not isinstance(entries, list):
+        return jsonify({'error': 'expected a JSON array'}), 400
+    now = datetime.now(timezone.utc)
+    for raw in entries[:50]:
+        if not isinstance(raw, dict):
+            continue
+        level = str(raw.get('level', '')).lower()
+        if level not in ('warn', 'error'):
+            continue
+        ts = str(raw.get('ts', now.isoformat()))
+        event = str(raw.get('event', 'unknown'))[:200]
+        msg = str(raw.get('error') or raw.get('reason') or raw.get('message') or '')
+        context = {k: v for k, v in raw.items() if k not in ('ts', 'level', 'event', 'error', 'reason', 'message')}
+        import json as _json
+        details = _json.dumps(context, ensure_ascii=False) if context else ''
+        db.session.add(AppLogEntry(
+            ts=ts, source='bot', level=level, event=event,
+            message=msg[:2000], details=details[:4000], created_at=now,
+        ))
+    db.session.commit()
+    # Prune to 500 most recent entries
+    cutoff_query = db.session.query(AppLogEntry.id).order_by(AppLogEntry.created_at.desc()).offset(500).limit(1).scalar()
+    if cutoff_query:
+        db.session.query(AppLogEntry).filter(AppLogEntry.id <= cutoff_query).delete()
+        db.session.commit()
+    return jsonify({'ok': True})
+
+
 @bp.route('/wiki/page', methods=['POST'])
 @require_bot_scope('write')
 @_limit('120 per minute')

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1034,7 +1034,7 @@ def bot_log():
     if not isinstance(entries, list):
         return jsonify({'error': 'expected a JSON array'}), 400
     now = datetime.now(timezone.utc)
-    for raw in entries[:50]:
+    for raw in entries[:100]:
         if not isinstance(raw, dict):
             continue
         level = str(raw.get('level', '')).lower()

--- a/apps/web/app/blueprints/audit.py
+++ b/apps/web/app/blueprints/audit.py
@@ -125,36 +125,44 @@ def _parse_error_entries(filename: str, lines: list[str]) -> list[dict]:
 @bp.route('/errors')
 @require_staff
 def errors():
-    """View warning/error alerts collected from local bot/web logs."""
-    max_lines = min(max(int(request.args.get('max_lines', '1200')), 100), 5000)
+    """View warning/error alerts from the DB-persisted log."""
+    from app.db import AppLogEntry
     source_filter = request.args.get('source', '').strip()
     level_filter = request.args.get('level', '').strip().lower()
     event_filter = request.args.get('event', '').strip().lower()
 
-    filenames = [source_filter] if source_filter in ERROR_LOG_FILES else list(ERROR_LOG_FILES)
-    entries: list[dict] = []
-    for filename in filenames:
-        entries.extend(_parse_error_entries(filename, _tail_lines(LOG_DIR / filename, max_lines)))
-
-    if level_filter in {'warn', 'error'}:
-        entries = [e for e in entries if e['level'] == level_filter]
+    query = AppLogEntry.query.order_by(AppLogEntry.created_at.desc())
+    if source_filter in ('bot', 'web'):
+        query = query.filter(AppLogEntry.source == source_filter)
+    if level_filter in ('warn', 'error'):
+        query = query.filter(AppLogEntry.level == level_filter)
     if event_filter:
-        entries = [e for e in entries if event_filter in e['event'].lower()]
+        query = query.filter(AppLogEntry.event.ilike(f'%{event_filter}%'))
+    db_entries = query.limit(200).all()
 
-    entries.sort(key=lambda e: (e['timestamp_sort'], e['source'], e['raw_index']), reverse=True)
+    entries = [
+        {
+            'timestamp': e.ts,
+            'source': e.source,
+            'level': e.level,
+            'event': e.event,
+            'message': e.message,
+            'details': e.details,
+        }
+        for e in db_entries
+    ]
+
     event_counts: dict[str, int] = {}
     for e in entries:
-        key = e['event']
-        event_counts[key] = event_counts.get(key, 0) + 1
+        event_counts[e['event']] = event_counts.get(e['event'], 0) + 1
 
     # Merge in-memory (real-time, current session) and DB (historical) sync errors
     rt_errors = _get_recent_sync_errors()
-    db_errors = db_service.get_recent_sync_errors(limit=100)
-    # Deduplicate: prefer DB entries (they have an id); RT entries not yet flushed are additions
-    db_keys = {(e['timestamp'], e['operation'], e['error']) for e in db_errors}
+    db_sync_errors = db_service.get_recent_sync_errors(limit=100)
+    db_keys = {(e['timestamp'], e['operation'], e['error']) for e in db_sync_errors}
     rt_only = [e for e in rt_errors
                if (e['timestamp'], e['operation'], e['error']) not in db_keys]
-    sync_errors = rt_only + db_errors
+    sync_errors = rt_only + db_sync_errors
 
     return render_template(
         'audit/errors.html',
@@ -164,7 +172,5 @@ def errors():
         source_filter=source_filter,
         level_filter=level_filter,
         event_filter=event_filter,
-        max_lines=max_lines,
-        log_dir=str(LOG_DIR),
         sync_errors=sync_errors,
     )

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -8,6 +8,19 @@ from sqlalchemy import DateTime, Integer, String, Boolean, Text
 db = SQLAlchemy()
 
 
+class AppLogEntry(db.Model):
+    """Persisted warn/error log entries from the bot and web app."""
+    __tablename__ = 'app_log_entries'
+    id = db.Column(Integer, primary_key=True)
+    ts = db.Column(String(30), nullable=False)
+    source = db.Column(String(10), nullable=False)   # 'bot' | 'web'
+    level = db.Column(String(10), nullable=False)    # 'warn' | 'error'
+    event = db.Column(String(200), nullable=False, default='')
+    message = db.Column(Text, default='')
+    details = db.Column(Text, default='')
+    created_at = db.Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
+
+
 class DbCharacter(db.Model):
     __tablename__ = 'characters'
     id = db.Column(Integer, primary_key=True)

--- a/apps/web/app/templates/audit/errors.html
+++ b/apps/web/app/templates/audit/errors.html
@@ -3,14 +3,24 @@
 {% block title %}Error Alerts — MCbN XP Tracker{% endblock %}
 
 {% block content %}
-<h2 class="mb-4"><i class="bi bi-exclamation-triangle"></i> Error Alerts</h2>
+<div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
+  <h2 class="mb-0"><i class="bi bi-exclamation-triangle"></i> Error Alerts</h2>
+  <div class="d-flex gap-2 align-items-center">
+    <small class="text-muted">Updated {{ now }}</small>
+    <a href="{{ request.url }}" class="btn btn-sm btn-outline-secondary">
+      <i class="bi bi-arrow-clockwise"></i> Refresh
+    </a>
+    <a href="https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%20severity%3E%3DWARNING?project=mcbn-xp-tracker"
+       target="_blank" rel="noopener" class="btn btn-sm btn-outline-info">
+      <i class="bi bi-cloud"></i> Cloud Logs
+    </a>
+  </div>
+</div>
 
 {% if sync_errors %}
 <div class="card mb-4 border-warning">
     <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
-        <span><i class="bi bi-cloud-slash"></i> <strong>Sheets Sync Errors</strong>
-            <small class="fw-normal ms-1">(DB-persisted + current session)</small>
-        </span>
+        <span><i class="bi bi-cloud-slash"></i> <strong>Sheets Sync Errors</strong></span>
         <span class="badge bg-dark">{{ sync_errors|length }}</span>
     </div>
     <div class="table-responsive">
@@ -40,11 +50,11 @@
     <div class="card-body">
         <form method="GET" class="row g-3 align-items-end">
             <div class="col-md-3">
-                <label for="source" class="form-label">Source Log</label>
+                <label for="source" class="form-label">Source</label>
                 <select class="form-select" id="source" name="source">
                     <option value="">All</option>
-                    <option value="bot.err.log" {% if source_filter == 'bot.err.log' %}selected{% endif %}>bot.err.log</option>
-                    <option value="web.err.log" {% if source_filter == 'web.err.log' %}selected{% endif %}>web.err.log</option>
+                    <option value="bot" {% if source_filter == 'bot' %}selected{% endif %}>bot</option>
+                    <option value="web" {% if source_filter == 'web' %}selected{% endif %}>web</option>
                 </select>
             </div>
             <div class="col-md-2">
@@ -57,7 +67,7 @@
             </div>
             <div class="col-md-4">
                 <label for="event" class="form-label">Event contains</label>
-                <input type="text" class="form-control" id="event" name="event" value="{{ event_filter }}" placeholder="claim_reminder_...">
+                <input type="text" class="form-control" id="event" name="event" value="{{ event_filter }}" placeholder="notion_sync_error">
             </div>
             <div class="col-md-3">
                 <button type="submit" class="btn btn-outline-light w-100">
@@ -65,59 +75,68 @@
                 </button>
             </div>
         </form>
-        <p class="text-muted mt-3 mb-0">
-            Read from {{ log_dir }} (last {{ max_lines }} lines per selected file), snapshot at {{ now }}.
-        </p>
     </div>
 </div>
 
 {% if event_counts %}
 <div class="card bg-dark border-secondary mb-4">
-    <div class="card-header">Top Error Events</div>
+    <div class="card-header">Top Events</div>
     <div class="card-body">
         {% for event_name, count in event_counts %}
-        <span class="badge bg-secondary me-2 mb-2">{{ event_name }}: {{ count }}</span>
+        <a href="?event={{ event_name | urlencode }}" class="badge bg-secondary text-decoration-none me-2 mb-2">{{ event_name }}: {{ count }}</a>
         {% endfor %}
     </div>
 </div>
 {% endif %}
 
+{% if entries %}
 <div class="table-responsive">
-    <table class="table table-hover">
+    <table class="table table-hover align-middle">
         <thead>
             <tr>
-                <th>Timestamp</th>
-                <th>Source</th>
-                <th>Level</th>
-                <th>Event</th>
-                <th>Message</th>
-                <th>Details</th>
+                <th style="width: 160px;">Time (UTC)</th>
+                <th style="width: 55px;">Src</th>
+                <th style="width: 60px;">Level</th>
+                <th style="width: 200px;">Event</th>
+                <th>Message / Details</th>
             </tr>
         </thead>
         <tbody>
             {% for entry in entries %}
             <tr>
-                <td class="text-nowrap">{{ entry.timestamp or 'n/a' }}</td>
-                <td><code>{{ entry.source }}</code></td>
+                <td class="text-muted small text-nowrap">{{ entry.timestamp[:19] | replace('T', ' ') if entry.timestamp else '' }}</td>
+                <td><span class="badge bg-secondary">{{ entry.source }}</span></td>
                 <td>
                     <span class="badge {% if entry.level == 'error' %}bg-danger{% else %}bg-warning text-dark{% endif %}">
                         {{ entry.level }}
                     </span>
                 </td>
-                <td><code>{{ entry.event }}</code></td>
-                <td style="max-width: 420px; white-space: pre-wrap;">{{ entry.message }}</td>
-                <td style="max-width: 420px; white-space: pre-wrap;"><small class="text-muted">{{ entry.details }}</small></td>
+                <td><code class="small">{{ entry.event }}</code></td>
+                <td>
+                    {% if entry.message %}
+                    <div class="small" style="white-space: pre-wrap; word-break: break-word;">{{ entry.message }}</div>
+                    {% endif %}
+                    {% if entry.details %}
+                    <details class="mt-1">
+                        <summary class="text-muted small" style="cursor:pointer;">Details</summary>
+                        <pre class="mt-1 small text-muted" style="white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto;">{{ entry.details }}</pre>
+                    </details>
+                    {% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
 </div>
-
-{% if not entries %}
+{% else %}
 <div class="text-center text-muted py-5">
     <i class="bi bi-check-circle" style="font-size: 3rem;"></i>
-    <p class="mt-2">No warning/error alerts matched your filters.</p>
+    <p class="mt-2">No warn/error entries{% if source_filter or level_filter or event_filter %} matching your filters{% endif %}.</p>
 </div>
 {% endif %}
-{% endblock %}
 
+<script>
+  // Auto-refresh every 30s so new bot log entries appear without manual reload
+  setTimeout(() => location.reload(), 30000);
+</script>
+{% endblock %}

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -423,4 +423,8 @@
   </div>
 
 </div>
+
+{% if notion_sync.requested or notion_sync.status == 'running' %}
+<script>setTimeout(() => location.reload(), 10000);</script>
+{% endif %}
 {% endblock %}

--- a/apps/web/migrations/versions/f3a7b91e45c2_add_app_log_entries_table.py
+++ b/apps/web/migrations/versions/f3a7b91e45c2_add_app_log_entries_table.py
@@ -1,0 +1,36 @@
+"""add app_log_entries table
+
+Revision ID: f3a7b91e45c2
+Revises: e5a2f8b31c9d
+Create Date: 2026-04-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f3a7b91e45c2'
+down_revision = 'e5a2f8b31c9d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'app_log_entries',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('ts', sa.String(30), nullable=False),
+        sa.Column('source', sa.String(10), nullable=False),
+        sa.Column('level', sa.String(10), nullable=False),
+        sa.Column('event', sa.String(200), nullable=False, server_default=''),
+        sa.Column('message', sa.Text, server_default=''),
+        sa.Column('details', sa.Text, server_default=''),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+    )
+    op.create_index('ix_app_log_entries_created_at', 'app_log_entries', ['created_at'])
+
+
+def downgrade():
+    op.drop_index('ix_app_log_entries_created_at', table_name='app_log_entries')
+    op.drop_table('app_log_entries')


### PR DESCRIPTION
## Summary

- **Error Alerts page now works in production** — reads from a DB table instead of log files that don't exist on Cloud Run
- **Bot errors are forwarded automatically** — `BotLogForwarder` flushes warn/error events to `/api/bot-log` every 30s
- **Web 500s are captured** — new `app.errorhandler(Exception)` writes traceback + path to the same table
- **Notion sync status auto-refreshes** — settings page reloads every 10s while a sync is running or queued, so you can see when it finishes without manual refreshing
- **Error Alerts auto-refreshes** every 30s so new entries appear without manual reload
- **Cloud Logging link** added to Error Alerts page for full web app traces (GCP project `mcbn-xp-tracker`)

## New things

| Thing | What it does |
|-------|-------------|
| `AppLogEntry` DB table | Stores bot + web warn/error entries, capped at 500 rows |
| `POST /api/bot-log` | Write-token endpoint, accepts batches of up to 50 log entries |
| `BotLogForwarder` | Bot service, flushes buffered warn/errors every 30s |
| Migration `f3a7b91e45c2` | Creates `app_log_entries` table |

## Test plan
- [ ] Merge and wait for Cloud Run to deploy
- [ ] Restart bot container
- [ ] Trigger a Notion sync — settings page should auto-refresh and show Running → Success without manual reload
- [ ] Check Error Alerts — should show entries within ~30s of any bot warn/error

🤖 Generated with [Claude Code](https://claude.com/claude-code)