### PR TITLE
Add persisted Notion sync history to web settings

### DIFF
--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -21,6 +21,7 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `/api/bot-restart-ack`
   - `/api/notion-sync-ack`
   - `/api/bot-log`
+- Web now stores sync lifecycle history in `notion_sync_events` (append-only, bounded).
 
 ## Bot Runtime (Current)
 - Entry point: `apps/bot/src/index.ts`
@@ -56,7 +57,7 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 - `runNotionSync` is still a large monolithic script (1218 LOC) doing both Notion and Wiki writes.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
-- Scheduled vs manual sync source is persisted (`BOT_NOTION_SYNC_SOURCE`) for operator context, but no historical run log exists beyond current status keys.
+- Scheduled vs manual sync source is persisted (`BOT_NOTION_SYNC_SOURCE`) and mirrored into `notion_sync_events`; run correlation IDs are still not captured.
 
 ## Operational Files to Keep in Mind
 - Bot local state:

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -990,7 +990,7 @@ def set_reminder_pref(discord_id):
 def notion_sync_ack():
     """Bot calls this to report Notion sync status."""
     from datetime import datetime, timezone
-    from app.db import AppSetting, db
+    from app.db import AppSetting, NotionSyncEvent, db
     data = request.get_json(silent=True) or {}
     status = data.get('status')
     if status not in ('running', 'success', 'error'):
@@ -1032,7 +1032,30 @@ def notion_sync_ack():
         upsert('BOT_NOTION_SYNC_SOURCE', source)
         upsert('BOT_NOTION_SYNC_FINISHED_AT', now)
         upsert('BOT_NOTION_SYNC_ERROR', data.get('error', 'unknown error'))
+
+    db.session.add(
+        NotionSyncEvent(
+            ts=now,
+            source=source,
+            status=status,
+            error=(str(data.get('error') or '')[:2000]),
+            created_at=datetime.now(timezone.utc),
+        )
+    )
     db.session.commit()
+
+    # Keep a bounded sync history to avoid unbounded growth.
+    cutoff_query = (
+        db.session.query(NotionSyncEvent.id)
+        .order_by(NotionSyncEvent.created_at.desc())
+        .offset(500)
+        .limit(1)
+        .scalar()
+    )
+    if cutoff_query:
+        db.session.query(NotionSyncEvent).filter(NotionSyncEvent.id <= cutoff_query).delete()
+        db.session.commit()
+
     return jsonify({'ok': True})
 
 

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -210,7 +210,7 @@ def index():
         'BOT_PASSAGE_OF_TIME_ENABLED': 'BOT_LIVE_PASSAGE_OF_TIME_ENABLED',
         'BOT_HUNT_CONSEQUENCE_ENABLED': 'BOT_LIVE_HUNT_CONSEQUENCE_ENABLED',
     }
-    from app.db import AppSetting
+    from app.db import AppSetting, NotionSyncEvent
     live_keys = list(LIVE_KEY_MAP.values())
     live_records = {r.key: r for r in AppSetting.query.filter(AppSetting.key.in_(live_keys)).all()}
 
@@ -410,6 +410,15 @@ def index():
         'stale_after_seconds': _notion_stale_after_seconds,
         'is_stale': _notion_is_stale,
     }
+    notion_sync_history = [
+        {
+            'ts': row.ts,
+            'source': row.source,
+            'status': row.status,
+            'error': row.error or '',
+        }
+        for row in NotionSyncEvent.query.order_by(NotionSyncEvent.created_at.desc()).limit(12).all()
+    ]
 
     return render_template(
         'settings/index.html',
@@ -424,6 +433,7 @@ def index():
         bot_heartbeat_ts=bot_heartbeat_ts,
         bot_restart_pending=_restart_pending,
         notion_sync=notion_sync,
+        notion_sync_history=notion_sync_history,
     )
 
 

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -139,6 +139,17 @@ class AppSetting(db.Model):
     updated_at = db.Column(DateTime, nullable=False, default=datetime.utcnow)
 
 
