### PR TITLE
Add runId correlation to Notion sync status and history

### DIFF
--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -21,7 +21,7 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `/api/bot-restart-ack`
   - `/api/notion-sync-ack`
   - `/api/bot-log`
-- Web now stores sync lifecycle history in `notion_sync_events` (append-only, bounded).
+- Web now stores sync lifecycle history in `notion_sync_events` (append-only, bounded), including `run_id` correlation.
 
 ## Bot Runtime (Current)
 - Entry point: `apps/bot/src/index.ts`
@@ -57,7 +57,7 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 - `runNotionSync` is still a large monolithic script (1218 LOC) doing both Notion and Wiki writes.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
-- Scheduled vs manual sync source is persisted (`BOT_NOTION_SYNC_SOURCE`) and mirrored into `notion_sync_events`; run correlation IDs are still not captured.
+- Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.
 
 ## Operational Files to Keep in Mind
 - Bot local state:

--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -93,8 +93,12 @@ describe('ConfigSyncWorker sync orchestration', () => {
       webWriteToken: 'write-token',
       msgLimit: 123,
     });
-    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'manual');
-    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'success', undefined, 'manual');
+    const firstRunId = vi.mocked(adapter.ackNotionSync).mock.calls[0][3];
+    const secondRunId = vi.mocked(adapter.ackNotionSync).mock.calls[1][3];
+    expect(firstRunId).toEqual(expect.any(String));
+    expect(secondRunId).toBe(firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'manual', firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'success', undefined, 'manual', firstRunId);
   });
 
   it('does not start sync when running ack fails', async () => {
@@ -107,7 +111,9 @@ describe('ConfigSyncWorker sync orchestration', () => {
     await vi.waitFor(() => {
       expect(adapter.ackNotionSync).toHaveBeenCalledTimes(1);
     });
-    expect(adapter.ackNotionSync).toHaveBeenCalledWith('running', undefined, 'manual');
+    const firstRunId = vi.mocked(adapter.ackNotionSync).mock.calls[0][3];
+    expect(firstRunId).toEqual(expect.any(String));
+    expect(adapter.ackNotionSync).toHaveBeenCalledWith('running', undefined, 'manual', firstRunId);
     expect(runNotionSync).not.toHaveBeenCalled();
   });
 });

--- a/apps/bot/src/__tests__/wikiSyncScheduler.test.ts
+++ b/apps/bot/src/__tests__/wikiSyncScheduler.test.ts
@@ -109,4 +109,23 @@ describe('WikiSyncScheduler orchestration', () => {
     expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled', firstRunId);
     expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'error', 'boom', 'scheduled', firstRunId);
   });
+
+  it('preserves runId on thrown scheduled sync errors', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T04:01:00.000Z'));
+    vi.mocked(runNotionSync).mockRejectedValueOnce(new Error('kaboom'));
+    const adapter = makeAdapter();
+    const scheduler = makeScheduler(adapter);
+    (scheduler as unknown as { lastTickTime: Date }).lastTickTime = new Date('2026-01-02T03:59:00.000Z');
+
+    await (scheduler as unknown as { tick: () => Promise<void> }).tick();
+
+    expect(adapter.ackNotionSync).toHaveBeenCalledTimes(2);
+    const firstRunId = vi.mocked(adapter.ackNotionSync).mock.calls[0][3];
+    const secondRunId = vi.mocked(adapter.ackNotionSync).mock.calls[1][3];
+    expect(firstRunId).toEqual(expect.any(String));
+    expect(secondRunId).toBe(firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled', firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'error', 'Error: kaboom', 'scheduled', firstRunId);
+  });
 });

