### PR TITLE
Replace deprecated Query.get() calls with Session.get()

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -650,7 +650,7 @@ def bot_config():
 def bot_restart_ack():
     """Bot calls this to clear the restart-requested flag just before exiting."""
     from app.db import AppSetting, db
-    record = AppSetting.query.get('BOT_RESTART_REQUESTED')
+    record = db.session.get(AppSetting, 'BOT_RESTART_REQUESTED')
     if record:
         db.session.delete(record)
         db.session.commit()
@@ -664,7 +664,7 @@ def bot_heartbeat_post():
     from datetime import datetime, timezone
     from app.db import AppSetting, db
     ts = datetime.now(timezone.utc).isoformat()
-    record = AppSetting.query.get('BOT_LAST_HEARTBEAT')
+    record = db.session.get(AppSetting, 'BOT_LAST_HEARTBEAT')
     if record:
         record.value = ts
         record.updated_at = datetime.now(timezone.utc)
@@ -706,8 +706,8 @@ def bot_heartbeat_post():
 @_limit('60 per minute')
 def bot_heartbeat_get():
     from datetime import datetime, timezone
-    from app.db import AppSetting
-    record = AppSetting.query.get('BOT_LAST_HEARTBEAT')
+    from app.db import AppSetting, db
+    record = db.session.get(AppSetting, 'BOT_LAST_HEARTBEAT')
     if not record:
         return jsonify({'last_heartbeat': None, 'age_seconds': None})
     ts = record.value
@@ -1005,7 +1005,7 @@ def notion_sync_ack():
     now = datetime.now(timezone.utc).isoformat()
 
     def upsert(key, value):
-        rec = AppSetting.query.get(key)
+        rec = db.session.get(AppSetting, key)
         if rec:
             rec.value = value
             rec.updated_at = datetime.now(timezone.utc)
@@ -1014,7 +1014,7 @@ def notion_sync_ack():
             db.session.add(AppSetting(key=key, value=value, updated_by='bot'))
 
     def delete_key(key):
-        rec = AppSetting.query.get(key)
+        rec = db.session.get(AppSetting, key)
         if rec:
             db.session.delete(rec)
 

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -380,8 +380,8 @@ def index():
     ]
 
     # ── Bot heartbeat ───────────────────────────────────────────────────────
-    from app.db import AppSetting
-    _hb = AppSetting.query.get('BOT_LAST_HEARTBEAT')
+    from app.db import AppSetting, db
+    _hb = db.session.get(AppSetting, 'BOT_LAST_HEARTBEAT')
     bot_heartbeat_age = None
     bot_heartbeat_ts = None
     if _hb:
@@ -398,13 +398,13 @@ def index():
 
     # ── Notion sync status ─────────────────────────────────────────────────
     _notion_sync_requested = 'BOT_NOTION_SYNC_REQUESTED' in overrides and overrides['BOT_NOTION_SYNC_REQUESTED'].value.lower() in ('true', '1', 'yes')