+class NotionSyncEvent(db.Model):
+    """Append-only history of Notion/wiki sync lifecycle events."""
+    __tablename__ = 'notion_sync_events'
+    id = db.Column(Integer, primary_key=True)
+    ts = db.Column(String(30), nullable=False)
+    source = db.Column(String(16), nullable=False)  # manual | scheduled
+    status = db.Column(String(16), nullable=False)  # running | success | error
+    error = db.Column(Text, default='')
+    created_at = db.Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
+
+
 class DbSheetsSyncError(db.Model):
     __tablename__ = 'sheets_sync_errors'
     id = db.Column(Integer, primary_key=True)

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -279,6 +279,50 @@
         <span class="badge bg-secondary">Never run</span>
         <small class="text-muted ms-2">Click <strong>Run Notion Sync</strong> to populate the Notion page from Discord.</small>
       {% endif %}
+
+      {% if notion_sync_history %}
+      <div class="mt-3 pt-3 border-top border-secondary">
+        <small class="text-muted d-block mb-2">Recent sync events</small>
+        <div class="table-responsive">
+          <table class="table table-dark table-sm mb-0 align-middle">
+            <thead>
+              <tr>
+                <th style="width:180px">Timestamp (UTC)</th>
+                <th style="width:100px">Source</th>
+                <th style="width:100px">Status</th>
+                <th>Error</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for event in notion_sync_history %}
+              <tr>
+                <td class="small text-muted">{{ event.ts[:19] | replace('T', ' ') }}</td>
+                <td>
+                  {% if event.source == 'scheduled' %}
+                    <span class="badge bg-secondary">Scheduled</span>
+                  {% else %}
+                    <span class="badge bg-dark border border-secondary">Manual</span>
+                  {% endif %}
+                </td>
+                <td>
+                  {% if event.status == 'success' %}
+                    <span class="badge bg-success">Success</span>
+                  {% elif event.status == 'error' %}
+                    <span class="badge bg-danger">Error</span>
+                  {% else %}
+                    <span class="badge bg-info text-dark">Running</span>
+                  {% endif %}
+                </td>
+                <td class="small {% if event.status == 'error' and event.error %}text-danger{% else %}text-muted{% endif %}">
+                  {{ event.error if event.error else '—' }}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
 

