### PR TITLE
feat(web): mirror wiki images to GCS + portrait indicator on roster

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1072,6 +1072,21 @@ def upsert_wiki_page():
     if not slug or not title:
         return jsonify({'error': 'slug and title are required'}), 400
 
+    from app.gcs import mirror_to_gcs, is_discord_cdn_url
+    from flask import current_app as _app
+
+    def _resolve_cover(url: str, page_slug: str) -> str:
+        """Upload Discord CDN images to GCS; return permanent URL."""
+        if not url or not is_discord_cdn_url(url):
+            return url
+        return mirror_to_gcs(
+            url=url,
+            slug=page_slug,
+            bucket_name=_app.config.get('GCS_BUCKET_NAME', 'mcbn-wiki-images'),
+            credentials_json=_app.config.get('GOOGLE_CREDENTIALS_JSON', ''),
+            credentials_file=_app.config.get('GOOGLE_CREDENTIALS_FILE', ''),
+        )
+
     p = WikiPage.query.filter_by(slug=slug).first()
     if p:
         p.title = title
@@ -1080,7 +1095,7 @@ def upsert_wiki_page():
         if 'category' in data:
             p.category = data['category']
         if 'cover_image_url' in data:
-            p.cover_image_url = data['cover_image_url']
+            p.cover_image_url = _resolve_cover(data['cover_image_url'], slug)
         if 'published' in data:
             p.published = bool(data['published'])
         p.source = data.get('source', p.source)
@@ -1094,7 +1109,7 @@ def upsert_wiki_page():
         title=title,
         body_markdown=data.get('body_markdown', ''),
         category=data.get('category', ''),
-        cover_image_url=data.get('cover_image_url', ''),
+        cover_image_url=_resolve_cover(data.get('cover_image_url', ''), slug),
         source=data.get('source', 'api-sync'),
         published=bool(data.get('published', True)),
         updated_by=data.get('updated_by', 'api-sync'),

--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -35,15 +35,25 @@ def _parse_creation_xp(raw_value: str | None) -> int:
 @require_staff
 def list_characters():
     """List all characters with filtering."""
+    from app.db import WikiPage
     show = request.args.get('show', 'active')  # active, inactive, all
     clan_filter = request.args.get('clan', request.args.get('clan_filter', ''))
     sect_filter = request.args.get('sect', request.args.get('sect_filter', ''))
+    portrait_filter = request.args.get('portrait', '')  # '' | 'missing'
 
     characters = db_service.get_all_characters()
     xp_by_character = {
         row['character_name'].lower(): row['available_xp']
         for row in db_service.get_dashboard_data()
     }
+
+    # Build portrait status map: name.lower() → 'yes' | 'no' | 'none'
+    wiki_pages = {p.title.lower(): p for p in WikiPage.query.all()}
+    def _portrait_status(name: str) -> str:
+        page = wiki_pages.get(name.lower())
+        if page is None:
+            return 'none'
+        return 'yes' if page.cover_image_url else 'no'
 
     if show == 'active':
         characters = [c for c in characters if c.active]
@@ -56,13 +66,16 @@ def list_characters():
     if sect_filter:
         characters = [c for c in characters
                       if c.sect.lower() == sect_filter.lower()]
+    if portrait_filter == 'missing':
+        characters = [c for c in characters
+                      if _portrait_status(c.character_name) != 'yes']
 
-    # Compute available XP for each character
     char_data = []
     for c in characters:
         char_data.append({
             'char': c,
             'available_xp': xp_by_character.get(c.character_name.lower(), 0),
+            'portrait': _portrait_status(c.character_name),
         })
 
     return render_template(
@@ -71,6 +84,7 @@ def list_characters():
         show=show,
         clan_filter=clan_filter,
         sect_filter=sect_filter,
+        portrait_filter=portrait_filter,
         clans=CLANS,
         sects=SECTS,
     )

