### PR TITLE
CI/docs: enforce bot command semantics parity

### DIFF
--- a/apps/bot/src/__tests__/docsCommandSemanticsParity.test.ts
+++ b/apps/bot/src/__tests__/docsCommandSemanticsParity.test.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('bot docs command semantics parity', () => {
+  it('documents portal-first semantics for xp submit/claim/spend commands', () => {
+    const docsPath = path.resolve(__dirname, '../../../../docs/BOT.md');
+    const botDocs = fs.readFileSync(docsPath, 'utf8');
+
+    expect(botDocs).toContain('| `/xp submit` | Players | Redirect to the web player portal claim flow |');
+    expect(botDocs).toContain('| `/xp claim` | Players | Redirect to the web player portal claim flow |');
+    expect(botDocs).toContain('| `/xp spend` | Players | Redirect to the web player portal spend flow |');
+  });
+});

--- a/scripts/check-docs-parity.sh
+++ b/scripts/check-docs-parity.sh
@@ -21,3 +21,8 @@ assert_contains "README.md" "compose.full.yml" "top-level full compose reference
 assert_contains "README.md" "docs/ENV_AND_SECRETS.md" "env/secrets runbook reference"
 assert_contains "docs/INSTALL_LITE.md" "./scripts/bootstrap-local.sh web-only" "lite install one-command bootstrap"
 assert_contains "docs/INSTALL_REGULAR.md" "./scripts/bootstrap-local.sh web+bot" "regular install one-command bootstrap"
+
+# Command semantics parity (portal-first claim/spend flow)
+assert_contains "docs/BOT.md" '| `/xp submit` | Players | Redirect to the web player portal claim flow |' "xp submit portal semantics"
+assert_contains "docs/BOT.md" '| `/xp claim` | Players | Redirect to the web player portal claim flow |' "xp claim portal semantics"
+assert_contains "docs/BOT.md" '| `/xp spend` | Players | Redirect to the web player portal spend flow |' "xp spend portal semantics"


### PR DESCRIPTION
## Summary
- add a bot test that asserts docs/BOT.md keeps portal-first semantics for /xp submit, /xp claim, and /xp spend
- extend scripts/check-docs-parity.sh with matching command-semantics assertions
- this creates a guardrail in both bot CI and docs hygiene CI to prevent redirect-vs-submit drift

## Validation
- cd apps/bot && npm test -- --run src/__tests__/docsCommandSemanticsParity.test.ts src/__tests__/xpCommand.test.ts
- cd apps/bot && npm run typecheck
- ./scripts/check-docs-parity.sh