-    _notion_status_rec = AppSetting.query.get('BOT_NOTION_SYNC_STATUS')
-    _notion_run_id_rec = AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID')
-    _notion_started_rec = AppSetting.query.get('BOT_NOTION_SYNC_STARTED_AT')
-    _notion_finished_rec = AppSetting.query.get('BOT_NOTION_SYNC_FINISHED_AT')
-    _notion_error_rec = AppSetting.query.get('BOT_NOTION_SYNC_ERROR')
-    _notion_source_rec = AppSetting.query.get('BOT_NOTION_SYNC_SOURCE')
-    _notion_capable_rec = AppSetting.query.get('BOT_LIVE_NOTION_SYNC_CAPABLE')
+    _notion_status_rec = db.session.get(AppSetting, 'BOT_NOTION_SYNC_STATUS')
+    _notion_run_id_rec = db.session.get(AppSetting, 'BOT_NOTION_SYNC_RUN_ID')
+    _notion_started_rec = db.session.get(AppSetting, 'BOT_NOTION_SYNC_STARTED_AT')
+    _notion_finished_rec = db.session.get(AppSetting, 'BOT_NOTION_SYNC_FINISHED_AT')
+    _notion_error_rec = db.session.get(AppSetting, 'BOT_NOTION_SYNC_ERROR')
+    _notion_source_rec = db.session.get(AppSetting, 'BOT_NOTION_SYNC_SOURCE')
+    _notion_capable_rec = db.session.get(AppSetting, 'BOT_LIVE_NOTION_SYNC_CAPABLE')
     _notion_capable = None if _notion_capable_rec is None else _is_truthy(_notion_capable_rec.value)
     _notion_stale_after_seconds = max(
         60,
@@ -499,8 +499,8 @@ def request_notion_sync():
         flash('You do not have permission to run the Notion sync.', 'danger')
         return redirect(url_for('settings.index'))
 
-    from app.db import AppSetting
-    notion_capability = AppSetting.query.get('BOT_LIVE_NOTION_SYNC_CAPABLE')
+    from app.db import AppSetting, db
+    notion_capability = db.session.get(AppSetting, 'BOT_LIVE_NOTION_SYNC_CAPABLE')
     if notion_capability is not None and not _is_truthy(notion_capability.value):
         flash(
             'Bot reports Notion sync prerequisites are missing (NOTION_TOKEN and/or DISCORD_GUILD_ID). '
@@ -538,7 +538,7 @@ def reset_notion_sync():
     )
     deleted = 0
     for key in reset_keys:
-        rec = AppSetting.query.get(key)
+        rec = db.session.get(AppSetting, key)
         if rec:
             db.session.delete(rec)
             deleted += 1

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -535,12 +535,12 @@ class DBService:
         return [_row_to_claim(r) for r in rows]
 
     def get_claim_by_row(self, row_index: int) -> Optional[XPClaim]:
-        row = DbXPClaim.query.get(row_index)
+        row = db.session.get(DbXPClaim, row_index)
         return _row_to_claim(row) if row else None
 
     def approve_claim(self, row_index: int, approved_xp: int,
                       reviewer: str, notes: str = '') -> None:
-        row = DbXPClaim.query.get(row_index)
+        row = db.session.get(DbXPClaim, row_index)
         if not row:
             raise ValueError(f'Claim not found: {row_index}')
         row.status = 'Approved'
@@ -552,7 +552,7 @@ class DBService:
 
     def deny_claim(self, row_index: int, reviewer: str,
                    notes: str = '') -> None:
-        row = DbXPClaim.query.get(row_index)
+        row = db.session.get(DbXPClaim, row_index)
         if not row:
             raise ValueError(f'Claim not found: {row_index}')
         row.status = 'Denied'
@@ -565,7 +565,7 @@ class DBService:
     def reopen_claim_for_amendment(self, row_index: int, reviewer: str,
                                    notes: str = '') -> None:
         """Set a denied claim to 'Amend' so the player can edit and resubmit."""
-        row = DbXPClaim.query.get(row_index)
+        row = db.session.get(DbXPClaim, row_index)
         if not row:
             raise ValueError(f'Claim not found: {row_index}')
         row.status = 'Amend'
@@ -576,7 +576,7 @@ class DBService:
 
     def amend_claim(self, row_index: int, categories: dict) -> None:
         """Update claim evidence fields in-place and return it to Pending."""
-        row = DbXPClaim.query.get(row_index)
+        row = db.session.get(DbXPClaim, row_index)
         if not row:
             raise ValueError(f'Claim not found: {row_index}')
         cat_keys = [
@@ -710,12 +710,12 @@ class DBService:
         return [_row_to_spend(r) for r in rows]
 
     def get_spend_by_row(self, row_index: int) -> Optional[SpendRequest]:
-        row = DbSpendRequest.query.get(row_index)
+        row = db.session.get(DbSpendRequest, row_index)
         return _row_to_spend(row) if row else None
 
     def approve_spend(self, row_index: int, verified_cost: int,
                       reviewer: str, notes: str = '') -> None:
-        row = DbSpendRequest.query.get(row_index)
+        row = db.session.get(DbSpendRequest, row_index)
         if not row:
             raise ValueError(f'Spend request not found: {row_index}')
         row.status = 'Approved'
@@ -727,7 +727,7 @@ class DBService:
 
     def deny_spend(self, row_index: int, reviewer: str,
                    notes: str = '') -> None:
-        row = DbSpendRequest.query.get(row_index)
+        row = db.session.get(DbSpendRequest, row_index)
         if not row:
             raise ValueError(f'Spend request not found: {row_index}')
         row.status = 'Denied'
@@ -918,7 +918,7 @@ class DBService:
 
     def delete_ledger_entry(self, row_index: int) -> None:
         """Delete a ledger entry by its DB id (row_index == id)."""
-        row = DbLedgerEntry.query.get(row_index)
+        row = db.session.get(DbLedgerEntry, row_index)
         if not row:
             raise ValueError(f'Ledger entry not found: {row_index}')
         db.session.delete(row)

--- a/apps/web/tests/test_bot_heartbeat.py
+++ b/apps/web/tests/test_bot_heartbeat.py
@@ -77,6 +77,6 @@ def test_heartbeat_post_persists_notion_sync_capability_flag():
         assert res.status_code == 200
 
     with app.app_context():
-        rec = AppSetting.query.get('BOT_LIVE_NOTION_SYNC_CAPABLE')
+        rec = db.session.get(AppSetting, 'BOT_LIVE_NOTION_SYNC_CAPABLE')
         assert rec is not None
         assert rec.value == 'false'

--- a/apps/web/tests/test_claim_amendment.py
+++ b/apps/web/tests/test_claim_amendment.py
@@ -42,14 +42,14 @@ class TestReopenClaimForAmendment:
         svc = DBService()
         claim_id = _seed_claim('Denied')
         svc.reopen_claim_for_amendment(claim_id, reviewer='ST', notes='Please fix link.')
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.status == 'Amend'
 
     def test_stores_reviewer_and_notes(self, app_ctx):
         svc = DBService()
         claim_id = _seed_claim('Denied')
         svc.reopen_claim_for_amendment(claim_id, reviewer='ST', notes='Fix your links.')
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.reviewed_by == 'ST'
         assert row.st_notes == 'Fix your links.'
 
@@ -57,7 +57,7 @@ class TestReopenClaimForAmendment:
         svc = DBService()
         claim_id = _seed_claim('Denied')
         svc.reopen_claim_for_amendment(claim_id, reviewer='ST')
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.review_date  # non-empty timestamp
 
     def test_raises_for_missing_claim(self, app_ctx):
@@ -75,7 +75,7 @@ class TestAmendClaim:
             'scene_with_another': 'https://discord.com/scene-link',
         }
         svc.amend_claim(claim_id, new_cats)
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.posted_once is True
         assert row.posted_once_link == 'https://discord.com/new-link'
         assert row.scene_with_another is True
@@ -86,7 +86,7 @@ class TestAmendClaim:
         claim_id = _seed_claim('Amend')
         # Only scene_with_another — posted_once should be cleared
         svc.amend_claim(claim_id, {'scene_with_another': 'https://discord.com/x'})
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.posted_once is False
         assert row.posted_once_link == ''
 
@@ -94,14 +94,14 @@ class TestAmendClaim:
         svc = DBService()
         claim_id = _seed_claim('Amend')
         svc.amend_claim(claim_id, {'posted_once': 'https://discord.com/x'})
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.status == 'Pending'
 
     def test_clears_review_fields(self, app_ctx):
         svc = DBService()
         claim_id = _seed_claim('Amend')
         svc.amend_claim(claim_id, {'posted_once': 'https://discord.com/x'})
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.reviewed_by == ''
         assert row.review_date == ''
         assert row.st_notes == ''
@@ -115,7 +115,7 @@ class TestAmendClaim:
             'scene_with_another': 'https://discord.com/b',
             'conflict': 'https://discord.com/c',
         })
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.xp_claimed == 3
 
     def test_wildcard_xp_counted(self, app_ctx):