--- a/apps/web/app/gcs.py
+++ b/apps/web/app/gcs.py
@@ -1,0 +1,93 @@
+"""Google Cloud Storage helpers for wiki image mirroring."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Discord CDN hostnames whose URLs expire
+_DISCORD_CDN_HOSTS = {'cdn.discordapp.com', 'media.discordapp.net'}
+
+_GCS_PUBLIC_BASE = 'https://storage.googleapis.com'
+
+
+def is_discord_cdn_url(url: str) -> bool:
+    if not url:
+        return False
+    try:
+        return urlparse(url).hostname in _DISCORD_CDN_HOSTS
+    except Exception:
+        return False
+
+
+def is_gcs_url(url: str, bucket: str) -> bool:
+    if not url:
+        return False
+    return url.startswith(f'{_GCS_PUBLIC_BASE}/{bucket}/')
+
+
+def _ext_from_url(url: str) -> str:
+    path = urlparse(url).path
+    _, ext = os.path.splitext(path)
+    ext = ext.split('?')[0].lower()
+    return ext if ext in ('.jpg', '.jpeg', '.png', '.gif', '.webp') else '.jpg'
+
+
+def mirror_to_gcs(
+    url: str,
+    slug: str,
+    bucket_name: str,
+    credentials_json: str = '',
+    credentials_file: str = '',
+) -> str:
+    """Download *url* from Discord CDN and upload to GCS. Returns the public GCS URL.
+
+    Falls back to the original *url* on any error so the caller can still save.
+    """
+    if not url or not is_discord_cdn_url(url):
+        return url
+
+    try:
+        import requests as _requests
+        from google.cloud import storage as _gcs
+        from google.oauth2 import service_account as _sa
+        import json as _json
+
+        # Build credentials
+        scopes = ['https://www.googleapis.com/auth/devstorage.read_write']
+        if credentials_json:
+            info = _json.loads(credentials_json)
+            creds = _sa.Credentials.from_service_account_info(info, scopes=scopes)
+        elif credentials_file and os.path.exists(credentials_file):
+            creds = _sa.Credentials.from_service_account_file(credentials_file, scopes=scopes)
+        else:
+            # Fall back to application default credentials (works on Cloud Run)
+            creds = None
+
+        client = _gcs.Client(credentials=creds)
+        bucket = client.bucket(bucket_name)
+
+        # Download image
+        resp = _requests.get(url, timeout=30)
+        resp.raise_for_status()
+        content_type = resp.headers.get('Content-Type', 'image/jpeg').split(';')[0].strip()
+
+        ext = _ext_from_url(url)
+        # Sanitize slug for use as an object name
+        safe_slug = re.sub(r'[^a-z0-9\-_]', '-', slug.lower())
+        object_name = f'wiki-covers/{safe_slug}{ext}'
+
+        blob = bucket.blob(object_name)
+        blob.upload_from_string(resp.content, content_type=content_type)
+
+        gcs_url = f'{_GCS_PUBLIC_BASE}/{bucket_name}/{object_name}'
+        logger.info('Mirrored %s → %s', url, gcs_url)
+        return gcs_url
+
+    except Exception as exc:
+        logger.warning('GCS mirror failed for slug=%s: %s', slug, exc)
+        return url

--- a/apps/web/app/templates/roster/list.html
+++ b/apps/web/app/templates/roster/list.html
@@ -37,13 +37,20 @@
           {% endfor %}
         </select>
       </div>
-      <div class="col-md-3">
+      <div class="col-md-2">
         <label for="sect_filter" class="form-label">Sect</label>
         <select name="sect" id="sect_filter" class="form-select" onchange="this.form.submit()">
           <option value="">All Sects</option>
           {% for sect in sects %}
           <option value="{{ sect }}" {% if sect_filter == sect %}selected{% endif %}>{{ sect }}</option>
           {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-2">
+        <label for="portrait_filter" class="form-label">Portrait</label>
+        <select name="portrait" id="portrait_filter" class="form-select" onchange="this.form.submit()">
+          <option value="" {% if portrait_filter == '' %}selected{% endif %}>All</option>
+          <option value="missing" {% if portrait_filter == 'missing' %}selected{% endif %}>Missing</option>
         </select>
       </div>
     </div>
@@ -59,7 +66,8 @@
           <th class="sortable d-none d-md-table-cell" data-col="2" role="button" tabindex="0" aria-sort="none">Age <span class="sort-arrow"></span></th>
           <th class="sortable d-none d-md-table-cell" data-col="3" role="button" tabindex="0" aria-sort="none">Sect <span class="sort-arrow"></span></th>
           <th class="d-none d-sm-table-cell">Active</th>
-          <th class="sortable" data-col="5" role="button" tabindex="0" aria-sort="none">Available XP <span class="sort-arrow"></span></th>
+          <th class="d-none d-sm-table-cell" title="Wiki portrait status">Portrait</th>
+          <th class="sortable" data-col="6" role="button" tabindex="0" aria-sort="none">Available XP <span class="sort-arrow"></span></th>
         </tr>
       </thead>
       <tbody>
@@ -83,6 +91,15 @@
               <span class="badge bg-success">Yes</span>
             {% else %}
               <span class="badge bg-secondary">No</span>
+            {% endif %}
+          </td>
+          <td class="d-none d-sm-table-cell">
+            {% if item.portrait == 'yes' %}
+              <i class="bi bi-person-bounding-box text-success" title="Has portrait"></i>
+            {% elif item.portrait == 'no' %}
+              <i class="bi bi-journal-text text-warning" title="Wiki page exists but no portrait"></i>
+            {% else %}
+              <i class="bi bi-person-x text-secondary" title="No wiki page"></i>
             {% endif %}
           </td>
           <td class="{% if item.available_xp < 0 %}text-danger{% elif item.available_xp > 0 %}text-success{% endif %}">
@@ -141,7 +158,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // Sort rows
       const rows = Array.from(tbody.querySelectorAll('tr'));
-      const isNumeric = col === 5; // Available XP
+      const isNumeric = col === 6; // Available XP
 
       rows.sort(function (a, b) {
         let va = a.cells[col].textContent.trim();

--- a/apps/web/config.py
+++ b/apps/web/config.py
@@ -23,6 +23,9 @@ class Config:
     )
     # For Cloud Run: service-account JSON passed as env var instead of file
     GOOGLE_CREDENTIALS_JSON = os.environ.get('GOOGLE_CREDENTIALS_JSON', '')
+
+    # GCS bucket for permanent wiki image storage
+    GCS_BUCKET_NAME = os.environ.get('GCS_BUCKET_NAME', 'mcbn-wiki-images')
     SPREADSHEET_ID = os.environ.get('SPREADSHEET_ID', '')
     DISCORD_WEBHOOK_URL = os.environ.get('DISCORD_WEBHOOK_URL', '')
 

--- a/apps/web/requirements.txt
+++ b/apps/web/requirements.txt
@@ -6,6 +6,7 @@ Flask-Migrate==4.*
 requests==2.*
 gspread==6.*
 google-auth==2.*
+google-cloud-storage==2.*
 python-dotenv==1.*
 gunicorn==25.*
 pytest==9.*


### PR DESCRIPTION
## Summary

- **Discord CDN images are now permanently stored in GCS** — no more expiring URLs. `upsert_wiki_page` detects Discord CDN cover images, downloads them, uploads to `gs://mcbn-wiki-images/wiki-covers/{slug}.jpg`, and stores the permanent `storage.googleapis.com` URL instead. Re-uploads on each sync so portraits stay current if changed in Discord.
- **Portrait indicator on roster** — new icon column shows at a glance which characters have a portrait (green), have a wiki page but no portrait (yellow), or have no wiki page at all (grey).
- **"Missing portrait" filter** — roster filter dropdown lets staff filter to just characters needing a portrait.

## Setup (already done)
- `gs://mcbn-wiki-images` bucket created, public read enabled, service account granted `objectAdmin`

## After merge
Trigger a Notion sync from Settings — the next run will upload all existing Discord CDN images to GCS and update the stored URLs. From that point on, images will never expire.

## Test plan
- [ ] Merge + deploy
- [ ] Run Notion sync from Settings
- [ ] Verify wiki images load from `storage.googleapis.com` URLs
- [ ] Check roster — portrait column visible, "Missing" filter works

🤖 Generated with [Claude Code](https://claude.com/claude-code)