### PR TITLE
Bot wiki sync: extract Notion payload builders (phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2026-04-18] Wiki Sync Modularization (Phase 4)
+
+### Bot Notion Payload Builder Extraction
+
+- Extracted Notion page payload construction from [`discord-notion-sync.ts`](apps/bot/src/scripts/discord-notion-sync.ts) into [`notionPayloadBuilders.ts`](apps/bot/src/scripts/notionSync/notionPayloadBuilders.ts).
+- Centralized payload builders for:
+  - location entries
+  - hunting site entries
+  - SPC entries
+  - PC tracker entries
+  - session/post log entries
+- Updated `discord-notion-sync.ts` to call the shared payload builders with no behavior change.
+- Added focused tests in [`notionPayloadBuilders.test.ts`](apps/bot/src/__tests__/notionPayloadBuilders.test.ts).
+- Added release notes: [`docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE4.md`](docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE4.md).
+
+---
+
 ## [2026-04-18] Wiki Per-Page Sync Lock
 
 ### Manual Guardrail for Discord→Wiki Sync

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -73,12 +73,19 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `discord-notion-sync.ts` now imports `notionCall`, `appendBodyBlocks`,
     `cleanupPreImportEntries`, and `SOURCE_TAG` from this module.
   - dedicated tests added at `apps/bot/src/__tests__/notionWrites.test.ts`.
+- Notion payload builders extraction (phase 4):
+  - Notion page payload construction now lives in
+    `apps/bot/src/scripts/notionSync/notionPayloadBuilders.ts`.
+  - `discord-notion-sync.ts` now imports payload builders for
+    Location/Hunting/SPC/PC/Session create operations.
+  - dedicated tests added at
+    `apps/bot/src/__tests__/notionPayloadBuilders.test.ts`.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
-- Notion page payload construction is still mostly inline in
-  `discord-notion-sync.ts`; next phase should extract Notion page/db adapter
-  functions (PC/SPC/location/session builders) into a dedicated module.
+- Wiki API write wrappers (`wikiUpsert`, `wikiDelete`, `wikiSetCharacterStatus`)
+  are still inline in `discord-notion-sync.ts`; next phase should extract a
+  dedicated web wiki client module.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.

