### PR TITLE
Bot wiki sync: extract Notion write helpers (phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2026-04-18] Wiki Sync Modularization (Phase 3)
+
+### Bot Notion Write Maintainability
+
+- Extracted Notion write/retry helpers from [`discord-notion-sync.ts`](apps/bot/src/scripts/discord-notion-sync.ts) into [`notionWrites.ts`](apps/bot/src/scripts/notionSync/notionWrites.ts).
+- Centralized Notion helper behavior for:
+  - `notionCall` retry/backoff wrapper
+  - `appendBodyBlocks` chunked block writes
+  - `cleanupPreImportEntries` archive pass for non-sync rows
+  - shared `SOURCE_TAG` and title extraction helper
+- Added focused tests in [`notionWrites.test.ts`](apps/bot/src/__tests__/notionWrites.test.ts) for retry, chunking, and cleanup semantics.
+- Added release notes: [`docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE3.md`](docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE3.md).
+
+---
+
 ## [2026-04-18] Wiki Sync Modularization (Phase 2)
 
 ### Bot Discord Ingest Maintainability

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -62,11 +62,18 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `discord-notion-sync.ts` now imports `fetchAllMessages`, `fetchForumThreads`,
     `fetchPins`, and `fetchGuildMember` from this module.
   - dedicated tests added at `apps/bot/src/__tests__/discordIngest.test.ts`.
+- Notion writes extraction (phase 3):
+  - Notion retry/chunk/cleanup helpers now live in
+    `apps/bot/src/scripts/notionSync/notionWrites.ts`.
+  - `discord-notion-sync.ts` now imports `notionCall`, `appendBodyBlocks`,
+    `cleanupPreImportEntries`, and `SOURCE_TAG` from this module.
+  - dedicated tests added at `apps/bot/src/__tests__/notionWrites.test.ts`.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
-- Notion write orchestration and payload construction are still inline in
-  `discord-notion-sync.ts`; next phase should extract Notion page/db adapters.
+- Notion page payload construction is still mostly inline in
+  `discord-notion-sync.ts`; next phase should extract Notion page/db adapter
+  functions (PC/SPC/location/session builders) into a dedicated module.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.

