### PR TITLE
Bot wiki sync: extract reusable helper module (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2026-04-18] Wiki Sync Modularization (Phase 1)
+
+### Bot Wiki Sync Maintainability
+
+- Extracted wiki-focused sync helpers from `apps/bot/src/scripts/discord-notion-sync.ts` into `apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts`.
+- Centralized slug generation, markdown sanitization/rendering, SPC type inference, domain mapping, and coterie/faction taxonomy constants used by the sync pipeline.
+- Added targeted helper tests in `apps/bot/src/__tests__/wikiSyncHelpers.test.ts`.
+- Added release notes: `docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE1.md`.
+
+---
+
 ## [2026-03-14] Bulk Approvals, Claim Amendment, and Spend Queue
 
 ### Bulk Claim Approval

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-17
+Last updated: 2026-04-18
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -52,9 +52,13 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `PUT /api/character/<name>/status`
 - Cover image permanence:
   - web mirrors Discord CDN images to GCS in `app/gcs.py` from `POST /api/wiki/page`.
+- Wiki sync helper extraction (phase 1):
+  - shared wiki taxonomy + markdown/slug/domain helpers now live in
+    `apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts`.
+  - `discord-notion-sync.ts` imports these helpers; orchestration flow is unchanged.
 
 ## High-Signal Current Gaps