--- a/apps/bot/src/__tests__/wikiSyncScheduler.test.ts
+++ b/apps/bot/src/__tests__/wikiSyncScheduler.test.ts
@@ -59,8 +59,12 @@ describe('WikiSyncScheduler orchestration', () => {
 
     await (scheduler as unknown as { tick: () => Promise<void> }).tick();
 
-    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled');
-    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'success', undefined, 'scheduled');
+    const firstRunId = vi.mocked(adapter.ackNotionSync).mock.calls[0][3];
+    const secondRunId = vi.mocked(adapter.ackNotionSync).mock.calls[1][3];
+    expect(firstRunId).toEqual(expect.any(String));
+    expect(secondRunId).toBe(firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled', firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'success', undefined, 'scheduled', firstRunId);
     expect(runNotionSync).toHaveBeenCalledWith({
       botToken: 'bot-token',
       guildId: 'guild-1',
@@ -98,7 +102,11 @@ describe('WikiSyncScheduler orchestration', () => {
 
     await (scheduler as unknown as { tick: () => Promise<void> }).tick();
 
-    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled');
-    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'error', 'boom', 'scheduled');
+    const firstRunId = vi.mocked(adapter.ackNotionSync).mock.calls[0][3];
+    const secondRunId = vi.mocked(adapter.ackNotionSync).mock.calls[1][3];
+    expect(firstRunId).toEqual(expect.any(String));
+    expect(secondRunId).toBe(firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(1, 'running', undefined, 'scheduled', firstRunId);
+    expect(adapter.ackNotionSync).toHaveBeenNthCalledWith(2, 'error', 'boom', 'scheduled', firstRunId);
   });
 });

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -64,6 +64,7 @@ export interface TrackerAdapter {
     status: 'running' | 'success' | 'error',
     error?: string,
     source?: 'manual' | 'scheduled',
+    runId?: string,
   ): Promise<void>;
   postBotLog(entries: Array<Record<string, unknown>>): Promise<void>;
   postHeartbeat(liveState?: Record<string, boolean>): Promise<void>;
@@ -562,12 +563,13 @@ export class WebAppAdapter implements TrackerAdapter {
     status: 'running' | 'success' | 'error',
     error?: string,
     source: 'manual' | 'scheduled' = 'manual',
+    runId?: string,
   ): Promise<void> {
     const url = `${this.baseUrl}/api/notion-sync-ack`;
     const res = await this.fetchWithTimeout(url, {
       method: 'POST',
       headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status, source, ...(error ? { error } : {}) }),
+      body: JSON.stringify({ status, source, ...(runId ? { runId } : {}), ...(error ? { error } : {}) }),
     });
     if (!res.ok) throw new Error(`notion-sync-ack POST failed: ${res.status}`);
   }

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -1,6 +1,7 @@
 import { liveConfig } from '../liveConfig';
 import { logEvent } from '../logger';
 import { config } from '../config';
+import { randomUUID } from 'node:crypto';
 import type { TrackerAdapter } from './adapter';
 import { runNotionSync } from '../scripts/discord-notion-sync';
 import { currentWikiSyncOwner, tryAcquireWikiSync } from './wikiSyncLock';
@@ -62,9 +63,10 @@ export class ConfigSyncWorker {
       return;
     }
     this.notionSyncRunning = true;
