### PR TITLE
Bot: update stale claim wizard fallback to portal guidance

### DIFF
--- a/apps/bot/src/__tests__/interactiveClaimWizard.test.ts
+++ b/apps/bot/src/__tests__/interactiveClaimWizard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ButtonInteraction, ModalSubmitInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  handleClaimWizardButton,
+  handleClaimWizardModal,
+  handleClaimWizardSelect,
+} from '../interactiveClaimWizard';
+
+const NO_ACTIVE_WIZARD_MESSAGE = 'No active claim wizard. Open the player portal to submit your claim.';
+
+describe('interactiveClaimWizard stale-session fallbacks', () => {
+  it('returns portal guidance when select interaction has no active draft', async () => {
+    const reply = vi.fn();
+    const interaction = {
+      customId: 'xp:submit:character',
+      user: { id: 'user-no-draft-select' },
+      values: ['Any'],
+      reply,
+    } as unknown as StringSelectMenuInteraction;
+
+    const handled = await handleClaimWizardSelect(interaction);
+
+    expect(handled).toBe(true);
+    expect(reply).toHaveBeenCalledWith({ content: NO_ACTIVE_WIZARD_MESSAGE, ephemeral: true });
+  });
+
+  it('returns portal guidance when button interaction has no active draft', async () => {
+    const reply = vi.fn();
+    const interaction = {
+      customId: 'xp:submit:confirm',
+      user: { id: 'user-no-draft-button' },
+      reply,
+    } as unknown as ButtonInteraction;
+
+    const handled = await handleClaimWizardButton(interaction, {} as never);
+
+    expect(handled).toBe(true);
+    expect(reply).toHaveBeenCalledWith({ content: NO_ACTIVE_WIZARD_MESSAGE, ephemeral: true });
+  });
+
+  it('returns portal guidance when links modal submit has no active draft', async () => {
+    const reply = vi.fn();
+    const interaction = {
+      customId: 'xp:submit:links-modal:posted_once',
+      user: { id: 'user-no-draft-modal' },
+      reply,
+    } as unknown as ModalSubmitInteraction;
+
+    const handled = await handleClaimWizardModal(interaction);
+
+    expect(handled).toBe(true);
+    expect(reply).toHaveBeenCalledWith({ content: NO_ACTIVE_WIZARD_MESSAGE, ephemeral: true });
+  });
+});

--- a/apps/bot/src/interactiveClaimWizard.ts
+++ b/apps/bot/src/interactiveClaimWizard.ts
@@ -40,6 +40,7 @@ const LINKS_BUTTON_ID = 'xp:submit:links';
 const SUBMIT_BUTTON_ID = 'xp:submit:confirm';
 const CANCEL_BUTTON_ID = 'xp:submit:cancel';
 const LINKS_MODAL_PREFIX = 'xp:submit:links-modal';
+const NO_ACTIVE_WIZARD_MESSAGE = 'No active claim wizard. Open the player portal to submit your claim.';
 
 type ClaimDraft = {
   characterName?: string;
@@ -307,7 +308,7 @@ export async function handleClaimWizardSelect(interaction: StringSelectMenuInter
   cleanupExpiredDrafts();
   const draft = drafts.get(interaction.user.id);
   if (!draft) {
-    await interaction.reply({ content: 'No active claim wizard. Run /xp submit again.', ephemeral: true });
+    await interaction.reply({ content: NO_ACTIVE_WIZARD_MESSAGE, ephemeral: true });
     return true;
   }
 
@@ -344,7 +345,7 @@ export async function handleClaimWizardButton(interaction: ButtonInteraction, ad
   cleanupExpiredDrafts();
   const draft = drafts.get(interaction.user.id);
   if (!draft) {
-    await interaction.reply({ content: 'No active claim wizard. Run /xp submit again.', ephemeral: true });
+    await interaction.reply({ content: NO_ACTIVE_WIZARD_MESSAGE, ephemeral: true });
     return true;
   }
 
@@ -490,7 +491,7 @@ export async function handleClaimWizardModal(interaction: ModalSubmitInteraction
   cleanupExpiredDrafts();
   const draft = drafts.get(interaction.user.id);
   if (!draft) {
-    await interaction.reply({ content: 'No active claim wizard. Run /xp submit again.', ephemeral: true });
+    await interaction.reply({ content: NO_ACTIVE_WIZARD_MESSAGE, ephemeral: true });
     return true;
   }
 


### PR DESCRIPTION
## Summary
- replace stale fallback text in interactive claim wizard handlers that previously told users to run /xp submit again
- fallback now points users to the player portal, matching current portal-first flow
- add focused tests for select/button/modal stale-session paths

## Validation
- cd apps/bot && npm test -- --run src/__tests__/interactiveClaimWizard.test.ts src/__tests__/xpCommand.test.ts
- cd apps/bot && npm run typecheck