--- a/apps/bot/src/__tests__/notionWrites.test.ts
+++ b/apps/bot/src/__tests__/notionWrites.test.ts
@@ -1,0 +1,142 @@
+import type { Client as NotionClient } from '@notionhq/client';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  appendBodyBlocks,
+  cleanupPreImportEntries,
+  getPageTitle,
+  notionCall,
+} from '../scripts/notionSync/notionWrites';
+
+describe('notionWrites helpers', () => {
+  it('notionCall retries transient notion errors then succeeds', async () => {
+    const sleepFn = vi.fn(async () => {});
+    const log = vi.fn();
+    let tries = 0;
+    const fn = vi.fn(async () => {
+      tries += 1;
+      if (tries < 3) {
+        const err = new Error('timeout') as Error & { code?: string };
+        err.code = 'notionhq_client_request_timeout';
+        throw err;
+      }
+      return 'ok';
+    });
+
+    const result = await notionCall(fn, { sleepFn, log });
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenNthCalledWith(1, 350);
+    expect(sleepFn).toHaveBeenNthCalledWith(2, 2000);
+    expect(sleepFn).toHaveBeenNthCalledWith(3, 4000);
+  });
+
+  it('notionCall does not retry non-transient errors', async () => {
+    const sleepFn = vi.fn(async () => {});
+    const fn = vi.fn(async () => {
+      throw new Error('boom');
+    });
+
+    await expect(notionCall(fn, { sleepFn, log: vi.fn() })).rejects.toThrow('boom');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('appendBodyBlocks chunks writes in batches of 100', async () => {
+    const append = vi.fn(async () => ({}));
+    const notion = {
+      blocks: { children: { append } },
+    } as unknown as NotionClient;
+    const blocks = Array.from({ length: 205 }, (_, i) => ({ object: 'block', id: `b-${i}` }));
+
+    await appendBodyBlocks(notion, 'page-1', blocks, async (fn) => fn());
+
+    expect(append).toHaveBeenCalledTimes(3);
+    expect(append.mock.calls[0][0].children).toHaveLength(100);
+    expect(append.mock.calls[1][0].children).toHaveLength(100);
+    expect(append.mock.calls[2][0].children).toHaveLength(5);
+  });
+
+  it('getPageTitle extracts title from notion-like properties', () => {
+    expect(getPageTitle({
+      Name: {
+        type: 'title',
+        title: [{ plain_text: 'Alpha' }, { plain_text: ' Beta' }],
+      },
+    })).toBe('Alpha Beta');
+    expect(getPageTitle({ Other: { type: 'rich_text', rich_text: [] } })).toBe('(untitled)');
+  });
+
+  it('cleanupPreImportEntries archives only non-sync pages', async () => {
+    const query = vi.fn(async () => ({
+      results: [
+        {
+          object: 'page',
+          id: 'keep-1',
+          properties: {
+            Source: { select: { name: 'discord-sync' } },
+            Name: { type: 'title', title: [{ plain_text: 'Keep' }] },
+          },
+        },
+        {
+          object: 'page',
+          id: 'old-1',
+          properties: {
+            Name: { type: 'title', title: [{ plain_text: 'Archive me' }] },
+          },
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    }));
+    const update = vi.fn(async () => ({}));
+    const notion = {
+      databases: { query },
+      pages: { update },
+    } as unknown as NotionClient;
+    const log = vi.fn();
+
+    await cleanupPreImportEntries(notion, {
+      databaseIds: { TEST_DB: 'db-1' },
+      dryRun: false,
+      call: async (fn) => fn(),
+      log,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({ page_id: 'old-1', archived: true });
+    expect(log).toHaveBeenCalledWith('  [TEST_DB] archive: "Archive me"');
+  });
+
+  it('cleanupPreImportEntries does not archive in dry-run mode', async () => {
+    const notion = {
+      databases: {
+        query: vi.fn(async () => ({
+          results: [
+            {
+              object: 'page',
+              id: 'old-1',
+              properties: {
+                Name: { type: 'title', title: [{ plain_text: 'Archive me' }] },
+              },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        })),
+      },
+      pages: { update: vi.fn(async () => ({})) },
+    } as unknown as NotionClient;
+
+    await cleanupPreImportEntries(notion, {
+      databaseIds: { TEST_DB: 'db-1' },
+      dryRun: true,
+      call: async (fn) => fn(),
+      log: vi.fn(),
+    });
+
+    expect(notion.pages.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -49,6 +49,12 @@ import {
   fetchPins,
 } from './notionSync/discordIngest';
 import {
+  appendBodyBlocks,
+  cleanupPreImportEntries,
+  notionCall,
+  SOURCE_TAG,
+} from './notionSync/notionWrites';
+import {
   CHAR_TO_COTERIE,
   COTERIE_MEMBERS,
   FACTIONS,
@@ -152,38 +158,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function notionCall<T>(fn: () => Promise<T>): Promise<T> {
-  await sleep(350);
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      const code = (err as { code?: string }).code;
-      if (code === 'notionhq_client_request_timeout' || code === 'notionhq_client_response_error') {
-        if (attempt < 2) {
-          console.log(`  [retry] Notion timeout/error, waiting ${(attempt + 1) * 2}s…`);
-          await sleep((attempt + 1) * 2000);
-          continue;
-        }
-      }
-      throw err;
-    }
-  }
-  throw new Error('unreachable');
-}
-
 function toTitleCase(str: string): string {
   return str.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function truncate(text: string, max: number): string {
   return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
-}
-
-function chunks<T>(arr: T[], size: number): T[][] {
-  const result: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) result.push(arr.slice(i, i + size));
-  return result;
 }
 
 function textToBlocks(text: string): object[] {
@@ -360,21 +340,6 @@ async function fetchActiveRoster(webBase: string, webReadToken: string): Promise
   }
 }
 
-// ---------------------------------------------------------------------------
-// Notion helpers
-// ---------------------------------------------------------------------------
-
-async function appendBodyBlocks(notion: NotionClient, pageId: string, blocks: object[]) {
-  for (const chunk of chunks(blocks, 100)) {
-    await notionCall(() =>
-      notion.blocks.children.append({
-        block_id: pageId,
-        children: chunk as Parameters<typeof notion.blocks.children.append>[0]['children'],
-      }),
-    );
-  }
-}
-
 function firstImage(messages: DiscordMessage[]): string | null {
   for (const msg of messages) {
     for (const a of msg.attachments ?? []) {
@@ -413,58 +378,6 @@ function messagesToBlocks(messages: DiscordMessage[]): object[] {
     blocks.push({ object: 'block', type: 'divider', divider: {} });
   }
   return blocks;
-}
-
-// ---------------------------------------------------------------------------
-// Pre-import cleanup
-// ---------------------------------------------------------------------------
-
-const SOURCE_TAG = 'discord-sync';
-
-function getPageTitle(page: { properties: Record<string, unknown> }): string {
-  for (const val of Object.values(page.properties)) {
-    const v = val as { id?: string; type?: string; title?: { plain_text: string }[] };
-    if (v.type === 'title' && Array.isArray(v.title)) {
-      return v.title.map((t) => t.plain_text).join('') || '(untitled)';
-    }
-  }
-  return '(untitled)';
-}
-
-async function cleanupPreImportEntries(notion: NotionClient, dryRun: boolean): Promise<void> {
-  console.log('\n[cleanup] Archiving pre-import entries from all databases…');
-  for (const [dbName, dbId] of Object.entries(NOTION_DB)) {
-    let cursor: string | undefined;
-    let removed = 0;
-    let kept = 0;
-    for (;;) {
-      const result = await notionCall(() =>
-        notion.databases.query({
-          database_id: dbId,
-          page_size: 100,
-          ...(cursor ? { start_cursor: cursor } : {}),
-        }),
-      );
-      for (const page of result.results) {
-        if (page.object !== 'page' || !('properties' in page)) continue;
-        const props = page.properties as Record<string, unknown>;
-        const source = (props['Source'] as { select?: { name: string } } | undefined)?.select?.name;
-        if (source === SOURCE_TAG) {
-          kept++;
-        } else {
-          const title = getPageTitle({ properties: props });
-          console.log(`  [${dbName}] archive: "${title}"`);
-          if (!dryRun) {
-            await notionCall(() => notion.pages.update({ page_id: page.id, archived: true }));
-          }
-          removed++;
-        }
-      }
-      if (!result.has_more) break;
-      cursor = result.next_cursor ?? undefined;
-    }
-    console.log(`  [${dbName}] kept: ${kept}, archived: ${removed}${dryRun ? ' (dry-run)' : ''}`);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -513,7 +426,10 @@ async function main(opts: NotionSyncOptions) {
   }
 
   if (CLEANUP && NOTION_ENABLED) {
-    await cleanupPreImportEntries(notion!, DRY_RUN);
+    await cleanupPreImportEntries(notion!, {
+      databaseIds: NOTION_DB,
+      dryRun: DRY_RUN,
+    });
   }
 
   // ------------------------------------------------------------------

--- a/apps/bot/src/scripts/notionSync/notionWrites.ts
+++ b/apps/bot/src/scripts/notionSync/notionWrites.ts
@@ -1,0 +1,121 @@
+import type { Client as NotionClient } from '@notionhq/client';
+
+export const SOURCE_TAG = 'discord-sync';
+
+type SleepFn = (ms: number) => Promise<void>;
+type LogFn = (message: string) => void;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function notionCall<T>(
+  fn: () => Promise<T>,
+  opts: {
+    sleepFn?: SleepFn;
+    log?: LogFn;
+  } = {},
+): Promise<T> {
+  const sleepFn = opts.sleepFn ?? sleep;
+  const log = opts.log ?? console.log;
+
+  await sleepFn(350);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === 'notionhq_client_request_timeout' || code === 'notionhq_client_response_error') {
+        if (attempt < 2) {
+          const retryDelayMs = (attempt + 1) * 2000;
+          log(`  [retry] Notion timeout/error, waiting ${(attempt + 1) * 2}s…`);
+          await sleepFn(retryDelayMs);
+          continue;
+        }
+      }
+      throw err;
+    }
+  }
+  throw new Error('unreachable');
+}
+
+function chunks<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) result.push(arr.slice(i, i + size));
+  return result;
+}
+
+export async function appendBodyBlocks(
+  notion: NotionClient,
+  pageId: string,
+  blocks: object[],
+  call: <T>(fn: () => Promise<T>) => Promise<T> = notionCall,
+): Promise<void> {
+  for (const chunk of chunks(blocks, 100)) {
+    await call(() =>
+      notion.blocks.children.append({
+        block_id: pageId,
+        children: chunk as Parameters<typeof notion.blocks.children.append>[0]['children'],
+      }),
+    );
+  }
+}
+
+export function getPageTitle(properties: Record<string, unknown>): string {
+  for (const val of Object.values(properties)) {
+    const v = val as { type?: string; title?: { plain_text: string }[] };
+    if (v.type === 'title' && Array.isArray(v.title)) {
+      return v.title.map((t) => t.plain_text).join('') || '(untitled)';
+    }
+  }
+  return '(untitled)';
+}
+
+export async function cleanupPreImportEntries(
+  notion: NotionClient,
+  opts: {
+    databaseIds: Record<string, string>;
+    dryRun: boolean;
+    call?: <T>(fn: () => Promise<T>) => Promise<T>;
+    log?: LogFn;
+    sourceTag?: string;
+  },
+): Promise<void> {
+  const call = opts.call ?? notionCall;
+  const log = opts.log ?? console.log;
+  const sourceTag = opts.sourceTag ?? SOURCE_TAG;
+
+  log('\n[cleanup] Archiving pre-import entries from all databases…');
+  for (const [dbName, dbId] of Object.entries(opts.databaseIds)) {
+    let cursor: string | undefined;
+    let removed = 0;
+    let kept = 0;
+    for (;;) {
+      const result = await call(() =>
+        notion.databases.query({
+          database_id: dbId,
+          page_size: 100,
+          ...(cursor ? { start_cursor: cursor } : {}),
+        }),
+      );
+      for (const page of result.results) {
+        if (page.object !== 'page' || !('properties' in page)) continue;
+        const props = page.properties as Record<string, unknown>;
+        const source = (props.Source as { select?: { name: string } } | undefined)?.select?.name;
+        if (source === sourceTag) {
+          kept++;
+        } else {
+          const title = getPageTitle(props);
+          log(`  [${dbName}] archive: "${title}"`);
+          if (!opts.dryRun) {
+            await call(() => notion.pages.update({ page_id: page.id, archived: true }));
+          }
+          removed++;
+        }
+      }
+      if (!result.has_more) break;
+      cursor = result.next_cursor ?? undefined;
+    }
+    log(`  [${dbName}] kept: ${kept}, archived: ${removed}${opts.dryRun ? ' (dry-run)' : ''}`);
+  }
+}

--- a/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE3.md
+++ b/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE3.md
@@ -1,0 +1,54 @@
+# Release: 2026-04-18 — Wiki Sync Modularization (Phase 3)
+
+## Summary
+
+Continues decomposition of `discord-notion-sync.ts` by extracting Notion
+write/retry helpers into a dedicated module and adding focused tests.
+
+## What Changed
+
+### 1) New Notion writes module
+
+Added:
+
+- `apps/bot/src/scripts/notionSync/notionWrites.ts`
+
+This module now owns:
+
+- `notionCall` (retry/backoff wrapper for transient Notion API errors)
+- `appendBodyBlocks` (chunked children append in batches of 100)
+- `cleanupPreImportEntries` (archive pre-import rows not tagged as sync-owned)
+- `SOURCE_TAG` constant and `getPageTitle` extraction helper
+
+### 2) `discord-notion-sync.ts` imports Notion helpers
+
+`apps/bot/src/scripts/discord-notion-sync.ts` now imports the Notion helper
+functions from `notionWrites.ts` instead of defining them inline. Runtime flow
+and sync behavior remain unchanged.
+
+### 3) New Notion helper tests
+
+Added:
+
+- `apps/bot/src/__tests__/notionWrites.test.ts`
+
+Covers:
+
+- transient Notion error retry behavior
+- non-transient failure passthrough
+- append chunk sizing for body block writes
+- pre-import cleanup archival selection and dry-run behavior
+
+## Validation
+
+- `npm run typecheck` (in `apps/bot`)
+- `npm test -- --run src/__tests__/notionWrites.test.ts src/__tests__/discordIngest.test.ts src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`
+
+## Follow-ups
+
+1. Extract Notion page payload builders (PC/SPC/location/session) into
+   reusable adapter functions.
+2. Extract wiki web-API write client (`wikiUpsert` / `wikiDelete` /
+   `wikiSetCharacterStatus`) into a dedicated module.
+3. Add orchestration-level integration tests around `runNotionSync` with
+   mocked Discord + web + Notion clients.


### PR DESCRIPTION
## Summary
- extract Notion write/retry/cleanup helpers from `discord-notion-sync.ts` into `src/scripts/notionSync/notionWrites.ts`
- centralize `notionCall`, `appendBodyBlocks`, `cleanupPreImportEntries`, `SOURCE_TAG`, and page-title extraction helper logic
- add focused Notion helper tests and update docs/memory snapshots

## Why
- continues wiki sync modularization with behavior-preserving refactor
- isolates Notion API concerns from orchestration flow and creates a seam for payload-builder extraction

## Validation
- npm run typecheck
- npm test -- --run src/__tests__/notionWrites.test.ts src/__tests__/discordIngest.test.ts src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts
- ./scripts/check-docs-parity.sh