--- a/apps/bot/src/__tests__/notionPayloadBuilders.test.ts
+++ b/apps/bot/src/__tests__/notionPayloadBuilders.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHuntingSiteCreatePayload,
+  buildLocationCreatePayload,
+  buildPcTrackerCreatePayload,
+  buildSessionLogCreatePayload,
+  buildSpcCreatePayload,
+} from '../scripts/notionSync/notionPayloadBuilders';
+
+describe('notionPayloadBuilders', () => {
+  it('builds location payload with optional atmosphere notes', () => {
+    const withNotes = buildLocationCreatePayload({
+      databaseId: 'db-location',
+      locationName: 'North Nashville',
+      sourceTag: 'discord-sync',
+      atmosphereNotes: 'Neon and rain.',
+    });
+    expect(withNotes.parent).toEqual({ database_id: 'db-location' });
+    expect(withNotes.properties).toMatchObject({
+      Location: { title: [{ text: { content: 'North Nashville' } }] },
+      Source: { select: { name: 'discord-sync' } },
+      'Atmosphere Notes': { rich_text: [{ text: { content: 'Neon and rain.' } }] },
+    });
+
+    const withoutNotes = buildLocationCreatePayload({
+      databaseId: 'db-location',
+      locationName: 'Midtown',
+      sourceTag: 'discord-sync',
+    });
+    expect(withoutNotes.properties).not.toHaveProperty('Atmosphere Notes');
+  });
+
+  it('builds hunting site payload with optional domain', () => {
+    const withDomain = buildHuntingSiteCreatePayload({
+      databaseId: 'db-hunting',
+      siteName: 'Printer Alley',
+      description: 'Crowded nightlife feeding ground.',
+      sourceTag: 'discord-sync',
+      domain: 'Downtown',
+    });
+    expect(withDomain.properties).toMatchObject({
+      'Site Name': { title: [{ text: { content: 'Printer Alley' } }] },
+      Description: { rich_text: [{ text: { content: 'Crowded nightlife feeding ground.' } }] },
+      Source: { select: { name: 'discord-sync' } },
+      Domain: { select: { name: 'Downtown' } },
+    });
+
+    const withoutDomain = buildHuntingSiteCreatePayload({
+      databaseId: 'db-hunting',
+      siteName: 'Riverbank',
+      description: 'Quiet.',
+      sourceTag: 'discord-sync',
+    });
+    expect(withoutDomain.properties).not.toHaveProperty('Domain');
+  });
+
+  it('builds spc payload with optional type and cover', () => {
+    const withCover = buildSpcCreatePayload({
+      databaseId: 'db-spc',
+      name: 'Sheriff Vale',
+      sourceTag: 'discord-sync',
+      relationshipNotes: 'Sheriff of the city.',
+      spcType: 'Mawla',
+      coverUrl: 'https://example.com/cover.png',
+    });
+    expect(withCover.cover).toEqual({ type: 'external', external: { url: 'https://example.com/cover.png' } });
+    expect(withCover.properties).toMatchObject({
+      Name: { title: [{ text: { content: 'Sheriff Vale' } }] },
+      Status: { select: { name: 'Active' } },
+      Source: { select: { name: 'discord-sync' } },
+      Type: { select: { name: 'Mawla' } },
+      'Relationship Notes': { rich_text: [{ text: { content: 'Sheriff of the city.' } }] },
+    });
+
+    const withoutType = buildSpcCreatePayload({
+      databaseId: 'db-spc',
+      name: 'Unknown',
+      sourceTag: 'discord-sync',
+      relationshipNotes: 'N/A',
+    });
+    expect(withoutType).not.toHaveProperty('cover');
+    expect(withoutType.properties).not.toHaveProperty('Type');
+  });
+
+  it('builds pc tracker payload with optional player metadata', () => {
+    const payload = buildPcTrackerCreatePayload({
+      databaseId: 'db-pc',
+      name: 'Alice',
+      sourceTag: 'discord-sync',
+      playerName: 'Player One',
+      clan: 'Ventrue',
+      sect: 'Camarilla',
+      coterie: 'The Brood',
+    });
+    expect(payload.properties).toMatchObject({
+      'Character Name': { title: [{ text: { content: 'Alice' } }] },
+      Source: { select: { name: 'discord-sync' } },
+      Player: { rich_text: [{ text: { content: 'Player One' } }] },
+      Clan: { select: { name: 'Ventrue' } },
+      Sect: { select: { name: 'Camarilla' } },
+      Coterie: { rich_text: [{ text: { content: 'The Brood' } }] },
+    });
+
+    const minimal = buildPcTrackerCreatePayload({
+      databaseId: 'db-pc',
+      name: 'Bob',
+      sourceTag: 'discord-sync',
+    });
+    expect(minimal.properties).not.toHaveProperty('Player');
+    expect(minimal.properties).not.toHaveProperty('Clan');
+    expect(minimal.properties).not.toHaveProperty('Sect');
+    expect(minimal.properties).not.toHaveProperty('Coterie');
+  });
+
+  it('builds session log payload with optional cover', () => {
+    const payload = buildSessionLogCreatePayload({
+      databaseId: 'db-session',
+      title: '#music-city-histories archive',
+      summary: 'Latest post summary',
+      date: '2026-04-18',
+      sourceTag: 'discord-sync',
+      coverUrl: 'https://example.com/session-cover.png',
+    });
+    expect(payload.cover).toEqual({
+      type: 'external',
+      external: { url: 'https://example.com/session-cover.png' },
+    });
+    expect(payload.properties).toMatchObject({
+      'Session/Post Title': { title: [{ text: { content: '#music-city-histories archive' } }] },
+      Status: { select: { name: 'Complete' } },
+      Source: { select: { name: 'discord-sync' } },
+      Summary: { rich_text: [{ text: { content: 'Latest post summary' } }] },
+      Date: { date: { start: '2026-04-18' } },
+    });
+
+    const noCover = buildSessionLogCreatePayload({
+      databaseId: 'db-session',
+      title: 'Entry',
+      summary: 'Summary',
+      date: '2026-04-19',
+      sourceTag: 'discord-sync',
+    });
+    expect(noCover).not.toHaveProperty('cover');
+  });
+});

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -55,6 +55,13 @@ import {
   SOURCE_TAG,
 } from './notionSync/notionWrites';
 import {
+  buildHuntingSiteCreatePayload,
+  buildLocationCreatePayload,
+  buildPcTrackerCreatePayload,
+  buildSessionLogCreatePayload,
+  buildSpcCreatePayload,
+} from './notionSync/notionPayloadBuilders';
+import {
   CHAR_TO_COTERIE,
   COTERIE_MEMBERS,
   FACTIONS,
@@ -357,10 +364,6 @@ function firstImage(messages: DiscordMessage[]): string | null {
   return null;
 }
 
-function coverProp(url: string): { type: 'external'; external: { url: string } } {
-  return { type: 'external', external: { url } };
-}
-
 function imageBlock(url: string): object {
   return {
     object: 'block',
@@ -483,14 +486,12 @@ async function main(opts: NotionSyncOptions) {
       if (!DRY_RUN) {
         if (NOTION_ENABLED) {
           await notionCall(() =>
-            notion!.pages.create({
-              parent: { database_id: NOTION_DB.LOCATION_DB },
-              properties: {
-                'Location': { title: [{ text: { content: locationName } }] },
-                'Source': { select: { name: SOURCE_TAG } },
-                ...(ch.topic ? { 'Atmosphere Notes': { rich_text: [{ text: { content: truncate(ch.topic, 2000) } }] } } : {}),
-              },
-            }),
+            notion!.pages.create(buildLocationCreatePayload({
+              databaseId: NOTION_DB.LOCATION_DB,
+              locationName,
+              sourceTag: SOURCE_TAG,
+              atmosphereNotes: ch.topic ? truncate(ch.topic, 2000) : undefined,
+            })),
           );
         }
         // Wiki upsert deferred to step 4 so hunting site pins can be included.
@@ -523,15 +524,13 @@ async function main(opts: NotionSyncOptions) {
       console.log(`    → ${siteName}`);
       if (!DRY_RUN && NOTION_ENABLED) {
         await notionCall(() =>
-          notion!.pages.create({
-            parent: { database_id: NOTION_DB.HUNTING_SITES },
-            properties: {
-              'Site Name': { title: [{ text: { content: siteName } }] },
-              'Description': { rich_text: [{ text: { content: truncate(pin.content, 2000) } }] },
-              'Source': { select: { name: SOURCE_TAG } },
-              ...(domain ? { 'Domain': { select: { name: domain } } } : {}),
-            },
-          }),
+          notion!.pages.create(buildHuntingSiteCreatePayload({
+            databaseId: NOTION_DB.HUNTING_SITES,
+            siteName,
+            description: truncate(pin.content, 2000),
+            sourceTag: SOURCE_TAG,
+            domain: domain ?? undefined,
+          })),
         );
       }
       pinSections.push(`### ${siteName}\n\n${pin.content.trim()}`);
@@ -577,17 +576,14 @@ async function main(opts: NotionSyncOptions) {
         const cover = firstImage(messages);
         if (NOTION_ENABLED) {
           const page = await notionCall(() =>
-            notion!.pages.create({
-              parent: { database_id: NOTION_DB.SPC_TRACKER },
-              ...(cover ? { cover: coverProp(cover) } : {}),
-              properties: {
-                'Name': { title: [{ text: { content: name } }] },
-                'Status': { select: { name: 'Active' } },
-                'Source': { select: { name: SOURCE_TAG } },
-                ...(spcType ? { 'Type': { select: { name: spcType } } } : {}),
-                'Relationship Notes': { rich_text: [{ text: { content: truncate(bodyContent, 2000) } }] },
-              },
-            }),
+            notion!.pages.create(buildSpcCreatePayload({
+              databaseId: NOTION_DB.SPC_TRACKER,
+              name,
+              sourceTag: SOURCE_TAG,
+              relationshipNotes: truncate(bodyContent, 2000),
+              spcType,
+              coverUrl: cover ?? undefined,
+            })),
           );
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }
@@ -618,16 +614,13 @@ async function main(opts: NotionSyncOptions) {
       if (!DRY_RUN) {
         if (NOTION_ENABLED) {
           const page = await notionCall(() =>
-            notion!.pages.create({
-              parent: { database_id: NOTION_DB.SPC_TRACKER },
-              properties: {
-                'Name': { title: [{ text: { content: name } }] },
-                'Status': { select: { name: 'Active' } },
-                'Source': { select: { name: SOURCE_TAG } },
-                ...(spcType ? { 'Type': { select: { name: spcType } } } : {}),
-                'Relationship Notes': { rich_text: [{ text: { content: truncate(msg.content, 2000) } }] },
-              },
-            }),
+            notion!.pages.create(buildSpcCreatePayload({
+              databaseId: NOTION_DB.SPC_TRACKER,
+              name,
+              sourceTag: SOURCE_TAG,
+              relationshipNotes: truncate(msg.content, 2000),
+              spcType,
+            })),
           );
           await appendBodyBlocks(notion!, page.id, textToBlocks(msg.content));
         }
@@ -690,17 +683,15 @@ async function main(opts: NotionSyncOptions) {
       if (!DRY_RUN) {
         if (NOTION_ENABLED) {
           await notionCall(() =>
-            notion!.pages.create({
-              parent: { database_id: NOTION_DB.PC_TRACKER },
-              properties: {
-                'Character Name': { title: [{ text: { content: name } }] },
-                'Source': { select: { name: SOURCE_TAG } },
-                ...(playerName ? { 'Player': { rich_text: [{ text: { content: playerName } }] } } : {}),
-                ...(clan ? { 'Clan': { select: { name: clan } } } : {}),
-                ...(sect ? { 'Sect': { select: { name: sect } } } : {}),
-                ...(coterie ? { 'Coterie': { rich_text: [{ text: { content: coterie } }] } } : {}),
-              },
-            }),
+            notion!.pages.create(buildPcTrackerCreatePayload({
+              databaseId: NOTION_DB.PC_TRACKER,
+              name,
+              sourceTag: SOURCE_TAG,
+              playerName,
+              clan,
+              sect,
+              coterie,
+            })),
           );
         }
         const pcProfile = lookupPcProfile(pcProfileMap, name);
@@ -845,19 +836,15 @@ async function main(opts: NotionSyncOptions) {
           const preview = truncate(messages[0]?.content ?? '', 500);
           const cover = firstImage(messages);
           if (NOTION_ENABLED) {
-            const sessionProps = {
-              'Session/Post Title': { title: [{ text: { content: title } }] },
-              'Status': { select: { name: 'Complete' } },
-              'Source': { select: { name: SOURCE_TAG } },
-              'Summary': { rich_text: [{ text: { content: preview } }] },
-              'Date': { date: { start: postDate } },
-            };
             const page = await notionCall(() =>
-              notion!.pages.create({
-                parent: { database_id: NOTION_DB.SESSION_LOG },
-                ...(cover ? { cover: coverProp(cover) } : {}),
-                properties: sessionProps,
-              }),
+              notion!.pages.create(buildSessionLogCreatePayload({
+                databaseId: NOTION_DB.SESSION_LOG,
+                title,
+                summary: preview,
+                date: postDate,
+                sourceTag: SOURCE_TAG,
+                coverUrl: cover ?? undefined,
+              })),
             );
             await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
           }
@@ -893,15 +880,14 @@ async function main(opts: NotionSyncOptions) {
 
       if (!DRY_RUN) {
         if (NOTION_ENABLED) {
-          const sessionProps = {
-            'Session/Post Title': { title: [{ text: { content: title } }] },
-            'Status': { select: { name: 'Complete' } },
-            'Source': { select: { name: SOURCE_TAG } },
-            'Summary': { rich_text: [{ text: { content: preview } }] },
-            'Date': { date: { start: mostRecentDate } },
-          };
           const page = await notionCall(() =>
-            notion!.pages.create({ parent: { database_id: NOTION_DB.SESSION_LOG }, properties: sessionProps }),
+            notion!.pages.create(buildSessionLogCreatePayload({
+              databaseId: NOTION_DB.SESSION_LOG,
+              title,
+              summary: preview,
+              date: mostRecentDate,
+              sourceTag: SOURCE_TAG,
+            })),
           );
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }

--- a/apps/bot/src/scripts/notionSync/notionPayloadBuilders.ts
+++ b/apps/bot/src/scripts/notionSync/notionPayloadBuilders.ts
@@ -1,0 +1,117 @@
+import type { Client as NotionClient } from '@notionhq/client';
+
+export type NotionCreatePagePayload = Parameters<NotionClient['pages']['create']>[0];
+
+function titleProp(content: string): { title: Array<{ text: { content: string } }> } {
+  return { title: [{ text: { content } }] };
+}
+
+function richTextProp(content: string): { rich_text: Array<{ text: { content: string } }> } {
+  return { rich_text: [{ text: { content } }] };
+}
+
+function selectProp(name: string): { select: { name: string } } {
+  return { select: { name } };
+}
+
+function externalCover(url: string): { type: 'external'; external: { url: string } } {
+  return { type: 'external', external: { url } };
+}
+
+export function buildLocationCreatePayload(args: {
+  databaseId: string;
+  locationName: string;
+  sourceTag: string;
+  atmosphereNotes?: string;
+}): NotionCreatePagePayload {
+  return {
+    parent: { database_id: args.databaseId },
+    properties: {
+      Location: titleProp(args.locationName),
+      Source: selectProp(args.sourceTag),
+      ...(args.atmosphereNotes ? { 'Atmosphere Notes': richTextProp(args.atmosphereNotes) } : {}),
+    },
+  } as NotionCreatePagePayload;
+}
+
+export function buildHuntingSiteCreatePayload(args: {
+  databaseId: string;
+  siteName: string;
+  description: string;
+  sourceTag: string;
+  domain?: string;
+}): NotionCreatePagePayload {
+  return {
+    parent: { database_id: args.databaseId },
+    properties: {
+      'Site Name': titleProp(args.siteName),
+      Description: richTextProp(args.description),
+      Source: selectProp(args.sourceTag),
+      ...(args.domain ? { Domain: selectProp(args.domain) } : {}),
+    },
+  } as NotionCreatePagePayload;
+}
+
+export function buildSpcCreatePayload(args: {
+  databaseId: string;
+  name: string;
+  sourceTag: string;
+  relationshipNotes: string;
+  spcType?: string | null;
+  coverUrl?: string | null;
+}): NotionCreatePagePayload {
+  return {
+    parent: { database_id: args.databaseId },
+    ...(args.coverUrl ? { cover: externalCover(args.coverUrl) } : {}),
+    properties: {
+      Name: titleProp(args.name),
+      Status: selectProp('Active'),
+      Source: selectProp(args.sourceTag),
+      ...(args.spcType ? { Type: selectProp(args.spcType) } : {}),
+      'Relationship Notes': richTextProp(args.relationshipNotes),
+    },
+  } as NotionCreatePagePayload;
+}
+
+export function buildPcTrackerCreatePayload(args: {
+  databaseId: string;
+  name: string;
+  sourceTag: string;
+  playerName?: string;
+  clan?: string | null;
+  sect?: string | null;
+  coterie?: string | null;
+}): NotionCreatePagePayload {
+  return {
+    parent: { database_id: args.databaseId },
+    properties: {
+      'Character Name': titleProp(args.name),
+      Source: selectProp(args.sourceTag),
+      ...(args.playerName ? { Player: richTextProp(args.playerName) } : {}),
+      ...(args.clan ? { Clan: selectProp(args.clan) } : {}),
+      ...(args.sect ? { Sect: selectProp(args.sect) } : {}),
+      ...(args.coterie ? { Coterie: richTextProp(args.coterie) } : {}),
+    },
+  } as NotionCreatePagePayload;
+}
+
+export function buildSessionLogCreatePayload(args: {
+  databaseId: string;
+  title: string;
+  summary: string;
+  date: string;
+  sourceTag: string;
+  coverUrl?: string | null;
+}): NotionCreatePagePayload {
+  return {
+    parent: { database_id: args.databaseId },
+    ...(args.coverUrl ? { cover: externalCover(args.coverUrl) } : {}),
+    properties: {
+      'Session/Post Title': titleProp(args.title),
+      Status: selectProp('Complete'),
+      Source: selectProp(args.sourceTag),
+      Summary: richTextProp(args.summary),
+      Date: { date: { start: args.date } },
+    },
+  } as NotionCreatePagePayload;
+}

--- a/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE4.md
+++ b/docs/RELEASE_2026-04-18_WIKI_SYNC_MODULARIZATION_PHASE4.md
@@ -1,0 +1,49 @@
+# Release: 2026-04-18 — Wiki Sync Modularization (Phase 4)
+
+## Summary
+
+Continues decomposition of `discord-notion-sync.ts` by extracting Notion page
+payload builders into a dedicated module, while preserving existing sync
+behavior.
+
+## What Changed
+
+### 1) New Notion payload builder module
+
+Added:
+
+- `apps/bot/src/scripts/notionSync/notionPayloadBuilders.ts`
+
+This module now owns payload construction for Notion page creates:
+
+- location entries
+- hunting site entries
+- SPC entries
+- PC tracker entries
+- session/post log entries
+
+### 2) `discord-notion-sync.ts` now imports payload builders
+
+`apps/bot/src/scripts/discord-notion-sync.ts` now calls shared builders instead
+of constructing Notion page `properties`/`cover` objects inline for each flow.
+
+### 3) New payload builder tests
+
+Added:
+
+- `apps/bot/src/__tests__/notionPayloadBuilders.test.ts`
+
+Covers optional-field handling and output shape for all extracted builder
+functions.
+
+## Validation
+
+- `npm run typecheck` (in `apps/bot`)
+- `npm test -- --run src/__tests__/notionPayloadBuilders.test.ts src/__tests__/notionWrites.test.ts src/__tests__/discordIngest.test.ts src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts`
+
+## Follow-ups
+
+1. Extract web wiki write wrappers (`wikiUpsert`, `wikiDelete`,
+   `wikiSetCharacterStatus`) into a dedicated client module.
+2. Add orchestration-level integration tests around `runNotionSync` with mocked
+   Discord + web + Notion APIs.


### PR DESCRIPTION
## Summary
- extract Notion page payload construction from `discord-notion-sync.ts` into `src/scripts/notionSync/notionPayloadBuilders.ts`
- centralize payload builders for Location, Hunting Site, SPC, PC Tracker, and Session/Post log page creates
- update sync script to use shared builders while preserving behavior
- add focused unit tests for builder output and optional-field handling
- update changelog, release notes, and bot memory snapshot

## Why
- continues the approved wiki sync modularization plan
- isolates Notion payload shaping from orchestration logic so future changes are safer and easier to test

## Validation
- npm run typecheck
- npm test -- --run src/__tests__/notionPayloadBuilders.test.ts src/__tests__/notionWrites.test.ts src/__tests__/discordIngest.test.ts src/__tests__/wikiSyncHelpers.test.ts src/__tests__/configSyncWorker.test.ts src/__tests__/wikiSyncScheduler.test.ts
- ./scripts/check-docs-parity.sh
