### PR TITLE
Add bot tests for sync worker and scheduler orchestration

### DIFF
--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -54,10 +54,7 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## High-Signal Current Gaps
 - `runNotionSync` is still a large monolithic script (1218 LOC) doing both Notion and Wiki writes.
-- Bot tests do not currently cover:
-  - `ConfigSyncWorker`
-  - `WikiSyncScheduler`
-  - Notion/Wiki sync orchestration edge cases.
+- Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source is persisted (`BOT_NOTION_SYNC_SOURCE`) for operator context, but no historical run log exists beyond current status keys.
 

--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BotConfigResponse, TrackerAdapter } from '../services/adapter';
+import { ConfigSyncWorker } from '../services/configSyncWorker';
+import { currentWikiSyncOwner, tryAcquireWikiSync } from '../services/wikiSyncLock';
+import { runNotionSync } from '../scripts/discord-notion-sync';
+
+vi.mock('../config', () => ({
+  config: {
+    botToken: 'bot-token',
+    discordGuildId: 'guild-1',
+    notionToken: 'notion-token',
+    webAppBaseUrl: 'https://web.example',
+    webAppApiToken: 'legacy-token',
+    webAppApiReadToken: 'read-token',
+    webAppApiWriteToken: 'write-token',
+    notionSyncMsgLimit: 123,
+  },
+}));
+
+vi.mock('../logger', () => ({
+  logEvent: vi.fn(),
+}));
+
+vi.mock('../scripts/discord-notion-sync', () => ({
+  runNotionSync: vi.fn(),
+}));
+
+function baseBotConfig(overrides: Partial<BotConfigResponse> = {}): BotConfigResponse {
+  return {
+    reviewNotifierEnabled: null,
+    submissionNotifierEnabled: null,
+    autoPeriodCreatorEnabled: null,
+    autoPeriodCloserEnabled: null,
+    claimReminderEnabled: null,
+    passageOfTimeEnabled: null,
+    huntConsequenceEnabled: null,
+    restartRequested: null,
+    notionSyncRequested: null,
+    passageOfTimeIntervalMs: null,
+    reviewNotifierIntervalMs: null,
+    submissionNotifierIntervalMs: null,
+    claimReminderIntervalMs: null,
+    announcementsChannelId: null,
+    ...overrides,
+  };
+}
+
+function makeAdapter(cfg: BotConfigResponse): TrackerAdapter {
+  return {
+    getBotConfig: vi.fn(async () => cfg),
+    ackNotionSync: vi.fn(async () => {}),
+    ackBotRestart: vi.fn(async () => {}),
+  } as unknown as TrackerAdapter;
+}
+
+describe('ConfigSyncWorker sync orchestration', () => {
+  afterEach(() => {
+    expect(currentWikiSyncOwner()).toBeNull();
+    vi.clearAllMocks();
+  });
+
+  it('skips manual sync when shared wiki lock is already held', async () => {
+    const lease = tryAcquireWikiSync('scheduled');
+    expect(lease).not.toBeNull();
+    const adapter = makeAdapter(baseBotConfig({ notionSyncRequested: true }));
+    vi.mocked(runNotionSync).mockResolvedValueOnce({ success: true });
+
+    const worker = new ConfigSyncWorker(adapter);
+    await worker.sync();
+
+    expect(adapter.ackNotionSync).not.toHaveBeenCalled();
+    expect(runNotionSync).not.toHaveBeenCalled();
+    lease?.release();
+  });
+
+  it('acks running/success and executes notion sync for manual requests', async () => {
+    const adapter = makeAdapter(baseBotConfig({ notionSyncRequested: true }));
+    vi.mocked(runNotionSync).mockResolvedValueOnce({ success: true });
+
+    const worker = new ConfigSyncWorker(adapter);
+    await worker.sync();
+
+    await vi.waitFor(() => {
+      expect(runNotionSync).toHaveBeenCalledTimes(1);
+      expect(adapter.ackNotionSync).toHaveBeenCalledTimes(2);
+    });
+    expect(runNotionSync).toHaveBeenCalledWith({
+      botToken: 'bot-token',
+      guildId: 'guild-1',
+      notionToken: 'notion-token',
+      webBase: 'https://web.example',
+      webReadToken: 'read-token',
+      webWriteToken: 'write-token',
+      msgLimit: 123,
+    });
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'manual');
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'success', undefined, 'manual');
+  });
+
+  it('does not start sync when running ack fails', async () => {
+    const adapter = makeAdapter(baseBotConfig({ notionSyncRequested: true }));
+    vi.mocked(adapter.ackNotionSync).mockRejectedValueOnce(new Error('ack failed'));
+
+    const worker = new ConfigSyncWorker(adapter);
+    await worker.sync();
+
+    await vi.waitFor(() => {
+      expect(adapter.ackNotionSync).toHaveBeenCalledTimes(1);
+    });
+    expect(adapter.ackNotionSync).toHaveBeenCalledWith('running', undefined, 'manual');
+    expect(runNotionSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bot/src/__tests__/wikiSyncScheduler.test.ts
+++ b/apps/bot/src/__tests__/wikiSyncScheduler.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TrackerAdapter } from '../services/adapter';
+import { WikiSyncScheduler } from '../services/wikiSyncScheduler';
+import { currentWikiSyncOwner, tryAcquireWikiSync } from '../services/wikiSyncLock';
+import { runNotionSync } from '../scripts/discord-notion-sync';
+
+vi.mock('../config', () => ({
+  config: {
+    botToken: 'bot-token',
+    discordGuildId: 'guild-1',
+    notionToken: 'manual-notion-token',
+    webAppBaseUrl: 'https://web.example',
+    webAppApiToken: 'legacy-token',
+    webAppApiReadToken: 'read-token',
+    webAppApiWriteToken: 'write-token',
+    notionSyncMsgLimit: 321,
+  },
+}));
+
+vi.mock('../logger', () => ({
+  logEvent: vi.fn(),
+  errorToMessage: (err: unknown) => String(err),
+}));
+
+vi.mock('../scripts/discord-notion-sync', () => ({
+  runNotionSync: vi.fn(),
+}));
+
+function makeAdapter(): TrackerAdapter {
+  return {
+    ackNotionSync: vi.fn(async () => {}),
+  } as unknown as TrackerAdapter;
+}
+
+function makeScheduler(adapter: TrackerAdapter) {
+  return new WikiSyncScheduler(adapter, {
+    enabled: true,
+    hourLocal: 4,
+    minuteLocal: 0,
+    timezone: 'UTC',
+    intervalMs: 60_000,
+  });
+}
+
+describe('WikiSyncScheduler orchestration', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    expect(currentWikiSyncOwner()).toBeNull();
+    vi.clearAllMocks();
+  });
+
+  it('runs scheduled sync with wiki-only notion token and acks running/success', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T04:01:00.000Z'));
+    vi.mocked(runNotionSync).mockResolvedValueOnce({ success: true });
+    const adapter = makeAdapter();
+    const scheduler = makeScheduler(adapter);
+    (scheduler as unknown as { lastTickTime: Date }).lastTickTime = new Date('2026-01-02T03:59:00.000Z');
+
+    await (scheduler as unknown as { tick: () => Promise<void> }).tick();
+
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled');
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'success', undefined, 'scheduled');
+    expect(runNotionSync).toHaveBeenCalledWith({
+      botToken: 'bot-token',
+      guildId: 'guild-1',
+      notionToken: '',
+      webBase: 'https://web.example',
+      webReadToken: 'read-token',
+      webWriteToken: 'write-token',
+      msgLimit: 321,
+    });
+  });
+
+  it('skips scheduled sync when shared wiki lock is already held', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T04:01:00.000Z'));
+    const adapter = makeAdapter();
+    const scheduler = makeScheduler(adapter);
+    (scheduler as unknown as { lastTickTime: Date }).lastTickTime = new Date('2026-01-02T03:59:00.000Z');
+    const lease = tryAcquireWikiSync('manual');
+    expect(lease).not.toBeNull();
+
+    await (scheduler as unknown as { tick: () => Promise<void> }).tick();
+
+    expect(adapter.ackNotionSync).not.toHaveBeenCalled();
+    expect(runNotionSync).not.toHaveBeenCalled();
+    lease?.release();
+  });
+
+  it('acks running/error when scheduled sync returns failure', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T04:01:00.000Z'));
+    vi.mocked(runNotionSync).mockResolvedValueOnce({ success: false, error: 'boom' });
+    const adapter = makeAdapter();
+    const scheduler = makeScheduler(adapter);
+    (scheduler as unknown as { lastTickTime: Date }).lastTickTime = new Date('2026-01-02T03:59:00.000Z');
+
+    await (scheduler as unknown as { tick: () => Promise<void> }).tick();
+
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled');
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'error', 'boom', 'scheduled');
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated unit tests for `ConfigSyncWorker` sync orchestration behavior
- add dedicated unit tests for `WikiSyncScheduler` lock/ack behavior and wiki-only scheduled sync payload
- refresh `apps/bot/BOT_MEMORY.md` to reflect new coverage and remaining gaps

## What is covered
- `ConfigSyncWorker`
  - skips manual sync when shared wiki lock is already held
  - manual request path acks `running` then `success`
  - short-circuits when `running` ack fails
- `WikiSyncScheduler`
  - scheduled trigger acks `running` then `success` and sends `notionToken: ''`
  - skips when lock is busy
  - acks `error` when sync returns failure

## Validation
- `npm test -- --run src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`
- `npm run typecheck`
