### PR TITLE
Settings: summarize Notion sync history by run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,4 +129,6 @@ The `docker-and-docs-hygiene` job validates all compose files and smoke-starts t
 - `docs/INSTALL_LITE.md` / `docs/INSTALL_REGULAR.md` — install guides
 - `docs/RELEASE_2026-03-13_TURSO_DB_MIGRATION.md` — Turso DB migration release notes
 - `docs/RELEASE_2026-03-16_BOT_HEALTH_AND_FIXES.md` — bot health monitoring, cubby monitor fix, sidebar pin, Docker ARM64 fixes
+- `docs/RELEASE_2026-04-17_SYNC_CONTROL_PLANE_HARDENING.md` — source-aware sync acks, stale reset controls, and shared sync config constants
+- `docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md` — persisted sync events with run-level settings summaries (started/finished/duration/final status)
 - `docs/RELEASE_2026-04-07_BROADCAST_AND_SCHEDULER_FIX.md` — latest release notes (staff broadcast overhaul, passage-of-time scheduler fix, MONOREPO_ROOT Docker fix)

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -33,6 +33,18 @@ def _parse_iso_utc(value: str | None) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def _format_duration(seconds: int | None) -> str:
+    if seconds is None or seconds < 0:
+        return '—'
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f'{hours}h {minutes}m {secs}s'
+    if minutes:
+        return f'{minutes}m {secs}s'
+    return f'{secs}s'
+
+
 @bp.route('/')
 @require_staff
 def index():
@@ -412,16 +424,49 @@ def index():
         'stale_after_seconds': _notion_stale_after_seconds,
         'is_stale': _notion_is_stale,
     }