+    const runId = randomUUID();
     logEvent('info', 'notion_sync_starting', {});
     try {
-      await this.adapter.ackNotionSync('running', undefined, 'manual');
+      await this.adapter.ackNotionSync('running', undefined, 'manual', runId);
     } catch (err) {
       logEvent('warn', 'notion_sync_ack_running_failed', { error: String(err) });
       lease.release();
@@ -83,14 +85,14 @@ export class ConfigSyncWorker {
       });
       if (result.success) {
         logEvent('info', 'notion_sync_completed', {});
-        await this.adapter.ackNotionSync('success', undefined, 'manual');
+        await this.adapter.ackNotionSync('success', undefined, 'manual', runId);
       } else {
         logEvent('warn', 'notion_sync_failed', { error: result.error });
-        await this.adapter.ackNotionSync('error', result.error, 'manual');
+        await this.adapter.ackNotionSync('error', result.error, 'manual', runId);
       }
     } catch (err) {
       logEvent('warn', 'notion_sync_error', { error: String(err) });
-      try { await this.adapter.ackNotionSync('error', String(err), 'manual'); } catch { /* ignore */ }
+      try { await this.adapter.ackNotionSync('error', String(err), 'manual', runId); } catch { /* ignore */ }
     } finally {
       lease.release();
       this.notionSyncRunning = false;

--- a/apps/bot/src/services/wikiSyncScheduler.ts
+++ b/apps/bot/src/services/wikiSyncScheduler.ts
@@ -9,6 +9,7 @@
 
 import { errorToMessage, logEvent } from '../logger';
 import { config } from '../config';
+import { randomUUID } from 'node:crypto';
 import type { TrackerAdapter } from './adapter';
 import { runNotionSync } from '../scripts/discord-notion-sync';
 import { currentWikiSyncOwner, tryAcquireWikiSync } from './wikiSyncLock';
@@ -117,6 +118,7 @@ export class WikiSyncScheduler {
       }
 
       logEvent('info', 'wiki_sync_scheduled_triggered', { dateKey: parts.dateKey });
+      const runId = randomUUID();
       lease = tryAcquireWikiSync('scheduled');
       if (!lease) {
         logEvent('info', 'wiki_sync_scheduled_skipped_lock_busy', {
@@ -126,7 +128,7 @@ export class WikiSyncScheduler {
         return;
       }
       try {
-        await this.adapter.ackNotionSync('running', undefined, 'scheduled');
+        await this.adapter.ackNotionSync('running', undefined, 'scheduled', runId);
       } catch (ackErr) {
         logEvent('warn', 'wiki_sync_ack_running_failed', { error: errorToMessage(ackErr) });
       }
@@ -145,10 +147,10 @@ export class WikiSyncScheduler {
 
       if (result.success) {
         logEvent('info', 'wiki_sync_scheduled_complete', { dateKey: parts.dateKey });
-        try { await this.adapter.ackNotionSync('success', undefined, 'scheduled'); } catch { /* ignore */ }
+        try { await this.adapter.ackNotionSync('success', undefined, 'scheduled', runId); } catch { /* ignore */ }
       } else {
         logEvent('warn', 'wiki_sync_scheduled_failed', { dateKey: parts.dateKey, error: result.error });
-        try { await this.adapter.ackNotionSync('error', result.error, 'scheduled'); } catch { /* ignore */ }
+        try { await this.adapter.ackNotionSync('error', result.error, 'scheduled', runId); } catch { /* ignore */ }
       }
     } catch (error) {
       logEvent('warn', 'wiki_sync_scheduler_error', { error: errorToMessage(error) });

--- a/apps/bot/src/services/wikiSyncScheduler.ts
+++ b/apps/bot/src/services/wikiSyncScheduler.ts
@@ -88,6 +88,7 @@ export class WikiSyncScheduler {
     if (this.running) return;
     this.running = true;
     let lease: ReturnType<typeof tryAcquireWikiSync> | null = null;
+    let runId: string | undefined;
     try {
       const now = new Date();
       const parts = localParts(now, this.cfg.timezone);
@@ -118,7 +119,7 @@ export class WikiSyncScheduler {
       }
 
       logEvent('info', 'wiki_sync_scheduled_triggered', { dateKey: parts.dateKey });
-      const runId = randomUUID();
+      runId = randomUUID();
       lease = tryAcquireWikiSync('scheduled');
       if (!lease) {
         logEvent('info', 'wiki_sync_scheduled_skipped_lock_busy', {
@@ -154,7 +155,7 @@ export class WikiSyncScheduler {
       }
     } catch (error) {
       logEvent('warn', 'wiki_sync_scheduler_error', { error: errorToMessage(error) });
-      try { await this.adapter.ackNotionSync('error', String(error), 'scheduled'); } catch { /* ignore */ }
+      try { await this.adapter.ackNotionSync('error', String(error), 'scheduled', runId); } catch { /* ignore */ }
     } finally {
       lease?.release();
       this.running = false;

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -998,6 +998,9 @@ def notion_sync_ack():
     source = str(data.get('source', 'manual')).strip().lower()
     if source not in ('manual', 'scheduled'):
         return jsonify({'error': 'source must be manual or scheduled'}), 400
+    run_id = str(data.get('runId', '')).strip()
+    if len(run_id) > 64:
+        return jsonify({'error': 'runId must be at most 64 characters'}), 400
     now = datetime.now(timezone.utc).isoformat()
 
     def upsert(key, value):
@@ -1019,23 +1022,36 @@ def notion_sync_ack():
             delete_key('BOT_NOTION_SYNC_REQUESTED')
         upsert('BOT_NOTION_SYNC_STATUS', 'running')
         upsert('BOT_NOTION_SYNC_SOURCE', source)
+        if run_id:
+            upsert('BOT_NOTION_SYNC_RUN_ID', run_id)
+        else:
+            delete_key('BOT_NOTION_SYNC_RUN_ID')
         upsert('BOT_NOTION_SYNC_STARTED_AT', now)
         delete_key('BOT_NOTION_SYNC_FINISHED_AT')
         delete_key('BOT_NOTION_SYNC_ERROR')
     elif status == 'success':
         upsert('BOT_NOTION_SYNC_STATUS', 'success')
         upsert('BOT_NOTION_SYNC_SOURCE', source)
+        if run_id:
+            upsert('BOT_NOTION_SYNC_RUN_ID', run_id)
+        else:
+            delete_key('BOT_NOTION_SYNC_RUN_ID')
         upsert('BOT_NOTION_SYNC_FINISHED_AT', now)
         delete_key('BOT_NOTION_SYNC_ERROR')
     else:
         upsert('BOT_NOTION_SYNC_STATUS', 'error')
         upsert('BOT_NOTION_SYNC_SOURCE', source)
+        if run_id:
+            upsert('BOT_NOTION_SYNC_RUN_ID', run_id)
+        else:
+            delete_key('BOT_NOTION_SYNC_RUN_ID')
         upsert('BOT_NOTION_SYNC_FINISHED_AT', now)
         upsert('BOT_NOTION_SYNC_ERROR', data.get('error', 'unknown error'))
 
     db.session.add(
         NotionSyncEvent(
             ts=now,
+            run_id=run_id,
             source=source,
             status=status,
             error=(str(data.get('error') or '')[:2000]),

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -383,6 +383,7 @@ def index():
     # ── Notion sync status ─────────────────────────────────────────────────
     _notion_sync_requested = 'BOT_NOTION_SYNC_REQUESTED' in overrides and overrides['BOT_NOTION_SYNC_REQUESTED'].value.lower() in ('true', '1', 'yes')
     _notion_status_rec = AppSetting.query.get('BOT_NOTION_SYNC_STATUS')
+    _notion_run_id_rec = AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID')
     _notion_started_rec = AppSetting.query.get('BOT_NOTION_SYNC_STARTED_AT')
     _notion_finished_rec = AppSetting.query.get('BOT_NOTION_SYNC_FINISHED_AT')
     _notion_error_rec = AppSetting.query.get('BOT_NOTION_SYNC_ERROR')
@@ -402,6 +403,7 @@ def index():
     notion_sync = {
         'requested': _notion_sync_requested,
         'status': _notion_status_rec.value if _notion_status_rec else None,
+        'run_id': _notion_run_id_rec.value if _notion_run_id_rec else None,
         'started_at': _notion_started_at,
         'finished_at': _notion_finished_rec.value if _notion_finished_rec else None,
         'error': _notion_error_rec.value if _notion_error_rec else None,
@@ -413,6 +415,7 @@ def index():
     notion_sync_history = [
         {
             'ts': row.ts,
+            'run_id': row.run_id or '',
             'source': row.source,
             'status': row.status,
             'error': row.error or '',
@@ -465,6 +468,7 @@ def reset_notion_sync():
     reset_keys = (
         'BOT_NOTION_SYNC_REQUESTED',
         'BOT_NOTION_SYNC_STATUS',
+        'BOT_NOTION_SYNC_RUN_ID',
         'BOT_NOTION_SYNC_STARTED_AT',
         'BOT_NOTION_SYNC_FINISHED_AT',
         'BOT_NOTION_SYNC_ERROR',

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -144,6 +144,7 @@ class NotionSyncEvent(db.Model):
     __tablename__ = 'notion_sync_events'
     id = db.Column(Integer, primary_key=True)
     ts = db.Column(String(30), nullable=False)
+    run_id = db.Column(String(64), default='', index=True)
     source = db.Column(String(16), nullable=False)  # manual | scheduled
     status = db.Column(String(16), nullable=False)  # running | success | error
     error = db.Column(Text, default='')

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -259,10 +259,16 @@
         {% if notion_sync.started_at %}
           <small class="text-muted ms-2">Started {{ notion_sync.started_at[:19] | replace('T', ' ') }} UTC</small>
         {% endif %}
+        {% if notion_sync.run_id %}
+          <small class="text-muted d-block mt-1">Run ID: <code>{{ notion_sync.run_id }}</code></small>
+        {% endif %}
       {% elif notion_sync.status == 'success' %}
         <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Success</span>
         {% if notion_sync.finished_at %}
           <small class="text-muted ms-2">Completed {{ notion_sync.finished_at[:19] | replace('T', ' ') }} UTC</small>
+        {% endif %}
+        {% if notion_sync.run_id %}
+          <small class="text-muted d-block mt-1">Run ID: <code>{{ notion_sync.run_id }}</code></small>
         {% endif %}
       {% elif notion_sync.status == 'error' %}
         <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Error</span>
@@ -271,6 +277,9 @@
         {% endif %}
         {% if notion_sync.started_at %}
           <small class="text-muted ms-2">(started {{ notion_sync.started_at[:19] | replace('T', ' ') }} UTC)</small>
+        {% endif %}
+        {% if notion_sync.run_id %}
+          <small class="text-muted d-block mt-1">Run ID: <code>{{ notion_sync.run_id }}</code></small>
         {% endif %}
       {% elif notion_sync.requested %}
         <span class="badge bg-secondary">Queued</span>
@@ -288,6 +297,7 @@
             <thead>
               <tr>
                 <th style="width:180px">Timestamp (UTC)</th>
+                <th style="width:220px">Run ID</th>
                 <th style="width:100px">Source</th>
                 <th style="width:100px">Status</th>
                 <th>Error</th>
@@ -297,6 +307,7 @@
               {% for event in notion_sync_history %}
               <tr>
                 <td class="small text-muted">{{ event.ts[:19] | replace('T', ' ') }}</td>
+                <td class="small font-monospace text-muted">{{ event.run_id if event.run_id else '—' }}</td>
                 <td>
                   {% if event.source == 'scheduled' %}
                     <span class="badge bg-secondary">Scheduled</span>

--- a/apps/web/migrations/versions/b7c1f2d9a4e6_add_run_id_to_notion_sync_events.py
+++ b/apps/web/migrations/versions/b7c1f2d9a4e6_add_run_id_to_notion_sync_events.py
@@ -1,0 +1,26 @@
+"""add run_id to notion_sync_events
+
+Revision ID: b7c1f2d9a4e6
+Revises: a6e9d2c7f4b1
+Create Date: 2026-04-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7c1f2d9a4e6'
+down_revision = 'a6e9d2c7f4b1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('notion_sync_events', sa.Column('run_id', sa.String(length=64), nullable=False, server_default=''))
+    op.create_index('ix_notion_sync_events_run_id', 'notion_sync_events', ['run_id'])
+
+
+def downgrade():
+    op.drop_index('ix_notion_sync_events_run_id', table_name='notion_sync_events')
+    op.drop_column('notion_sync_events', 'run_id')

--- a/apps/web/tests/test_notion_sync_ack.py
+++ b/apps/web/tests/test_notion_sync_ack.py
@@ -35,7 +35,7 @@ def test_running_ack_manual_clears_request_flag():
         res = client.post(
             '/api/notion-sync-ack',
             headers={'Authorization': 'Bearer write-token'},
-            json={'status': 'running', 'source': 'manual'},
+            json={'status': 'running', 'source': 'manual', 'runId': 'run-manual-1'},
         )
         assert res.status_code == 200
 
@@ -43,10 +43,12 @@ def test_running_ack_manual_clears_request_flag():
         assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
         assert AppSetting.query.get('BOT_NOTION_SYNC_STATUS').value == 'running'
         assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'manual'
+        assert AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID').value == 'run-manual-1'
         event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
         assert event is not None
         assert event.status == 'running'
         assert event.source == 'manual'
+        assert event.run_id == 'run-manual-1'
         assert event.error == ''
 
 
@@ -64,9 +66,11 @@ def test_running_ack_scheduled_does_not_clear_request_flag():
     with app.app_context():
         assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is not None
         assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'scheduled'
+        assert AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID') is None
         event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
         assert event is not None
         assert event.source == 'scheduled'
+        assert event.run_id == ''
 
 
 def test_running_ack_defaults_source_to_manual():
@@ -83,9 +87,11 @@ def test_running_ack_defaults_source_to_manual():
     with app.app_context():
         assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
         assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'manual'
+        assert AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID') is None
         event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
         assert event is not None
         assert event.source == 'manual'
+        assert event.run_id == ''
 
 
 def test_ack_rejects_invalid_source():
@@ -100,13 +106,25 @@ def test_ack_rejects_invalid_source():
         assert 'source must be manual or scheduled' in res.get_json()['error']
 
 
+def test_ack_rejects_oversized_run_id():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post(
+            '/api/notion-sync-ack',
+            headers={'Authorization': 'Bearer write-token'},
+            json={'status': 'running', 'source': 'manual', 'runId': 'x' * 65},
+        )
+        assert res.status_code == 400
+        assert 'runId must be at most 64 characters' in res.get_json()['error']
+
+
 def test_error_ack_persists_event_error_message():
     app = _app()
     with app.test_client() as client:
         res = client.post(
             '/api/notion-sync-ack',
             headers={'Authorization': 'Bearer write-token'},
-            json={'status': 'error', 'source': 'scheduled', 'error': 'sync exploded'},
+            json={'status': 'error', 'source': 'scheduled', 'runId': 'run-scheduled-9', 'error': 'sync exploded'},
         )
         assert res.status_code == 200
 
@@ -115,4 +133,5 @@ def test_error_ack_persists_event_error_message():
         assert event is not None
         assert event.status == 'error'
         assert event.source == 'scheduled'
+        assert event.run_id == 'run-scheduled-9'
         assert event.error == 'sync exploded'

--- a/apps/web/tests/test_settings_notion_sync_reset.py
+++ b/apps/web/tests/test_settings_notion_sync_reset.py
@@ -28,6 +28,7 @@ def _seed_sync_records(app: Flask):
         for key, value in (
             ('BOT_NOTION_SYNC_REQUESTED', 'true'),
             ('BOT_NOTION_SYNC_STATUS', 'running'),
+            ('BOT_NOTION_SYNC_RUN_ID', 'run-abc'),
             ('BOT_NOTION_SYNC_STARTED_AT', '2026-04-17T00:00:00+00:00'),
             ('BOT_NOTION_SYNC_FINISHED_AT', '2026-04-17T00:10:00+00:00'),
             ('BOT_NOTION_SYNC_ERROR', 'boom'),
@@ -57,6 +58,7 @@ def test_reset_notion_sync_clears_sync_state_for_admin():
         for key in (
             'BOT_NOTION_SYNC_REQUESTED',
             'BOT_NOTION_SYNC_STATUS',
+            'BOT_NOTION_SYNC_RUN_ID',
             'BOT_NOTION_SYNC_STARTED_AT',
             'BOT_NOTION_SYNC_FINISHED_AT',
             'BOT_NOTION_SYNC_ERROR',

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -143,7 +143,8 @@ Bot status callback for wiki/Notion sync runs.
 ```json
 {
   "status": "running",
-  "source": "manual"
+  "source": "manual",
+  "runId": "run-manual-1"
 }
 ```
 
@@ -151,13 +152,14 @@ Bot status callback for wiki/Notion sync runs.
 |-------|----------|--------|-------|
 | `status` | Yes | `running`, `success`, `error` | Current sync lifecycle state |
 | `source` | No | `manual`, `scheduled` | Defaults to `manual` when omitted |
+| `runId` | No | string (<=64 chars) | Correlation ID for one sync run lifecycle |
 | `error` | When `status=error` | string | Human-readable error summary |
 
 Behavior notes:
 - `status=running` with `source=manual` clears `BOT_NOTION_SYNC_REQUESTED`.
 - `status=running` with `source=scheduled` **does not** clear `BOT_NOTION_SYNC_REQUESTED` (prevents scheduled runs from consuming staff-queued manual runs).
 - Web stores `BOT_NOTION_SYNC_SOURCE` for UI/operator context.
-- Each ack appends a row to `notion_sync_events` (bounded history) for operator visibility in Settings.
+- Each ack appends a row to `notion_sync_events` (bounded history) including `runId` when provided.
 
 **Response 200:**
 ```json

--- a/docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md
+++ b/docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md
@@ -7,11 +7,13 @@ Adds persistent, operator-visible history for Notion/wiki sync lifecycle events.
 ## What Changed
 
 - Added DB table `notion_sync_events` (migration + model).
-- `/api/notion-sync-ack` now appends an event row on every ack (`running|success|error`, `manual|scheduled`, optional error).
+- `/api/notion-sync-ack` now appends an event row on every ack (`running|success|error`, `manual|scheduled`, `run_id`, optional error).
 - Settings page now shows recent sync history rows under the Notion Sync card.
 - History is bounded server-side (keeps most recent 500 events).
+- Bot now generates a `runId` per sync run and sends it on all ack phases so lifecycle events correlate cleanly.
 
 ## Validation
 
 - `pytest -q apps/web/tests/test_notion_sync_ack.py apps/web/tests/test_settings_notion_sync_reset.py`
 - `python3 -m py_compile apps/web/app/db.py apps/web/app/blueprints/api.py apps/web/app/blueprints/settings.py`
+- `npm test -- --run src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`

--- a/docs/WEB_APP.md
+++ b/docs/WEB_APP.md
@@ -93,7 +93,7 @@ The Settings page includes web-app runtime controls plus bot operations panels.
 - Manual **Run Notion Sync** queue button for staff.
 - Live sync state badges (Queued / Running / Success / Error / Stale).
 - `Reset Stale` action for settings admins to clear stuck sync status keys and safely requeue.
-- Recent sync history table (source, status, timestamp, error) backed by persisted `notion_sync_events`.
+- Recent sync history table (run ID, source, status, timestamp, error) backed by persisted `notion_sync_events`.
 
 ![Settings](screenshots/settings.png)
 


### PR DESCRIPTION
## Summary
- add sync `runId` correlation from bot -> `/api/notion-sync-ack` -> web status/history
- persist run IDs in both current status (`BOT_NOTION_SYNC_RUN_ID`) and event history (`notion_sync_events.run_id`)
- surface run IDs in Settings for current sync state and recent history rows

## Key Changes
- bot:
  - generate one UUID per sync run in `ConfigSyncWorker` and `WikiSyncScheduler`
  - send `runId` on all running/success/error ack calls
  - extend adapter `ackNotionSync(..., source, runId)`
- web:
  - new migration: `b7c1f2d9a4e6_add_run_id_to_notion_sync_events.py`
  - `NotionSyncEvent` model gains `run_id`
  - `/api/notion-sync-ack` validates optional `runId` (<=64), stores in app settings and history rows
  - settings page renders run ID in current status and history table
  - stale reset also clears `BOT_NOTION_SYNC_RUN_ID`
- tests/docs/memory:
  - bot orchestration tests assert runId propagation consistency
  - web ack/reset tests cover runId behavior
  - docs and BOT memory updated

## Validation
- `npm test -- --run src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`
- `npm test`
- `npm run typecheck` (apps/bot)
- `pytest -q apps/web/tests/test_notion_sync_ack.py apps/web/tests/test_settings_notion_sync_reset.py`
- `python3 -m py_compile apps/web/app/db.py apps/web/app/blueprints/api.py apps/web/app/blueprints/settings.py`