-- `runNotionSync` is still a large monolithic script (1218 LOC) doing both Notion and Wiki writes.
+- `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.

--- a/apps/bot/src/__tests__/wikiSyncHelpers.test.ts
+++ b/apps/bot/src/__tests__/wikiSyncHelpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAR_TO_COTERIE,
+  inferSpcType,
+  mapDomain,
+  messagesToMarkdown,
+  sanitizeDiscordMarkdown,
+  wikiSlug,
+} from '../scripts/notionSync/wikiSyncHelpers';
+
+describe('wikiSyncHelpers', () => {
+  it('builds category-prefixed slugs', () => {
+    expect(wikiSlug('characters', 'Alice No. 1')).toBe('char-alice-no-1');
+    expect(wikiSlug('locations', 'North Nashville')).toBe('loc-north-nashville');
+    expect(wikiSlug('factions', 'Camarilla')).toBe('factions-camarilla');
+  });
+
+  it('sanitizes discord-only markdown extensions', () => {
+    const raw = '||secret|| <:smile:123> ping <@123> at <t:1720000000:F> **oops';
+    expect(sanitizeDiscordMarkdown(raw)).toBe('secret  ping  at  **oops**');
+  });
+
+  it('renders messages to markdown with sanitized content', () => {
+    const out = messagesToMarkdown([
+      {
+        content: 'Hello <#12345>',
+        author: { username: 'st', global_name: 'Storyteller' },
+        timestamp: '2026-04-18T10:00:00.000Z',
+      },
+      {
+        content: '   ',
+        author: { username: 'ignored' },
+        timestamp: '2026-04-18T11:00:00.000Z',
+      },
+    ]);
+    expect(out).toContain('### Storyteller · 2026-04-18');
+    expect(out).toContain('\n\nHello');
+    expect(out).not.toContain('<#12345>');
+    expect(out).not.toContain('ignored');
+  });
+
+  it('infers spc type from text keywords', () => {
+    expect(inferSpcType('Trusted Mawla and ally')).toBe('Mawla');
+    expect(inferSpcType('Unknown category')).toBeNull();
+  });
+
+  it('maps canonical domain names from freeform location strings', () => {
+    expect(mapDomain('North Nashville - Riverview')).toBe('North Nashville');
+    expect(mapDomain('Somewhere Else')).toBeNull();
+  });
+
+  it('includes reverse coterie membership lookups', () => {
+    expect(CHAR_TO_COTERIE.get('alice')).toBe('Pillars of Community');
+    expect(CHAR_TO_COTERIE.get('not-a-member')).toBeUndefined();
+  });
+});

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -39,6 +39,15 @@ import path from 'node:path';
 import * as dotenv from 'dotenv';
 import { REST, Routes } from 'discord.js';
 import { Client as NotionClient } from '@notionhq/client';
+import {
+  CHAR_TO_COTERIE,
+  COTERIE_MEMBERS,
+  FACTIONS,
+  inferSpcType,
+  mapDomain,
+  messagesToMarkdown,
+  wikiSlug,
+} from './notionSync/wikiSyncHelpers';
 
 // ---------------------------------------------------------------------------
 // Public API — call this from the bot process or from the CLI
@@ -244,20 +253,6 @@ function heading3Block(content: string): object {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Chronicle Wiki helpers
-// ---------------------------------------------------------------------------
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/[\s_]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
 interface PcProfile { image: string | null; markdown: string; }
 
 /**
@@ -295,52 +290,6 @@ function lookupPcProfile(map: Map<string, PcProfile>, charName: string): PcProfi
     if (threadName.includes(key) || key.includes(threadName)) return profile;
   }
   return null;
-}
-
-/** Prefix slug with category abbreviation to prevent cross-category collisions. */
-function wikiSlug(category: string, name: string): string {
-  const prefixes: Record<string, string> = {
-    locations: 'loc',
-    characters: 'char',
-    lore: 'lore',
-  };
-  const prefix = prefixes[category] ?? category;
-  return `${prefix}-${slugify(name)}`;
-}
-
-/**
- * Strip Discord-specific markdown extensions so content renders cleanly
- * in standard Markdown (the wiki renderer).
- *
- * Handles:
- *  - Spoilers: ||text|| → text  (reveal hidden content)
- *  - Custom emoji: <:name:id> / <a:name:id> → removed
- *  - User/role/channel mentions: <@id> <@!id> <#id> <@&id> → removed
- *  - Timestamp tags: <t:123:F> → removed
- *  - Unbalanced ** bold markers: if count is odd, close at end of block
- */
-function sanitizeDiscordMarkdown(text: string): string {
-  let s = text
-    .replace(/\|\|([^|]*)\|\|/g, '$1')          // spoilers → plain text
-    .replace(/<a?:\w+:\d+>/g, '')                // custom emoji
-    .replace(/<[@#!&]?!?\d+>/g, '')              // mentions & channels
-    .replace(/<t:\d+(?::[tTdDfFR])?>/g, '');     // timestamp tags
-
-  // Close any unclosed bold markers (odd number of ** in the block)
-  if ((s.match(/\*\*/g) ?? []).length % 2 !== 0) s += '**';
-
-  return s.trim();
-}
-
-function messagesToMarkdown(messages: DiscordMessage[]): string {
-  return messages
-    .filter((m) => m.content.trim())
-    .map((m) => {
-      const author = m.author.global_name ?? m.author.username;
-      const date = m.timestamp.slice(0, 10);
-      return `### ${author} · ${date}\n\n${sanitizeDiscordMarkdown(m.content.trim())}`;
-    })
-    .join('\n\n---\n\n');
 }
 
 interface WikiPageData {
@@ -565,61 +514,6 @@ function messagesToBlocks(messages: DiscordMessage[]): object[] {
 // ---------------------------------------------------------------------------
 
 const SOURCE_TAG = 'discord-sync';
-
-// Coterie membership: display name → member character names (lowercase for matching)
-const COTERIE_MEMBERS: Record<string, string[]> = {
-  'The Brood':              ['ratcatcher', 'umaira', 'foxus', 'measly', 'viper'],
-  'Obsidian Citadel':       ['krayt', 'constance', 'patrick', 'nochtli'],
-  'Pillars of Community':   ['sonja', 'alice', 'gabriella', 'raize'],
-  'Danse Macabre':          ['ebba', 'alexander', 'kip'],
-  'The Magnolia Court':     ['cecilia', 'dahlia', 'david'],
-  'Ars Ananke':             ['argento', 'charmaine', 'marcus'],
-  'Culebra':                ['yamata', 'derrick', 'code red', 'percy'],
-  'Phantom Troupe':         ['jester', 'sikorsky', 'coral', 'jennifer jean'],
-  'The Assets':             ['big joey', 'lil joey', 'viktor'],
-  'Earth, Wind and Fire':   ['ashanti', 'aliyah', 'dolohov'],
-  'Midnight Oil':           ['rain', 'sierra', 'nightblazer'],
-};
-
-// Build reverse map: character name (lowercase) → coterie display name
-const CHAR_TO_COTERIE = new Map<string, string>();
-for (const [coterie, members] of Object.entries(COTERIE_MEMBERS)) {
-  for (const m of members) CHAR_TO_COTERIE.set(m, coterie);
-}
-
-interface FactionDef {
-  name: string;
-  sectAliases: string[];  // matches c.sect.toLowerCase()
-  loreChannels: string[]; // channel names whose archive pages link under Lore
-}
-const FACTIONS: FactionDef[] = [
-  { name: 'Camarilla', sectAliases: ['camarilla'],         loreChannels: ['camarilla-decrees'] },
-  { name: 'Anarchs',   sectAliases: ['anarch'],            loreChannels: ['anarch-mandates'] },
-  { name: 'Voivode',   sectAliases: ['hecata'],            loreChannels: ['hecata-notices'] },
-  { name: 'Autark',    sectAliases: ['autarkis'],          loreChannels: [] },
-];
-
-// SPC type keywords: if thread/message name contains keyword → Type tag
-const SPC_TYPE_KEYWORDS: { keyword: string; tag: string }[] = [
-  { keyword: 'haven',      tag: 'Haven' },
-  { keyword: 'mawla',      tag: 'Mawla' },
-  { keyword: 'retainer',   tag: 'Retainer' },
-  { keyword: 'contact',    tag: 'Contact' },
-  { keyword: 'allies',     tag: 'Allies' },
-  { keyword: 'ally',       tag: 'Allies' },
-  { keyword: 'herd',       tag: 'Herd' },
-  { keyword: 'rolodex',    tag: 'Rolodex' },
-  { keyword: 'famulus',    tag: 'Famulus' },
-  { keyword: 'touchstone', tag: 'Touchstone' },
-];
-
-function inferSpcType(text: string): string | null {
-  const lower = text.toLowerCase();
-  for (const { keyword, tag } of SPC_TYPE_KEYWORDS) {
-    if (lower.includes(keyword)) return tag;
-  }
-  return null;
-}
 
 function getPageTitle(page: { properties: Record<string, unknown> }): string {
   for (const val of Object.values(page.properties)) {
@@ -1196,23 +1090,3 @@ async function main(opts: NotionSyncOptions) {
 
   console.log(`\nDone!${DRY_RUN ? ' (dry-run: nothing written to Notion)' : ''}`);
 }
-
-// ---------------------------------------------------------------------------
-// Domain name normalisation
-// ---------------------------------------------------------------------------
-
-const DOMAIN_OPTIONS = [
-  'Madison', 'North Nashville', 'West Nashville', 'Bordeaux', 'East Nashville',
-  'Downtown', 'Midtown', 'South Nashville', 'Donelson', 'Sylvan Park',
-  'Hillwood', 'Green Hills', 'Bellevue', 'Hermitage', 'Percy Priest Lake',
-  'City Sewers', 'Metro Area',
-];
-
-function mapDomain(name: string): string | null {
-  const lower = name.toLowerCase();
-  for (const opt of DOMAIN_OPTIONS) {
-    if (lower.includes(opt.toLowerCase())) return opt;
-  }
-  return null;
-}
-

--- a/apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts
+++ b/apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts
@@ -1,0 +1,142 @@
+export type DiscordMessageForWiki = {
+  content: string;
+  author: { username: string; global_name?: string };
+  timestamp: string;
+};
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/** Prefix slug with category abbreviation to prevent cross-category collisions. */
+export function wikiSlug(category: string, name: string): string {
+  const prefixes: Record<string, string> = {
+    locations: 'loc',
+    characters: 'char',
+    lore: 'lore',
+  };
+  const prefix = prefixes[category] ?? category;
+  return `${prefix}-${slugify(name)}`;
+}
+
+/**
+ * Strip Discord-specific markdown extensions so content renders cleanly
+ * in standard Markdown (the wiki renderer).
+ *
+ * Handles:
+ *  - Spoilers: ||text|| → text  (reveal hidden content)
+ *  - Custom emoji: <:name:id> / <a:name:id> → removed
+ *  - User/role/channel mentions: <@id> <@!id> <#id> <@&id> → removed
+ *  - Timestamp tags: <t:123:F> → removed
+ *  - Unbalanced ** bold markers: if count is odd, close at end of block
+ */
+export function sanitizeDiscordMarkdown(text: string): string {
+  let s = text
+    .replace(/\|\|([^|]*)\|\|/g, '$1') // spoilers → plain text
+    .replace(/<a?:\w+:\d+>/g, '') // custom emoji
+    .replace(/<[@#!&]?!?\d+>/g, '') // mentions & channels
+    .replace(/<t:\d+(?::[tTdDfFR])?>/g, ''); // timestamp tags
+
+  if ((s.match(/\*\*/g) ?? []).length % 2 !== 0) s += '**';
+  return s.trim();
+}
+
+export function messagesToMarkdown(messages: DiscordMessageForWiki[]): string {
+  return messages
+    .filter((m) => m.content.trim())
+    .map((m) => {
+      const author = m.author.global_name ?? m.author.username;
+      const date = m.timestamp.slice(0, 10);
+      return `### ${author} · ${date}\n\n${sanitizeDiscordMarkdown(m.content.trim())}`;
+    })
+    .join('\n\n---\n\n');
+}
+
+// Coterie membership: display name → member character names (lowercase for matching)
+export const COTERIE_MEMBERS: Record<string, string[]> = {
+  'The Brood': ['ratcatcher', 'umaira', 'foxus', 'measly', 'viper'],
+  'Obsidian Citadel': ['krayt', 'constance', 'patrick', 'nochtli'],
+  'Pillars of Community': ['sonja', 'alice', 'gabriella', 'raize'],
+  'Danse Macabre': ['ebba', 'alexander', 'kip'],
+  'The Magnolia Court': ['cecilia', 'dahlia', 'david'],
+  'Ars Ananke': ['argento', 'charmaine', 'marcus'],
+  'Culebra': ['yamata', 'derrick', 'code red', 'percy'],
+  'Phantom Troupe': ['jester', 'sikorsky', 'coral', 'jennifer jean'],
+  'The Assets': ['big joey', 'lil joey', 'viktor'],
+  'Earth, Wind and Fire': ['ashanti', 'aliyah', 'dolohov'],
+  'Midnight Oil': ['rain', 'sierra', 'nightblazer'],
+};
+
+// Reverse map: character name (lowercase) → coterie display name
+export const CHAR_TO_COTERIE = new Map<string, string>();
+for (const [coterie, members] of Object.entries(COTERIE_MEMBERS)) {
+  for (const m of members) CHAR_TO_COTERIE.set(m, coterie);
+}
+
+export interface FactionDef {
+  name: string;
+  sectAliases: string[]; // matches c.sect.toLowerCase()
+  loreChannels: string[]; // channel names whose archive pages link under Lore
+}
+
+export const FACTIONS: FactionDef[] = [
+  { name: 'Camarilla', sectAliases: ['camarilla'], loreChannels: ['camarilla-decrees'] },
+  { name: 'Anarchs', sectAliases: ['anarch'], loreChannels: ['anarch-mandates'] },
+  { name: 'Voivode', sectAliases: ['hecata'], loreChannels: ['hecata-notices'] },
+  { name: 'Autark', sectAliases: ['autarkis'], loreChannels: [] },
+];
+
+const SPC_TYPE_KEYWORDS: { keyword: string; tag: string }[] = [
+  { keyword: 'haven', tag: 'Haven' },
+  { keyword: 'mawla', tag: 'Mawla' },
+  { keyword: 'retainer', tag: 'Retainer' },
+  { keyword: 'contact', tag: 'Contact' },
+  { keyword: 'allies', tag: 'Allies' },
+  { keyword: 'ally', tag: 'Allies' },
+  { keyword: 'herd', tag: 'Herd' },
+  { keyword: 'rolodex', tag: 'Rolodex' },
+  { keyword: 'famulus', tag: 'Famulus' },
+  { keyword: 'touchstone', tag: 'Touchstone' },
+];
+
+export function inferSpcType(text: string): string | null {
+  const lower = text.toLowerCase();
+  for (const { keyword, tag } of SPC_TYPE_KEYWORDS) {
+    if (lower.includes(keyword)) return tag;
+  }
+  return null;
+}
+
+const DOMAIN_OPTIONS = [
+  'Madison',
+  'North Nashville',
+  'West Nashville',
+  'Bordeaux',
+  'East Nashville',
+  'Downtown',
+  'Midtown',
+  'South Nashville',
+  'Donelson',
+  'Sylvan Park',
+  'Hillwood',
+  'Green Hills',
+  'Bellevue',
+  'Hermitage',
+  'Percy Priest Lake',
+  'City Sewers',
+  'Metro Area',
+];
+
+export function mapDomain(name: string): string | null {
+  const lower = name.toLowerCase();
+  for (const opt of DOMAIN_OPTIONS) {
+    if (lower.includes(opt.toLowerCase())) return opt;
+  }
+  return null;
+}

--- a/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE1.md
+++ b/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE1.md
@@ -1,0 +1,52 @@
+# Release: 2026-04-18 — Wiki Sync Modularization (Phase 1)
+
+## Summary
+
+Starts decomposing `apps/bot/src/scripts/discord-notion-sync.ts` by extracting
+wiki-focused pure helpers into a dedicated module, without changing sync
+behavior.
+
+## What Changed
+
+### 1) New helper module for wiki sync content/taxonomy logic
+
+Added:
+
+- `apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts`
+
+This module now owns:
+
+- slug helpers (`slugify`, `wikiSlug`)
+- Discord markdown cleanup (`sanitizeDiscordMarkdown`)
+- wiki markdown body rendering (`messagesToMarkdown`)
+- SPC type inference (`inferSpcType`)
+- location domain normalization (`mapDomain`)
+- coterie/faction wiki taxonomy constants
+  (`COTERIE_MEMBERS`, `CHAR_TO_COTERIE`, `FACTIONS`)
+
+### 2) `discord-notion-sync.ts` now imports shared helpers
+
+`apps/bot/src/scripts/discord-notion-sync.ts` was updated to import and reuse
+the extracted helpers instead of defining them inline. Runtime flow remains the
+same.
+
+### 3) New helper tests
+
+Added:
+
+- `apps/bot/src/__tests__/wikiSyncHelpers.test.ts`
+
+Covers slug generation, markdown sanitization, markdown rendering, SPC typing,
+domain mapping, and reverse coterie membership map behavior.
+
+## Validation
+
+- `npm run typecheck` (in `apps/bot`)
+- `npm test -- --run src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`
+
+## Follow-ups
+
+1. Extract Discord ingest and fetch routines into a separate module.
+2. Extract Notion write adapters and page upsert payload builders.
+3. Add integration tests that exercise `runNotionSync` with mocked Discord and
+   web API responses end-to-end.


### PR DESCRIPTION
## Summary
- extract wiki sync helper logic from `discord-notion-sync.ts` into `src/scripts/notionSync/wikiSyncHelpers.ts`
- centralize wiki taxonomy/constants and pure helper logic (slugging, markdown cleanup/rendering, spc typing, domain mapping)
- add helper unit tests and update bot integration memory + release notes

## Why
- starts the approved wiki roadmap modularization without changing runtime sync behavior
- shrinks the monolithic script and creates a stable seam for next-phase extraction work

## Validation
- npm run typecheck
- npm test -- --run src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts
- ./scripts/check-docs-parity.sh
