### PR TITLE
Settings: gate manual Notion sync on bot capability state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Container names: `mcbn-xp-tracker-web`, `lasombra-bot`.
 - **Never commit `.env` files or service-account JSON.**
 - In full-stack Docker, bot must use `WEB_APP_BASE_URL=http://web:5001` (not `127.0.0.1`). The bootstrap script patches this automatically.
 - Bot control-loop cadence can be tuned via `CONFIG_SYNC_INTERVAL_MS` and `BOT_HEARTBEAT_INTERVAL_MS` (defaults: 60000 ms each).
+- Notion sync manual run button in Settings is capability-gated by bot heartbeat state (`BOT_LIVE_NOTION_SYNC_CAPABLE`) and is disabled when bot reports missing `NOTION_TOKEN`/`DISCORD_GUILD_ID`.
 - Details: `docs/ENV_AND_SECRETS.md`
 
 ## Production Deploy (Web)

--- a/apps/bot/src/__tests__/botHeartbeatService.test.ts
+++ b/apps/bot/src/__tests__/botHeartbeatService.test.ts
@@ -48,4 +48,17 @@ describe('BotHeartbeatService', () => {
       huntConsequenceEnabled: true,
     });
   });
+
+  it('beat includes static capability state when provided', async () => {
+    const adapter = { postHeartbeat: vi.fn(async () => {}) } as unknown as TrackerAdapter;
+    const service = new BotHeartbeatService(adapter, 60_000, { notionSyncCapable: true });
+
+    await service.beat();
+
+    expect(adapter.postHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notionSyncCapable: true,
+      }),
+    );
+  });
 });

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -180,7 +180,12 @@ void applyStartupConfigOverrides().then(() => {
   });
 
   const configSyncWorker = new ConfigSyncWorker(adapter, config.configSyncIntervalMs);
-  const botHeartbeatService = new BotHeartbeatService(adapter, config.botHeartbeatIntervalMs);
+  const notionSyncCapable = Boolean(config.notionToken && config.discordGuildId);
+  const botHeartbeatService = new BotHeartbeatService(
+    adapter,
+    config.botHeartbeatIntervalMs,
+    { notionSyncCapable },
+  );
   const botLogForwarder = new BotLogForwarder(adapter);
 
   // Build hunt consequence config, respecting test mode