@@ -127,7 +127,7 @@ class TestAmendClaim:
             'wildcard_reason': 'Conclave',
             'wildcard_amount': '3',
         })
-        row = DbXPClaim.query.get(claim_id)
+        row = db.session.get(DbXPClaim, claim_id)
         assert row.xp_claimed == 4  # 1 standard + 3 wildcard
         assert row.wildcard_amount == 3
         assert row.wildcard_reason == 'Conclave'

--- a/apps/web/tests/test_notion_sync_ack.py
+++ b/apps/web/tests/test_notion_sync_ack.py
@@ -40,10 +40,10 @@ def test_running_ack_manual_clears_request_flag():
         assert res.status_code == 200
 
     with app.app_context():
-        assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
-        assert AppSetting.query.get('BOT_NOTION_SYNC_STATUS').value == 'running'
-        assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'manual'
-        assert AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID').value == 'run-manual-1'
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_REQUESTED') is None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_STATUS').value == 'running'
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_SOURCE').value == 'manual'
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_RUN_ID').value == 'run-manual-1'
         event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
         assert event is not None
         assert event.status == 'running'
@@ -64,9 +64,9 @@ def test_running_ack_scheduled_does_not_clear_request_flag():
         assert res.status_code == 200
 
     with app.app_context():
