### PR TITLE
Bot wiki sync: extract Discord ingest helpers (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2026-04-18] Wiki Sync Modularization (Phase 2)
+
+### Bot Discord Ingest Maintainability
+
+- Extracted Discord REST ingest helpers from [`discord-notion-sync.ts`](apps/bot/src/scripts/discord-notion-sync.ts) into [`discordIngest.ts`](apps/bot/src/scripts/notionSync/discordIngest.ts).
+- Centralized typed pagination/fetch behavior for:
+  - `fetchAllMessages`
+  - `fetchForumThreads`
+  - `fetchPins`
+  - `fetchGuildMember`
+- Added targeted ingest tests in [`discordIngest.test.ts`](apps/bot/src/__tests__/discordIngest.test.ts) to lock pagination/filtering/error behavior before deeper refactors.
+- Added release notes: [`docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE2.md`](docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE2.md).
+
+---
+
 ## [2026-04-18] Wiki Sync Modularization (Phase 1)
 
 ### Bot Wiki Sync Maintainability

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -56,9 +56,17 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - shared wiki taxonomy + markdown/slug/domain helpers now live in
     `apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts`.
   - `discord-notion-sync.ts` imports these helpers; orchestration flow is unchanged.
+- Discord ingest extraction (phase 2):
+  - Discord REST pagination helpers now live in
+    `apps/bot/src/scripts/notionSync/discordIngest.ts`.
+  - `discord-notion-sync.ts` now imports `fetchAllMessages`, `fetchForumThreads`,
+    `fetchPins`, and `fetchGuildMember` from this module.
+  - dedicated tests added at `apps/bot/src/__tests__/discordIngest.test.ts`.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
+- Notion write orchestration and payload construction are still inline in
+  `discord-notion-sync.ts`; next phase should extract Notion page/db adapters.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.

