### PR TITLE
feat(settings): add Rebuild Bot button with copy-able rebuild command

### DIFF
--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -422,6 +422,23 @@ def request_restart():
     return redirect(url_for('settings.index'))
 
 
+@bp.route('/request-rebuild', methods=['POST'])
+@require_staff
+def request_rebuild():
+    if not is_settings_admin():
+        flash('You do not have permission to restart the bot.', 'danger')
+        return redirect(url_for('settings.index'))
+
+    updated_by = (
+        session.get('discord_name')
+        or session.get('staff_user')
+        or session.get('discord_id', 'unknown')
+    )
+    set_app_setting('BOT_RESTART_REQUESTED', 'true', updated_by)
+    flash('Bot will exit within ~60s. Run the rebuild command shown below to bring it back up with the latest code.', 'info')
+    return redirect(url_for('settings.index'))
+
+
 @bp.route('/update', methods=['POST'])
 @require_staff
 def update():

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -152,18 +152,26 @@
     <div class="card-header border-secondary d-flex align-items-center justify-content-between">
       <h6 class="mb-0 text-light"><i class="bi bi-heart-pulse"></i> Bot Status</h6>
       {% if can_edit %}
-        <form method="POST" action="{{ url_for('settings.request_restart') }}" class="mb-0">
-          {% if bot_restart_pending %}
-            <button type="submit" class="btn btn-sm btn-warning" disabled>
-              <i class="bi bi-arrow-clockwise"></i> Restart Pending…
+        <div class="d-flex gap-2">
+          <form method="POST" action="{{ url_for('settings.request_restart') }}" class="mb-0">
+            {% if bot_restart_pending %}
+              <button type="submit" class="btn btn-sm btn-warning" disabled>
+                <i class="bi bi-arrow-clockwise"></i> Pending…
+              </button>
+            {% else %}
+              <button type="submit" class="btn btn-sm btn-outline-warning"
+                onclick="return confirm('Request bot restart? It will exit cleanly within ~60s and Docker will restart it.')">
+                <i class="bi bi-arrow-clockwise"></i> Restart
+              </button>
+            {% endif %}
+          </form>
+          <form method="POST" action="{{ url_for('settings.request_rebuild') }}" class="mb-0">
+            <button type="submit" class="btn btn-sm btn-outline-info"
+              onclick="return confirm('This will exit the bot within ~60s. Copy the rebuild command from the card, then run it in your terminal.')">
+              <i class="bi bi-hammer"></i> Rebuild
             </button>
-          {% else %}
-            <button type="submit" class="btn btn-sm btn-outline-warning"
-              onclick="return confirm('Request bot restart? It will exit cleanly within ~60s and Docker will restart it.')">
-              <i class="bi bi-arrow-clockwise"></i> Restart Bot
-            </button>
-          {% endif %}
-        </form>
+          </form>
+        </div>
       {% endif %}
     </div>
     <div class="card-body">
@@ -180,6 +188,23 @@
         <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Offline</span>
         <small class="text-muted ms-2">Last seen {{ (bot_heartbeat_age // 60) if bot_heartbeat_age else '?' }}m ago</small>
       {% endif %}
+
+      <div class="mt-3 pt-3 border-top border-secondary">
+        <small class="text-muted d-block mb-1">
+          <i class="bi bi-hammer me-1"></i>Rebuild command — run in terminal from <code>apps/bot/</code>:
+        </small>
+        <div class="d-flex align-items-center gap-2">
+          <code class="flex-grow-1 px-2 py-1 rounded small"
+                style="background:#111; color:#adb5bd; word-break:break-all;">
+            npm run ops:docker:down &amp;&amp; npm run ops:docker:up
+          </code>
+          <button class="btn btn-sm btn-outline-secondary text-nowrap" type="button"
+                  id="rebuild-copy-btn"
+                  onclick="navigator.clipboard.writeText('npm run ops:docker:down && npm run ops:docker:up'); var b=document.getElementById('rebuild-copy-btn'); b.textContent='Copied!'; setTimeout(function(){b.textContent='Copy'},2000);">
+            Copy
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- Adds a **Rebuild** button to the Bot Status card (alongside the existing Restart button)
- Clicking Rebuild requests a clean bot exit within ~60s (same signal as Restart)
- The rebuild command (`npm run ops:docker:down && npm run ops:docker:up`) is always visible on the card with a **Copy** button — no more trying to remember the docker commands

## Test plan
- [ ] Bot Status card shows both Restart and Rebuild buttons
- [ ] Rebuild command visible in card body with working Copy button
- [ ] Clicking Rebuild shows flash message directing to the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)