-    notion_sync_history = [
-        {
-            'ts': row.ts,
-            'run_id': row.run_id or '',
-            'source': row.source,
-            'status': row.status,
-            'error': row.error or '',
-        }
-        for row in NotionSyncEvent.query.order_by(NotionSyncEvent.created_at.desc()).limit(12).all()
-    ]
+    _history_rows = NotionSyncEvent.query.order_by(NotionSyncEvent.created_at.desc()).limit(120).all()
+    _run_buckets: dict[str, list[NotionSyncEvent]] = {}
+    for row in _history_rows:
+        key = (row.run_id or '').strip() or f'legacy-{row.id}'
+        _run_buckets.setdefault(key, []).append(row)
+
+    notion_sync_runs = []
+    for run_key, rows in _run_buckets.items():
+        rows_sorted = sorted(rows, key=lambda r: r.created_at or datetime.min)
+        latest = rows_sorted[-1]
+        started_row = next((r for r in rows_sorted if r.status == 'running'), rows_sorted[0])
+        started_at = started_row.ts
+        latest_at = latest.ts
+        finished_at = latest.ts if latest.status in ('success', 'error') else None
+        started_dt = _parse_iso_utc(started_at)
+        finished_dt = _parse_iso_utc(finished_at) if finished_at else None
+        duration_seconds = None
+        if started_dt and finished_dt:
+            duration_seconds = int((finished_dt - started_dt).total_seconds())
+        err_row = next(
+            (r for r in reversed(rows_sorted) if r.status == 'error' and str(r.error or '').strip()),
+            None,
+        )
+        notion_sync_runs.append(
+            {
+                'run_key': run_key,
+                'run_id': (latest.run_id or '').strip(),
+                'source': latest.source,
+                'status': latest.status,
+                'started_at': started_at,
+                'finished_at': finished_at,
+                'latest_at': latest_at,
+                'duration_seconds': duration_seconds,
+                'duration_display': _format_duration(duration_seconds),
+                'error': (err_row.error if err_row else ''),
+                'event_count': len(rows_sorted),
+            }
+        )
+    notion_sync_runs.sort(
+        key=lambda row: _parse_iso_utc(row['latest_at']) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    notion_sync_runs = notion_sync_runs[:12]
 
     return render_template(
         'settings/index.html',
@@ -436,7 +481,7 @@ def index():
         bot_heartbeat_ts=bot_heartbeat_ts,
         bot_restart_pending=_restart_pending,
         notion_sync=notion_sync,
-        notion_sync_history=notion_sync_history,
+        notion_sync_runs=notion_sync_runs,
     )
 
 

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -289,43 +289,47 @@
         <small class="text-muted ms-2">Click <strong>Run Notion Sync</strong> to populate the Notion page from Discord.</small>
       {% endif %}
 
-      {% if notion_sync_history %}
+      {% if notion_sync_runs %}
       <div class="mt-3 pt-3 border-top border-secondary">
-        <small class="text-muted d-block mb-2">Recent sync events</small>
+        <small class="text-muted d-block mb-2">Recent sync runs</small>
         <div class="table-responsive">
           <table class="table table-dark table-sm mb-0 align-middle">
             <thead>
               <tr>
-                <th style="width:180px">Timestamp (UTC)</th>
                 <th style="width:220px">Run ID</th>
+                <th style="width:180px">Started (UTC)</th>
+                <th style="width:180px">Finished (UTC)</th>
+                <th style="width:120px">Duration</th>
                 <th style="width:100px">Source</th>
-                <th style="width:100px">Status</th>
+                <th style="width:120px">Final Status</th>
                 <th>Error</th>
               </tr>
             </thead>
             <tbody>
-              {% for event in notion_sync_history %}
+              {% for run in notion_sync_runs %}
               <tr>
-                <td class="small text-muted">{{ event.ts[:19] | replace('T', ' ') }}</td>
-                <td class="small font-monospace text-muted">{{ event.run_id if event.run_id else '—' }}</td>
+                <td class="small font-monospace text-muted">{{ run.run_id if run.run_id else run.run_key }}</td>
+                <td class="small text-muted">{{ run.started_at[:19] | replace('T', ' ') if run.started_at else '—' }}</td>
+                <td class="small text-muted">{{ run.finished_at[:19] | replace('T', ' ') if run.finished_at else '—' }}</td>
+                <td class="small text-muted">{{ run.duration_display }}</td>
                 <td>
-                  {% if event.source == 'scheduled' %}
+                  {% if run.source == 'scheduled' %}
                     <span class="badge bg-secondary">Scheduled</span>
                   {% else %}
                     <span class="badge bg-dark border border-secondary">Manual</span>
                   {% endif %}
                 </td>
                 <td>
-                  {% if event.status == 'success' %}
+                  {% if run.status == 'success' %}
                     <span class="badge bg-success">Success</span>
-                  {% elif event.status == 'error' %}
+                  {% elif run.status == 'error' %}
                     <span class="badge bg-danger">Error</span>
                   {% else %}
                     <span class="badge bg-info text-dark">Running</span>
                   {% endif %}
                 </td>
-                <td class="small {% if event.status == 'error' and event.error %}text-danger{% else %}text-muted{% endif %}">
-                  {{ event.error if event.error else '—' }}
+                <td class="small {% if run.status == 'error' and run.error %}text-danger{% else %}text-muted{% endif %}">
+                  {{ run.error if run.error else '—' }}
                 </td>
               </tr>
               {% endfor %}

--- a/apps/web/tests/test_settings_notion_sync_reset.py
+++ b/apps/web/tests/test_settings_notion_sync_reset.py
@@ -1,22 +1,42 @@
 """Tests for settings-side Notion sync reset controls."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+from pathlib import Path
 
-from flask import Flask
+from flask import Blueprint, Flask
 
 from app.blueprints.settings import bp as settings_bp
-from app.db import AppSetting, db
+from app.db import AppSetting, NotionSyncEvent, db
+
+_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
+_STATIC_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
+
+
+def _stub_bp(name: str, prefix: str, routes: dict[str, str]) -> Blueprint:
+    bp = Blueprint(name, __name__, url_prefix=prefix)
+    for rule, fn_name in routes.items():
+        bp.add_url_rule(rule, fn_name, lambda **_: ('', 200))
+    return bp
 
 
 def _app():
-    app = Flask(__name__)
+    app = Flask(__name__, template_folder=_TEMPLATE_DIR, static_folder=_STATIC_DIR)
     app.config['TESTING'] = True
     app.secret_key = 'test-secret'
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SETTINGS_ADMIN_DISCORD_IDS'] = {'12345'}
     app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(hours=12)
+    app.jinja_env.globals['csrf_token'] = lambda: 'test-csrf'
     db.init_app(app)
+    app.register_blueprint(_stub_bp('dashboard', '/', {'/': 'index', '/login': 'login', '/logout': 'logout'}))
+    app.register_blueprint(_stub_bp('claims', '/claims', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('spends', '/spends', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('roster', '/roster', {'/': 'list_characters'}))
+    app.register_blueprint(_stub_bp('periods', '/periods', {'/': 'list_periods'}))
+    app.register_blueprint(_stub_bp('audit', '/audit', {'/': 'log', '/errors': 'errors'}))
+    app.register_blueprint(_stub_bp('player', '/player', {'/': 'my_characters'}))
+    app.register_blueprint(_stub_bp('wiki', '/wiki', {'/': 'index'}))
     app.register_blueprint(settings_bp, url_prefix='/settings')
     with app.app_context():
         db.create_all()
@@ -77,3 +97,50 @@ def test_reset_notion_sync_denied_for_non_admin():
 
     with app.app_context():
         assert AppSetting.query.get('BOT_NOTION_SYNC_STATUS') is not None
+
+
+def test_settings_index_shows_sync_run_summary_rows():
+    app = _app()
+    with app.app_context():
+        db.session.add(
+            NotionSyncEvent(
+                ts='2026-04-17T00:00:00+00:00',
+                run_id='run-111',
+                source='manual',
+                status='running',
+                error='',
+                created_at=datetime.fromisoformat('2026-04-17T00:00:00+00:00'),
+            )
+        )
+        db.session.add(
+            NotionSyncEvent(
+                ts='2026-04-17T00:10:00+00:00',
+                run_id='run-111',
+                source='manual',
+                status='success',
+                error='',
+                created_at=datetime.fromisoformat('2026-04-17T00:10:00+00:00'),
+            )
+        )
+        db.session.add(
+            NotionSyncEvent(
+                ts='2026-04-17T01:00:00+00:00',
+                run_id='run-222',
+                source='scheduled',
+                status='error',
+                error='sync failed',
+                created_at=datetime.fromisoformat('2026-04-17T01:00:00+00:00'),
+            )
+        )
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.get('/settings/')
+        assert res.status_code == 200
+        body = res.get_data(as_text=True)
+        assert 'Recent sync runs' in body
+        assert 'run-111' in body
+        assert 'run-222' in body
+        assert '10m 0s' in body
+        assert 'sync failed' in body

--- a/docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md
+++ b/docs/RELEASE_2026-04-17_NOTION_SYNC_HISTORY.md
@@ -8,7 +8,7 @@ Adds persistent, operator-visible history for Notion/wiki sync lifecycle events.
 
 - Added DB table `notion_sync_events` (migration + model).
 - `/api/notion-sync-ack` now appends an event row on every ack (`running|success|error`, `manual|scheduled`, `run_id`, optional error).
-- Settings page now shows recent sync history rows under the Notion Sync card.
+- Settings page now shows recent sync runs under the Notion Sync card, grouped by `run_id` (fallback legacy key) with started/finished timestamps, duration, final status, and error.
 - History is bounded server-side (keeps most recent 500 events).
 - Bot now generates a `runId` per sync run and sends it on all ack phases so lifecycle events correlate cleanly.
 

--- a/docs/WEB_APP.md
+++ b/docs/WEB_APP.md
@@ -93,7 +93,7 @@ The Settings page includes web-app runtime controls plus bot operations panels.
 - Manual **Run Notion Sync** queue button for staff.
 - Live sync state badges (Queued / Running / Success / Error / Stale).
 - `Reset Stale` action for settings admins to clear stuck sync status keys and safely requeue.
-- Recent sync history table (run ID, source, status, timestamp, error) backed by persisted `notion_sync_events`.
+- Recent sync runs table (run ID, source, started/finished, duration, final status, error) aggregated from persisted `notion_sync_events`.
 
 ![Settings](screenshots/settings.png)
 


### PR DESCRIPTION
## Summary
- replace raw Notion sync event rows in Settings with run-level summaries
- group notion_sync_events by run key and show started/finished/duration/final status
- add coverage for run summary rendering in settings tests
- update docs and CLAUDE memory notes to reflect run-level sync visibility

## Validation
- pytest -q apps/web/tests/test_notion_sync_ack.py apps/web/tests/test_settings_notion_sync_reset.py