--- a/apps/bot/src/services/botHeartbeatService.ts
+++ b/apps/bot/src/services/botHeartbeatService.ts
@@ -5,10 +5,12 @@ import type { TrackerAdapter } from './adapter';
 export class BotHeartbeatService {
   private readonly adapter: TrackerAdapter;
   private readonly intervalMs: number;
+  private readonly staticState: Record<string, boolean>;
 
-  constructor(adapter: TrackerAdapter, intervalMs = 60_000) {
+  constructor(adapter: TrackerAdapter, intervalMs = 60_000, staticState: Record<string, boolean> = {}) {
     this.adapter = adapter;
     this.intervalMs = intervalMs;
+    this.staticState = staticState;
   }
 
   async beat(): Promise<void> {
@@ -21,6 +23,7 @@ export class BotHeartbeatService {
         claimReminderEnabled: liveConfig.claimReminderEnabled,
         passageOfTimeEnabled: liveConfig.passageOfTimeEnabled,
         huntConsequenceEnabled: liveConfig.huntConsequenceEnabled,
+        ...this.staticState,
       });
     } catch (err) {
       logEvent('warn', 'heartbeat_failed', { error: String(err) });

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -683,6 +683,7 @@ def bot_heartbeat_post():
         'claimReminderEnabled': 'BOT_LIVE_CLAIM_REMINDER_ENABLED',
         'passageOfTimeEnabled': 'BOT_LIVE_PASSAGE_OF_TIME_ENABLED',
         'huntConsequenceEnabled': 'BOT_LIVE_HUNT_CONSEQUENCE_ENABLED',
+        'notionSyncCapable': 'BOT_LIVE_NOTION_SYNC_CAPABLE',
     }
     body = request.get_json(silent=True) or {}
     live_records = {r.key: r for r in AppSetting.query.filter(AppSetting.key.in_(LIVE_FLAG_KEYS.values())).all()}

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -45,6 +45,10 @@ def _format_duration(seconds: int | None) -> str:
     return f'{secs}s'
 
 
+def _is_truthy(value: str | None) -> bool:
+    return str(value or '').strip().lower() in ('true', '1', 'yes')
+
+
 @bp.route('/')
 @require_staff
 def index():
@@ -400,6 +404,8 @@ def index():
     _notion_finished_rec = AppSetting.query.get('BOT_NOTION_SYNC_FINISHED_AT')
     _notion_error_rec = AppSetting.query.get('BOT_NOTION_SYNC_ERROR')
     _notion_source_rec = AppSetting.query.get('BOT_NOTION_SYNC_SOURCE')
+    _notion_capable_rec = AppSetting.query.get('BOT_LIVE_NOTION_SYNC_CAPABLE')
+    _notion_capable = None if _notion_capable_rec is None else _is_truthy(_notion_capable_rec.value)
     _notion_stale_after_seconds = max(
         60,
         int(get_app_setting('BOT_NOTION_SYNC_STALE_AFTER_SECONDS', cfg.get('BOT_NOTION_SYNC_STALE_AFTER_SECONDS', 3600))),
@@ -420,6 +426,7 @@ def index():
         'finished_at': _notion_finished_rec.value if _notion_finished_rec else None,
         'error': _notion_error_rec.value if _notion_error_rec else None,
         'source': _notion_source_rec.value if _notion_source_rec else None,
+        'capable': _notion_capable,
         'running_age_seconds': _notion_running_age_seconds,
         'stale_after_seconds': _notion_stale_after_seconds,
         'is_stale': _notion_is_stale,
@@ -490,6 +497,16 @@ def index():
 def request_notion_sync():
     if not is_settings_admin():
         flash('You do not have permission to run the Notion sync.', 'danger')
+        return redirect(url_for('settings.index'))
+
+    from app.db import AppSetting
+    notion_capability = AppSetting.query.get('BOT_LIVE_NOTION_SYNC_CAPABLE')
+    if notion_capability is not None and not _is_truthy(notion_capability.value):
+        flash(
+            'Bot reports Notion sync prerequisites are missing (NOTION_TOKEN and/or DISCORD_GUILD_ID). '
+            'Update bot .env and restart the bot before running sync.',
+            'danger',
+        )
         return redirect(url_for('settings.index'))
 
     updated_by = (

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -215,7 +215,12 @@
       {% if can_edit %}
         <div class="d-flex align-items-center gap-2">
         <form method="POST" action="{{ url_for('settings.request_notion_sync') }}" class="mb-0">
-          {% if notion_sync.requested or (notion_sync.status == 'running' and not notion_sync.is_stale) %}
+          {% if notion_sync.capable is sameas false %}
+            <button type="submit" class="btn btn-sm btn-outline-secondary" disabled
+              title="Bot reports missing NOTION_TOKEN and/or DISCORD_GUILD_ID">
+              <i class="bi bi-slash-circle"></i> Missing Prereqs
+            </button>
+          {% elif notion_sync.requested or (notion_sync.status == 'running' and not notion_sync.is_stale) %}
             <button type="submit" class="btn btn-sm btn-info" disabled>
               <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
               {% if notion_sync.status == 'running' %}Running…{% else %}Queued…{% endif %}
@@ -244,6 +249,12 @@
         (PC Tracker, SPC Tracker, Location DB, Hunting Sites, Session &amp; Post Log).
         Requires <code>NOTION_TOKEN</code> and <code>DISCORD_GUILD_ID</code> in the bot's <code>.env</code>.
       </p>
+      {% if notion_sync.capable is sameas false %}
+        <small class="text-warning d-block mb-2">
+          <i class="bi bi-exclamation-triangle me-1"></i>
+          Bot currently reports missing sync prerequisites. Update bot <code>.env</code> and restart the bot to re-enable manual sync.
+        </small>
+      {% endif %}
       {% if notion_sync.status == 'running' and notion_sync.is_stale %}
         <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>Stale</span>
         {% if notion_sync.started_at %}

--- a/apps/web/tests/test_bot_heartbeat.py
+++ b/apps/web/tests/test_bot_heartbeat.py
@@ -3,7 +3,7 @@
 from flask import Flask
 
 from app.blueprints.api import bp as api_bp
-from app.db import db
+from app.db import AppSetting, db
 
 
 def _app():
@@ -64,3 +64,19 @@ def test_heartbeat_get_requires_auth():
     with app.test_client() as client:
         res = client.get('/api/bot-heartbeat')
         assert res.status_code == 401
+
+
+def test_heartbeat_post_persists_notion_sync_capability_flag():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post(
+            '/api/bot-heartbeat',
+            headers={'Authorization': 'Bearer test-token'},
+            json={'notionSyncCapable': False},
+        )
+        assert res.status_code == 200
+
+    with app.app_context():
+        rec = AppSetting.query.get('BOT_LIVE_NOTION_SYNC_CAPABLE')
+        assert rec is not None
+        assert rec.value == 'false'

--- a/apps/web/tests/test_settings_notion_sync_reset.py
+++ b/apps/web/tests/test_settings_notion_sync_reset.py
@@ -144,3 +144,35 @@ def test_settings_index_shows_sync_run_summary_rows():
         assert 'run-222' in body
         assert '10m 0s' in body
         assert 'sync failed' in body
+
+
+def test_request_notion_sync_denied_when_bot_reports_missing_prereqs():
+    app = _app()
+    with app.app_context():
+        db.session.merge(AppSetting(key='BOT_LIVE_NOTION_SYNC_CAPABLE', value='false', updated_by='bot'))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post('/settings/request-notion-sync')
+        assert res.status_code == 302
+
+    with app.app_context():
+        assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
+
+
+def test_request_notion_sync_allowed_when_bot_reports_capable():
+    app = _app()
+    with app.app_context():
+        db.session.merge(AppSetting(key='BOT_LIVE_NOTION_SYNC_CAPABLE', value='true', updated_by='bot'))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post('/settings/request-notion-sync')
+        assert res.status_code == 302
+
+    with app.app_context():
+        requested = AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED')
+        assert requested is not None
+        assert requested.value == 'true'

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -64,6 +64,7 @@ No authentication required. Liveness check.
 
 Called by the bot on startup and then on its heartbeat loop interval (default every 60 seconds, configurable with bot env `BOT_HEARTBEAT_INTERVAL_MS`) to record a liveness timestamp.
 The web app stores the timestamp in `AppSetting` under key `BOT_LAST_HEARTBEAT`.
+Optional live-state fields in the POST body are also persisted for Settings UI status cards (for example, `notionSyncCapable` stores to `BOT_LIVE_NOTION_SYNC_CAPABLE`).
 
 **Response 200:**
 ```json

--- a/docs/WEB_APP.md
+++ b/docs/WEB_APP.md
@@ -90,7 +90,7 @@ The Settings page includes web-app runtime controls plus bot operations panels.
 
 **Bot Status + Notion Sync** — operational controls for bot lifecycle and wiki/notion sync:
 - Bot heartbeat status (Online / Delayed / Offline) with restart/rebuild controls.
-- Manual **Run Notion Sync** queue button for staff.
+- Manual **Run Notion Sync** queue button for staff (disabled when the bot reports missing `NOTION_TOKEN` or `DISCORD_GUILD_ID` prerequisites).
 - Live sync state badges (Queued / Running / Success / Error / Stale).
 - `Reset Stale` action for settings admins to clear stuck sync status keys and safely requeue.
 - Recent sync runs table (run ID, source, started/finished, duration, final status, error) aggregated from persisted `notion_sync_events`.


### PR DESCRIPTION
## Summary
- extend bot heartbeat live-state payload with notionSyncCapable (derived from bot config prerequisites)
- persist notionSyncCapable in web via BOT_LIVE_NOTION_SYNC_CAPABLE
- disable Settings manual Run Notion Sync button when bot reports missing NOTION_TOKEN/DISCORD_GUILD_ID
- block request-notion-sync POST when capability is explicitly false
- add bot/web tests for heartbeat persistence and settings request gating
- update API/WEB docs and CLAUDE memory note

## Validation
- cd apps/bot && npm test -- --run src/__tests__/botHeartbeatService.test.ts
- cd apps/bot && npm run typecheck
- pytest -q apps/web/tests/test_bot_heartbeat.py apps/web/tests/test_settings_notion_sync_reset.py
- python3 -m py_compile apps/web/app/blueprints/api.py apps/web/app/blueprints/settings.py apps/web/tests/test_bot_heartbeat.py apps/web/tests/test_settings_notion_sync_reset.py