-        assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is not None
-        assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'scheduled'
-        assert AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID') is None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_REQUESTED') is not None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_SOURCE').value == 'scheduled'
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_RUN_ID') is None
         event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
         assert event is not None
         assert event.source == 'scheduled'
@@ -85,9 +85,9 @@ def test_running_ack_defaults_source_to_manual():
         assert res.status_code == 200
 
     with app.app_context():
-        assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
-        assert AppSetting.query.get('BOT_NOTION_SYNC_SOURCE').value == 'manual'
-        assert AppSetting.query.get('BOT_NOTION_SYNC_RUN_ID') is None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_REQUESTED') is None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_SOURCE').value == 'manual'
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_RUN_ID') is None
         event = NotionSyncEvent.query.order_by(NotionSyncEvent.id.desc()).first()
         assert event is not None
         assert event.source == 'manual'

--- a/apps/web/tests/test_settings_notion_sync_reset.py
+++ b/apps/web/tests/test_settings_notion_sync_reset.py
@@ -84,7 +84,7 @@ def test_reset_notion_sync_clears_sync_state_for_admin():
             'BOT_NOTION_SYNC_ERROR',
             'BOT_NOTION_SYNC_SOURCE',
         ):
-            assert AppSetting.query.get(key) is None
+            assert db.session.get(AppSetting, key) is None
 
 
 def test_reset_notion_sync_denied_for_non_admin():
@@ -96,7 +96,7 @@ def test_reset_notion_sync_denied_for_non_admin():
         assert res.status_code == 302
 
     with app.app_context():
-        assert AppSetting.query.get('BOT_NOTION_SYNC_STATUS') is not None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_STATUS') is not None
 
 
 def test_settings_index_shows_sync_run_summary_rows():
@@ -158,7 +158,7 @@ def test_request_notion_sync_denied_when_bot_reports_missing_prereqs():
         assert res.status_code == 302
 
     with app.app_context():
-        assert AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED') is None
+        assert db.session.get(AppSetting, 'BOT_NOTION_SYNC_REQUESTED') is None
 
 
 def test_request_notion_sync_allowed_when_bot_reports_capable():
@@ -173,6 +173,6 @@ def test_request_notion_sync_allowed_when_bot_reports_capable():
         assert res.status_code == 302
 
     with app.app_context():
-        requested = AppSetting.query.get('BOT_NOTION_SYNC_REQUESTED')
+        requested = db.session.get(AppSetting, 'BOT_NOTION_SYNC_REQUESTED')
         assert requested is not None
         assert requested.value == 'true'


### PR DESCRIPTION
## Summary
- replace remaining SQLAlchemy `Model.query.get(...)` calls in web tracker code with `db.session.get(Model, id)`
- update affected tests to use session-based lookups for primary-key fetches
- preserve existing behavior while removing `Query.get()` deprecation usage

## Validation
- pytest -q apps/web/tests/test_claim_amendment.py apps/web/tests/test_notion_sync_ack.py apps/web/tests/test_bot_heartbeat.py apps/web/tests/test_settings_notion_sync_reset.py
- pytest -q apps/web/tests