--- a/apps/web/migrations/versions/a6e9d2c7f4b1_add_notion_sync_events_table.py
+++ b/apps/web/migrations/versions/a6e9d2c7f4b1_add_notion_sync_events_table.py
@@ -1,0 +1,34 @@
+"""add notion_sync_events table
+
+Revision ID: a6e9d2c7f4b1
+Revises: f3a7b91e45c2
+Create Date: 2026-04-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a6e9d2c7f4b1'
+down_revision = 'f3a7b91e45c2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'notion_sync_events',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('ts', sa.String(30), nullable=False),
+        sa.Column('source', sa.String(16), nullable=False),
+        sa.Column('status', sa.String(16), nullable=False),
+        sa.Column('error', sa.Text, server_default=''),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+    )
+    op.create_index('ix_notion_sync_events_created_at', 'notion_sync_events', ['created_at'])
+
+
+def downgrade():
+    op.drop_index('ix_notion_sync_events_created_at', table_name='notion_sync_events')
+    op.drop_table('notion_sync_events')

--- a/apps/web/tests/test_notion_sync_ack.py
+++ b/apps/web/tests/test_notion_sync_ack.py
@@ -3,7 +3,7 @@
 from flask import Flask
 
 from app.blueprints.api import bp as api_bp
-from app.db import AppSetting, db
+from app.db import AppSetting, NotionSyncEvent, db
 
 
 def _app():
@@ -43,6 +43,11 @@ def test_running_ack_manual_clears_request_flag():
         assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
         assert AppSetting.query.get('BOT_NOTION_SYNC_STATUS').value == 'running'
         assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'manual'
+        event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
+        assert event is not None
+        assert event.status == 'running'
+        assert event.source == 'manual'
+        assert event.error == ''
 
 
 def test_running_ack_scheduled_does_not_clear_request_flag():
@@ -59,6 +64,9 @@ def test_running_ack_scheduled_does_not_clear_request_flag():
     with app.app_context():
         assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is not None
         assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'scheduled'
+        event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
+        assert event is not None
+        assert event.source == 'scheduled'
 
 
 def test_running_ack_defaults_source_to_manual():
@@ -75,6 +83,9 @@ def test_running_ack_defaults_source_to_manual():
     with app.app_context():
         assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
         assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'manual'
+        event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
+        assert event is not None
+        assert event.source == 'manual'
 
 
 def test_ack_rejects_invalid_source():
@@ -87,3 +98,21 @@ def test_ack_rejects_invalid_source():
         )
         assert res.status_code == 400
         assert 'source must be manual or scheduled' in res.get_json()['error']
+
+
+def test_error_ack_persists_event_error_message():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post(
+            '/api/notion-sync-ack',
+            headers={'Authorization': 'Bearer write-token'},
+            json={'status': 'error', 'source': 'scheduled', 'error': 'sync exploded'},
+        )
+        assert res.status_code == 200
+
+    with app.app_context():
+        event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
+        assert event is not None
+        assert event.status == 'error'
+        assert event.source == 'scheduled'
+        assert event.error == 'sync exploded'

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -157,6 +157,7 @@ Behavior notes:
 - `status=running` with `source=manual` clears `BOT_NOTION_SYNC_REQUESTED`.
 - `status=running` with `source=scheduled` **does not** clear `BOT_NOTION_SYNC_REQUESTED` (prevents scheduled runs from consuming staff-queued manual runs).
 - Web stores `BOT_NOTION_SYNC_SOURCE` for UI/operator context.
+- Each ack appends a row to `notion_sync_events` (bounded history) for operator visibility in Settings.
 
 **Response 200:**
 ```json

--- a/docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md
+++ b/docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md
@@ -1,0 +1,17 @@
+# Release: 2026-04-17 Notion Sync History
+
+## Summary
+
+Adds persistent, operator-visible history for Notion/wiki sync lifecycle events.
+
+## What Changed
+
+- Added DB table `notion_sync_events` (migration + model).
+- `/api/notion-sync-ack` now appends an event row on every ack (`running|success|error`, `manual|scheduled`, optional error).
+- Settings page now shows recent sync history rows under the Notion Sync card.
+- History is bounded server-side (keeps most recent 500 events).
+
+## Validation
+
+- `pytest -q apps/web/tests/test_notion_sync_ack.py apps/web/tests/test_settings_notion_sync_reset.py`
+- `python3 -m py_compile apps/web/app/db.py apps/web/app/blueprints/api.py apps/web/app/blueprints/settings.py`

--- a/docs/WEB_APP.md
+++ b/docs/WEB_APP.md
@@ -93,6 +93,7 @@ The Settings page includes web-app runtime controls plus bot operations panels.
 - Manual **Run Notion Sync** queue button for staff.
 - Live sync state badges (Queued / Running / Success / Error / Stale).
 - `Reset Stale` action for settings admins to clear stuck sync status keys and safely requeue.
+- Recent sync history table (source, status, timestamp, error) backed by persisted `notion_sync_events`.
 
 ![Settings](screenshots/settings.png)
 


### PR DESCRIPTION
## Summary
- add a persisted `notion_sync_events` table for Notion/wiki sync lifecycle history
- append a history row from every `/api/notion-sync-ack` call (`source`, `status`, `error`, timestamp)
- surface recent sync history in Settings under the Notion Sync panel
- update tests, docs, and repo memory to reflect the new operator visibility

## Key Changes
- DB/model:
  - `apps/web/app/db.py`: new `NotionSyncEvent` model
  - migration: `apps/web/migrations/versions/a6e9d2c7f4b1_add_notion_sync_events_table.py`
- API:
  - `apps/web/app/blueprints/api.py` now appends history events in `notion_sync_ack`
  - bounded retention (most recent 500 events)
- Settings:
  - `apps/web/app/blueprints/settings.py` reads latest 12 events
  - `apps/web/app/templates/settings/index.html` renders recent event table
- Tests:
  - `apps/web/tests/test_notion_sync_ack.py` asserts event persistence and error capture

## Validation
- `pytest -q apps/web/tests/test_notion_sync_ack.py apps/web/tests/test_settings_notion_sync_reset.py`
- `python3 -m py_compile apps/web/app/db.py apps/web/app/blueprints/api.py apps/web/app/blueprints/settings.py`
