### PR TITLE
fix(bot): pass webWriteToken to runNotionSync so wiki actually updates

### DIFF
--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -66,6 +66,7 @@ export class ConfigSyncWorker {
         notionToken: config.notionToken,
         webBase: config.webAppBaseUrl,
         webReadToken: config.webAppApiReadToken ?? config.webAppApiToken,
+        webWriteToken: config.webAppApiWriteToken ?? config.webAppApiToken,
         msgLimit: config.notionSyncMsgLimit,
       });
       if (result.success) {

--- a/apps/bot/src/services/wikiSyncScheduler.ts
+++ b/apps/bot/src/services/wikiSyncScheduler.ts
@@ -127,6 +127,7 @@ export class WikiSyncScheduler {
         notionToken: config.notionToken,
         webBase: config.webAppBaseUrl,
         webReadToken: config.webAppApiReadToken ?? config.webAppApiToken,
+        webWriteToken: config.webAppApiWriteToken ?? config.webAppApiToken,
         msgLimit: config.notionSyncMsgLimit,
       });
 


### PR DESCRIPTION
## Summary

`configSyncWorker` and `wikiSyncScheduler` were passing `webReadToken` but not `webWriteToken` when calling `runNotionSync()`. The sync script guards every `wikiUpsert()` call with \`if (!writeToken) return\` — so Notion was being updated correctly but the Chronicle Wiki pages were never touched, and images were never written.

One-line fix in each service: add `webWriteToken: config.webAppApiWriteToken ?? config.webAppApiToken`.

## Test plan
- [ ] Merge + rebuild bot
- [ ] Trigger sync — logs should show `Wiki sync enabled — pages will be upserted to Chronicle Wiki.` instead of `Wiki sync disabled`
- [ ] Wiki images appear after sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)