### PR TITLE
Bot tests: lock claim reminder CTA to player portal wording

### DIFF
--- a/apps/bot/src/__tests__/claimReminderService.test.ts
+++ b/apps/bot/src/__tests__/claimReminderService.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  config: {
+    playerWebUrl: 'https://mcbn.example/player/',
+  },
+}));
+
+import { buildClaimReminderText } from '../services/claimReminderService';
+
+describe('buildClaimReminderText', () => {
+  it('uses player portal url call-to-action when provided', () => {
+    const message = buildClaimReminderText(
+      'Night 88',
+      'Lucien',
+      '123456789',
+      'https://mcbn.example/player/',
+    );
+
+    expect(message).toContain('Submit your claim at https://mcbn.example/player/.');
+    expect(message).not.toContain('/xp submit');
+  });
+
+  it('uses player portal fallback call-to-action when url missing', () => {
+    const message = buildClaimReminderText('Night 88', 'Lucien', '123456789');
+
+    expect(message).toContain('Open the player portal to submit your claim.');
+    expect(message).not.toContain('/xp submit');
+  });
+});


### PR DESCRIPTION
## Summary
- add focused tests for buildClaimReminderText in claimReminderService
- assert CTA uses player-portal wording (both explicit URL and fallback text)
- assert stale /xp submit wording is not present

## Validation
- cd apps/bot && npm test -- --run src/__tests__/claimReminderService.test.ts
- cd apps/bot && npm run typecheck