--- a/apps/bot/src/__tests__/discordIngest.test.ts
+++ b/apps/bot/src/__tests__/discordIngest.test.ts
@@ -1,0 +1,86 @@
+import type { REST } from 'discord.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchAllMessages,
+  fetchForumThreads,
+  fetchGuildMember,
+} from '../scripts/notionSync/discordIngest';
+
+function message(id: string) {
+  return {
+    id,
+    content: `msg-${id}`,
+    author: { id: `u-${id}`, username: `user-${id}` },
+    timestamp: '2026-04-18T00:00:00.000Z',
+    attachments: [],
+  };
+}
+
+describe('discordIngest helpers', () => {
+  it('fetchAllMessages paginates and returns oldest-first ordering', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => message(String(200 - i)));
+    const secondPage = Array.from({ length: 20 }, (_, i) => message(String(100 - i)));
+    const get = vi.fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+    const rest = { get } as unknown as REST;
+
+    const result = await fetchAllMessages(rest, 'chan-1', 120, async () => {});
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(String(get.mock.calls[1][0])).toContain(`before=${firstPage[firstPage.length - 1].id}`);
+    expect(result).toHaveLength(120);
+    expect(result[0]?.id).toBe(secondPage[secondPage.length - 1].id);
+    expect(result[result.length - 1]?.id).toBe(firstPage[0].id);
+  });
+
+  it('fetchAllMessages returns empty when no messages are present', async () => {
+    const get = vi.fn().mockResolvedValueOnce([]);
+    const rest = { get } as unknown as REST;
+
+    const result = await fetchAllMessages(rest, 'chan-1', 50, async () => {});
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it('fetchGuildMember returns null on API errors', async () => {
+    const get = vi.fn().mockRejectedValueOnce(new Error('not found'));
+    const rest = { get } as unknown as REST;
+
+    const result = await fetchGuildMember(rest, 'guild-1', 'user-1');
+
+    expect(result).toBeNull();
+  });
+
+  it('fetchForumThreads merges active and archived forum threads', async () => {
+    const get = vi.fn()
+      .mockResolvedValueOnce({
+        threads: [
+          { id: 'active-forum', name: 'Active Forum', parent_id: 'forum-1', type: 11 },
+          { id: 'active-other', name: 'Active Other', parent_id: 'forum-2', type: 11 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        threads: [
+          { id: 'arch-2', name: 'Archived 2', parent_id: 'forum-1', type: 11 },
+          { id: 'arch-1', name: 'Archived 1', parent_id: 'forum-1', type: 11 },
+        ],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        threads: [
+          { id: 'arch-0', name: 'Archived 0', parent_id: 'forum-1', type: 11 },
+        ],
+        has_more: false,
+      });
+    const rest = { get } as unknown as REST;
+
+    const result = await fetchForumThreads(rest, 'guild-1', 'forum-1', async () => {});
+
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(String(get.mock.calls[1][0])).toContain('/channels/forum-1/threads/archived/public?');
+    expect(String(get.mock.calls[2][0])).toContain('before=arch-1');
+    expect(result.map((t) => t.id)).toEqual(['active-forum', 'arch-2', 'arch-1', 'arch-0']);
+  });
+});

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -40,6 +40,15 @@ import * as dotenv from 'dotenv';
 import { REST, Routes } from 'discord.js';
 import { Client as NotionClient } from '@notionhq/client';
 import {
+  type DiscordChannel,
+  type DiscordMessage,
+  type DiscordThread,
+  fetchAllMessages,
+  fetchForumThreads,
+  fetchGuildMember,
+  fetchPins,
+} from './notionSync/discordIngest';
+import {
   CHAR_TO_COTERIE,
   COTERIE_MEMBERS,
   FACTIONS,
@@ -133,45 +142,6 @@ if (require.main === module) {
   runNotionSync(cliOpts).then((result) => {
     if (!result.success) { console.error('Sync failed:', result.error); process.exit(1); }
   }).catch((err) => { console.error('Fatal:', err); process.exit(1); });
-}
-
-// ---------------------------------------------------------------------------
-// Discord types
-// ---------------------------------------------------------------------------
-
-interface DiscordChannel {
-  id: string;
-  name: string;
-  type: number;
-  parent_id?: string;
-  topic?: string;
-}
-
-interface DiscordThread {
-  id: string;
-  name: string;
-  parent_id: string;
-  type: number;
-  thread_metadata?: { archive_timestamp?: string };
-}
-
-interface DiscordAttachment {
-  url: string;
-  content_type?: string;
-  filename: string;
-}
-
-interface DiscordMessage {
-  id: string;
-  content: string;
-  author: { id: string; username: string; global_name?: string };
-  timestamp: string;
-  attachments?: DiscordAttachment[];
-}
-
-interface DiscordGuildMember {
-  user?: { id: string; username: string; global_name?: string };
-  nick?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -356,70 +326,6 @@ async function wikiDelete(webBase: string, writeToken: string, slug: string, dry
   } catch (err) {
     console.log(`  [wiki warn] delete "${slug}" failed: ${err}`);
   }
-}
-
-// ---------------------------------------------------------------------------
-// Discord REST helpers
-// ---------------------------------------------------------------------------
-
-async function fetchAllMessages(rest: REST, channelId: string, limit: number): Promise<DiscordMessage[]> {
-  const all: DiscordMessage[] = [];
-  let before: string | undefined;
-  while (all.length < limit) {
-    const batch = Math.min(100, limit - all.length);
-    const params = new URLSearchParams({ limit: String(batch) });
-    if (before) params.set('before', before);
-    const msgs = await rest.get(`${Routes.channelMessages(channelId)}?${params}`) as DiscordMessage[];
-    if (!msgs.length) break;
-    all.push(...msgs);
-    before = msgs[msgs.length - 1].id;
-    if (msgs.length < 100) break;
-    await sleep(250);
-  }
-  return all.reverse(); // oldest first
-}
-
-async function fetchPins(rest: REST, channelId: string): Promise<DiscordMessage[]> {
-  return rest.get(Routes.channelPins(channelId)) as Promise<DiscordMessage[]>;
-}
-
-async function fetchGuildMember(rest: REST, guildId: string, userId: string): Promise<DiscordGuildMember | null> {
-  try {
-    return await rest.get(Routes.guildMember(guildId, userId)) as DiscordGuildMember;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Fetch all threads for a forum channel (active + archived).
- * Active threads come from the guild-wide endpoint; archived are paginated per-channel.
- */
-async function fetchForumThreads(rest: REST, guildId: string, forumChannelId: string): Promise<DiscordThread[]> {
-  const threads: DiscordThread[] = [];
-
-  // Active threads (guild-wide, filter to this forum)
-  const active = await rest.get(Routes.guildActiveThreads(guildId)) as { threads: DiscordThread[] };
-  for (const t of active.threads) {
-    if (t.parent_id === forumChannelId) threads.push(t);
-  }
-  await sleep(200);
-
-  // Archived threads (paginated, forum-specific)
-  let before: string | undefined;
-  for (;;) {
-    const params = new URLSearchParams({ limit: '100' });
-    if (before) params.set('before', before);
-    const archived = await rest.get(
-      `/channels/${forumChannelId}/threads/archived/public?${params}`,
-    ) as { threads: DiscordThread[]; has_more: boolean };
-    threads.push(...archived.threads);
-    if (!archived.has_more || !archived.threads.length) break;
-    before = archived.threads[archived.threads.length - 1].id;
-    await sleep(250);
-  }
-
-  return threads;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/bot/src/scripts/notionSync/discordIngest.ts
+++ b/apps/bot/src/scripts/notionSync/discordIngest.ts
@@ -1,0 +1,114 @@
+import { REST, Routes } from 'discord.js';
+
+export interface DiscordChannel {
+  id: string;
+  name: string;
+  type: number;
+  parent_id?: string;
+  topic?: string;
+}
+
+export interface DiscordThread {
+  id: string;
+  name: string;
+  parent_id: string;
+  type: number;
+  thread_metadata?: { archive_timestamp?: string };
+}
+
+export interface DiscordAttachment {
+  url: string;
+  content_type?: string;
+  filename: string;
+}
+
+export interface DiscordMessage {
+  id: string;
+  content: string;
+  author: { id: string; username: string; global_name?: string };
+  timestamp: string;
+  attachments?: DiscordAttachment[];
+}
+
+export interface DiscordGuildMember {
+  user?: { id: string; username: string; global_name?: string };
+  nick?: string;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function fetchAllMessages(
+  rest: REST,
+  channelId: string,
+  limit: number,
+  pause: (ms: number) => Promise<void> = sleep,
+): Promise<DiscordMessage[]> {
+  const all: DiscordMessage[] = [];
+  let before: string | undefined;
+  while (all.length < limit) {
+    const batch = Math.min(100, limit - all.length);
+    const params = new URLSearchParams({ limit: String(batch) });
+    if (before) params.set('before', before);
+    const msgs = await rest.get(`${Routes.channelMessages(channelId)}?${params}`) as DiscordMessage[];
+    if (!msgs.length) break;
+    all.push(...msgs);
+    before = msgs[msgs.length - 1].id;
+    if (msgs.length < 100) break;
+    await pause(250);
+  }
+  return all.reverse(); // oldest first
+}
+
+export async function fetchPins(rest: REST, channelId: string): Promise<DiscordMessage[]> {
+  return rest.get(Routes.channelPins(channelId)) as Promise<DiscordMessage[]>;
+}
+
+export async function fetchGuildMember(
+  rest: REST,
+  guildId: string,
+  userId: string,
+): Promise<DiscordGuildMember | null> {
+  try {
+    return await rest.get(Routes.guildMember(guildId, userId)) as DiscordGuildMember;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch all threads for a forum channel (active + archived).
+ * Active threads come from the guild-wide endpoint; archived are paginated per-channel.
+ */
+export async function fetchForumThreads(
+  rest: REST,
+  guildId: string,
+  forumChannelId: string,
+  pause: (ms: number) => Promise<void> = sleep,
+): Promise<DiscordThread[]> {
+  const threads: DiscordThread[] = [];
+
+  // Active threads (guild-wide, filter to this forum)
+  const active = await rest.get(Routes.guildActiveThreads(guildId)) as { threads: DiscordThread[] };
+  for (const t of active.threads) {
+    if (t.parent_id === forumChannelId) threads.push(t);
+  }
+  await pause(200);
+
+  // Archived threads (paginated, forum-specific)
+  let before: string | undefined;
+  for (;;) {
+    const params = new URLSearchParams({ limit: '100' });
+    if (before) params.set('before', before);
+    const archived = await rest.get(
+      `/channels/${forumChannelId}/threads/archived/public?${params}`,
+    ) as { threads: DiscordThread[]; has_more: boolean };
+    threads.push(...archived.threads);
+    if (!archived.has_more || !archived.threads.length) break;
+    before = archived.threads[archived.threads.length - 1].id;
+    await pause(250);
+  }
+
+  return threads;
+}

--- a/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE2.md
+++ b/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE2.md
@@ -1,0 +1,52 @@
+# Release: 2026-04-18 — Wiki Sync Modularization (Phase 2)
+
+## Summary
+
+Continues the `discord-notion-sync.ts` decomposition by extracting Discord
+ingest/pagination helpers into a dedicated module and adding focused tests.
+
+## What Changed
+
+### 1) New Discord ingest module
+
+Added:
+
+- `apps/bot/src/scripts/notionSync/discordIngest.ts`
+
+This module now owns:
+
+- Discord data interfaces (`DiscordChannel`, `DiscordThread`, `DiscordMessage`,
+  `DiscordGuildMember`)
+- message pagination (`fetchAllMessages`)
+- forum thread retrieval (`fetchForumThreads`)
+- pin fetch (`fetchPins`)
+- guild member lookup (`fetchGuildMember`)
+
+### 2) `discord-notion-sync.ts` now imports ingest helpers
+
+`apps/bot/src/scripts/discord-notion-sync.ts` now imports the ingest helpers
+instead of defining these routines inline. Sync behavior remains unchanged.
+
+### 3) New ingest tests
+
+Added:
+
+- `apps/bot/src/__tests__/discordIngest.test.ts`
+
+Covers:
+
+- paginated message fetch + oldest-first output ordering
+- empty message handling
+- guild-member lookup error fallback
+- active/archived forum thread merge behavior and parent-forum filtering
+
+## Validation
+
+- `npm run typecheck` (in `apps/bot`)
+- `npm test -- --run src/__tests__/discordIngest.test.ts src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`
+
+## Follow-ups
+
+1. Extract Notion write adapters/payload builders into a `notionWrites` module.
+2. Extract web wiki upsert/delete/status write wrappers into a dedicated client module.
+3. Add orchestration-level integration tests for `runNotionSync` with mocked Discord + web APIs.


### PR DESCRIPTION
## Summary
- extract Discord ingest/pagination helpers from `discord-notion-sync.ts` into `src/scripts/notionSync/discordIngest.ts`
- centralize Discord sync interfaces and REST fetch behavior (`fetchAllMessages`, `fetchForumThreads`, `fetchPins`, `fetchGuildMember`)
- add ingest-specific unit tests and update docs/memory snapshots

## Why
- continues wiki sync modularization with behavior-preserving refactor
- creates a stable seam for upcoming Notion write and web wiki-client extractions

## Validation
- npm run typecheck
- npm test -- --run src/__tests__/discordIngest.test.ts src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts
- ./scripts/check-docs-parity.sh
