### PR TITLE
Bot wiki sync: extract web wiki client (phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2026-04-20] Wiki Sync Modularization (Phase 5)
+
+### Bot Web Wiki Client Extraction
+
+- Extracted wiki/status API write wrappers from [`discord-notion-sync.ts`](apps/bot/src/scripts/discord-notion-sync.ts) into [`webWikiClient.ts`](apps/bot/src/scripts/notionSync/webWikiClient.ts).
+- Centralized Chronicle Wiki write endpoint handling for:
+  - `POST /api/wiki/page` (upsert)
+  - `DELETE /api/wiki/page/{slug}` (delete)
+  - `PUT /api/character/{name}/status` (retired status updates)
+- Updated `discord-notion-sync.ts` to use a `WebWikiClient` instance with no sync behavior change.
+- Added focused tests in [`webWikiClient.test.ts`](apps/bot/src/__tests__/webWikiClient.test.ts) for dry-run, lock-skip, status handling, and error logging semantics.
+- Added release notes: [`docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE5.md`](docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE5.md).
+
+---
+
 ## [2026-04-18] Production Ops + Efficiency Hardening
 
 ### Deploy Guardrails and Cost Baseline Pinning

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-18
+Last updated: 2026-04-20
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -27,7 +27,7 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `BOT_NOTION_SYNC_REQUESTED`
   - `BOT_NOTION_SYNC_STALE_AFTER_SECONDS` (web UI stale threshold)
   - bot feature toggles and selected interval/channel overrides
-- Bot polls `/api/bot-config` (60s) via `ConfigSyncWorker` and updates `liveConfig`.
+- Bot polls `/api/bot-config` (120s default) via `ConfigSyncWorker` and updates `liveConfig`.
 - Bot reports status back via:
   - `/api/bot-heartbeat`
   - `/api/bot-restart-ack`
@@ -92,12 +92,16 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
     Location/Hunting/SPC/PC/Session create operations.
   - dedicated tests added at
     `apps/bot/src/__tests__/notionPayloadBuilders.test.ts`.
+- Web wiki client extraction (phase 5):
+  - wiki/status API write wrappers now live in
+    `apps/bot/src/scripts/notionSync/webWikiClient.ts`.
+  - `discord-notion-sync.ts` now calls `WebWikiClient` methods for
+    wiki upsert/delete and retired status updates.
+  - dedicated tests added at
+    `apps/bot/src/__tests__/webWikiClient.test.ts`.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
-- Wiki API write wrappers (`wikiUpsert`, `wikiDelete`, `wikiSetCharacterStatus`)
-  are still inline in `discord-notion-sync.ts`; next phase should extract a
-  dedicated web wiki client module.
 - Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.

--- a/apps/bot/src/__tests__/webWikiClient.test.ts
+++ b/apps/bot/src/__tests__/webWikiClient.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebWikiClient } from '../scripts/notionSync/webWikiClient';
+
+function response(status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+  } as Response;
+}
+
+describe('WebWikiClient', () => {
+  it('upsertPage no-ops on dry-run', async () => {
+    const fetchFn = vi.fn();
+    const client = new WebWikiClient({
+      webBase: 'https://example.test',
+      writeToken: 'token',
+      dryRun: true,
+      fetchFn,
+      log: vi.fn(),
+    });
+
+    await client.upsertPage({ slug: 'loc-test', title: 'Location Test' });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('upsertPage logs lock skips from 423', async () => {
+    const fetchFn = vi.fn(async () => response(423));
+    const log = vi.fn();
+    const client = new WebWikiClient({
+      webBase: 'https://example.test',
+      writeToken: 'token',
+      dryRun: false,
+      fetchFn,
+      log,
+    });
+
+    await client.upsertPage({ slug: 'loc-downtown', title: 'Downtown' });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(String(fetchFn.mock.calls[0][0])).toBe('https://example.test/api/wiki/page');
+    expect(log).toHaveBeenCalledWith('  [wiki] "loc-downtown" is sync-locked — skipped upsert.');
+  });
+
+  it('deletePage logs dry-run actions', async () => {
+    const log = vi.fn();
+    const client = new WebWikiClient({
+      webBase: 'https://example.test',
+      writeToken: 'token',
+      dryRun: true,
+      fetchFn: vi.fn(),
+      log,
+    });
+
+    await client.deletePage('lore-night-12');
+
+    expect(log).toHaveBeenCalledWith('  [wiki dry-run] would delete "lore-night-12"');
+  });
+
+  it('deletePage handles 404/423/200 statuses', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(response(404))
+      .mockResolvedValueOnce(response(423))
+      .mockResolvedValueOnce(response(200));
+    const log = vi.fn();
+    const client = new WebWikiClient({
+      webBase: 'https://example.test',
+      writeToken: 'token',
+      dryRun: false,
+      fetchFn,
+      log,
+    });
+
+    await client.deletePage('lore-a');
+    await client.deletePage('lore-b');
+    await client.deletePage('lore-c');
+
+    expect(log).toHaveBeenNthCalledWith(1, '  [wiki] "lore-a" not found — already deleted or never created.');
+    expect(log).toHaveBeenNthCalledWith(2, '  [wiki] "lore-b" is sync-locked — skipped delete.');
+    expect(log).toHaveBeenNthCalledWith(3, '  [wiki] deleted "lore-c"');
+  });
+
+  it('setCharacterStatus warns on non-404 HTTP errors', async () => {
+    const fetchFn = vi.fn(async () => response(500));
+    const log = vi.fn();
+    const client = new WebWikiClient({
+      webBase: 'https://example.test',
+      writeToken: 'token',
+      dryRun: false,
+      fetchFn,
+      log,
+    });
+
+    await client.setCharacterStatus('Alice Voss', 'retired');
+
+    expect(String(fetchFn.mock.calls[0][0])).toBe('https://example.test/api/character/Alice%20Voss/status');
+    expect(log).toHaveBeenCalledWith('  [warn] Failed to set status for Alice Voss: 500');
+  });
+
+  it('setCharacterStatus logs fetch failures', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const log = vi.fn();
+    const client = new WebWikiClient({
+      webBase: 'https://example.test',
+      writeToken: 'token',
+      dryRun: false,
+      fetchFn,
+      log,
+    });
+
+    await client.setCharacterStatus('Bob', 'retired');
+
+    expect(log).toHaveBeenCalledWith('  [warn] wikiSetCharacterStatus error for Bob: Error: network down');
+  });
+});

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -70,6 +70,7 @@ import {
   messagesToMarkdown,
   wikiSlug,
 } from './notionSync/wikiSyncHelpers';
+import { WebWikiClient } from './notionSync/webWikiClient';
 
 // ---------------------------------------------------------------------------
 // Public API — call this from the bot process or from the CLI
@@ -249,78 +250,6 @@ function lookupPcProfile(map: Map<string, PcProfile>, charName: string): PcProfi
   return null;
 }
 
-interface WikiPageData {
-  slug: string;
-  title: string;
-  body_markdown?: string;
-  category?: string;
-  cover_image_url?: string;
-  published?: boolean;
-}
-
-async function wikiSetCharacterStatus(
-  webBase: string,
-  writeToken: string,
-  characterName: string,
-  status: 'active' | 'deceased' | 'retired',
-  dryRun: boolean,
-): Promise<void> {
-  if (dryRun || !writeToken) return;
-  try {
-    const res = await fetch(`${webBase}/api/character/${encodeURIComponent(characterName)}/status`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${writeToken}` },
-      body: JSON.stringify({ status }),
-    });
-    if (!res.ok && res.status !== 404) {
-      console.log(`  [warn] Failed to set status for ${characterName}: ${res.status}`);
-    }
-  } catch (err) {
-    console.log(`  [warn] wikiSetCharacterStatus error for ${characterName}: ${err}`);
-  }
-}
-
-async function wikiUpsert(webBase: string, writeToken: string, data: WikiPageData, dryRun: boolean): Promise<void> {
-  if (dryRun || !writeToken) return;
-  try {
-    const res = await fetch(`${webBase}/api/wiki/page`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${writeToken}` },
-      body: JSON.stringify(data),
-      signal: AbortSignal.timeout(15_000),
-    });
-    if (res.status === 423) {
-      console.log(`  [wiki] "${data.slug}" is sync-locked — skipped upsert.`);
-    } else if (!res.ok) {
-      console.log(`  [wiki warn] upsert "${data.slug}" → HTTP ${res.status}`);
-    }
-  } catch (err) {
-    console.log(`  [wiki warn] upsert "${data.slug}" failed: ${err}`);
-  }
-}
-
-async function wikiDelete(webBase: string, writeToken: string, slug: string, dryRun: boolean): Promise<void> {
-  if (dryRun || !writeToken) { console.log(`  [wiki dry-run] would delete "${slug}"`); return; }
-  try {
-    const res = await fetch(`${webBase}/api/wiki/page/${encodeURIComponent(slug)}`, {
-      method: 'DELETE',
-      headers: { Authorization: `Bearer ${writeToken}` },
-      signal: AbortSignal.timeout(15_000),
-    });
-    if (res.status === 404) {
-      console.log(`  [wiki] "${slug}" not found — already deleted or never created.`);
-    } else if (res.status === 423) {
-      console.log(`  [wiki] "${slug}" is sync-locked — skipped delete.`);
-    } else if (!res.ok) {
-      console.log(`  [wiki warn] delete "${slug}" → HTTP ${res.status}`);
-    } else {
-      console.log(`  [wiki] deleted "${slug}"`);
-    }
-  } catch (err) {
-    console.log(`  [wiki warn] delete "${slug}" failed: ${err}`);
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Web API: active character roster
 // ---------------------------------------------------------------------------
@@ -406,6 +335,11 @@ async function main(opts: NotionSyncOptions) {
   } else {
     console.log('  Wiki sync disabled — set WEB_APP_API_WRITE_TOKEN to enable.');
   }
+  const wikiClient = new WebWikiClient({
+    webBase: WEB_BASE,
+    writeToken: WEB_WRITE_TOKEN,
+    dryRun: DRY_RUN,
+  });
 
   const flags = [DRY_RUN && 'DRY RUN', CLEANUP && 'CLEANUP'].filter(Boolean).join(' + ');
   console.log(`discord-notion-sync${flags ? ` [${flags}]` : ''}`);
@@ -542,13 +476,13 @@ async function main(opts: NotionSyncOptions) {
       ch.topic ?? '',
       pinSections.length ? `## Hunting Sites\n\n${pinSections.join('\n\n---\n\n')}` : '',
     ].filter(Boolean);
-    await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+    await wikiClient.upsertPage({
       slug: wikiSlug('locations', locationName),
       title: locationName,
       category: 'locations',
       body_markdown: bodyParts.join('\n\n---\n\n'),
       published: true,
-    }, DRY_RUN);
+    });
   }
   console.log(`  Created ${huntingTotal} hunting site entries.`);
 
@@ -587,14 +521,14 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }
-        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+        await wikiClient.upsertPage({
           slug: wikiSlug('characters', name),
           title: name,
           category: 'characters',
           body_markdown: messagesToMarkdown(messages),
           cover_image_url: cover ?? undefined,
           published: true,
-        }, DRY_RUN);
+        });
       }
       count++;
     }
@@ -624,13 +558,13 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion!, page.id, textToBlocks(msg.content));
         }
-        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+        await wikiClient.upsertPage({
           slug: wikiSlug('characters', name),
           title: name,
           category: 'characters',
           body_markdown: msg.content.trim(),
           published: true,
-        }, DRY_RUN);
+        });
       }
       count++;
     }
@@ -653,7 +587,7 @@ async function main(opts: NotionSyncOptions) {
   let deletedCount = 0;
   for (const threadName of pcProfileMap.keys()) {
     const slug = wikiSlug('lore', threadName);
-    await wikiDelete(WEB_BASE, WEB_WRITE_TOKEN, slug, DRY_RUN);
+    await wikiClient.deletePage(slug);
     deletedCount++;
   }
   console.log(`  Processed ${deletedCount} potential stale page(s).`);
@@ -705,14 +639,14 @@ async function main(opts: NotionSyncOptions) {
           metaParts.join('\n\n'),
           pcProfile?.markdown,
         ].filter(Boolean).join('\n\n---\n\n');
-        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+        await wikiClient.upsertPage({
           slug: wikiSlug('characters', name),
           title: name,
           category: 'characters',
           body_markdown: bodyMarkdown,
           cover_image_url: pcProfile?.image ?? undefined,
           published: true,
-        }, DRY_RUN);
+        });
       }
     }
     console.log(`  Created ${activeRoster.length} PC entries.`);
@@ -726,13 +660,13 @@ async function main(opts: NotionSyncOptions) {
     const memberList = members.map((m) => `- [${toTitleCase(m)}](/wiki/${wikiSlug('characters', m)})`).join('\n');
     const body = `## Members\n\n${memberList}`;
     console.log(`  → ${coterieName} (${members.length} members)`);
-    await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+    await wikiClient.upsertPage({
       slug: wikiSlug('coteries', coterieName),
       title: coterieName,
       category: 'coteries',
       body_markdown: body,
       published: true,
-    }, DRY_RUN);
+    });
   }
   console.log(`  Created ${Object.keys(COTERIE_MEMBERS).length} coterie pages.`);
 
@@ -756,13 +690,13 @@ async function main(opts: NotionSyncOptions) {
     if (loreLinks.length) bodyParts.push(`## Lore\n\n${loreLinks.join('\n')}`);
     const bodyMarkdown = bodyParts.join('\n\n') || '_No members found._';
     console.log(`  → ${faction.name} (${factionMembers.length} members)`);
-    await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+    await wikiClient.upsertPage({
       slug: wikiSlug('factions', faction.name),
       title: faction.name,
       category: 'factions',
       body_markdown: bodyMarkdown,
       published: true,
-    }, DRY_RUN);
+    });
   }
   console.log(`  Created ${FACTIONS.length} faction pages.`);
 
@@ -789,15 +723,15 @@ async function main(opts: NotionSyncOptions) {
       const image = firstImage(msgs);
       const bodyMarkdown = messagesToMarkdown(msgs);
       console.log(`  → ${name}`);
-      await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+      await wikiClient.upsertPage({
         slug: wikiSlug('characters', name),
         title: name,
         category: 'characters',
         body_markdown: bodyMarkdown,
         cover_image_url: image ?? undefined,
         published: true,
-      }, DRY_RUN);
-      await wikiSetCharacterStatus(WEB_BASE, WEB_WRITE_TOKEN, name, 'retired', DRY_RUN);
+      });
+      await wikiClient.setCharacterStatus(name, 'retired');
       retiredCount++;
     }
     console.log(`  Processed ${retiredCount} retired character(s).`);
@@ -851,14 +785,14 @@ async function main(opts: NotionSyncOptions) {
           // children-of-the-night threads are PC profiles — merged into character
           // pages in step 6, not duplicated as lore wiki pages.
           if (chanName !== 'children-of-the-night') {
-            await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+            await wikiClient.upsertPage({
               slug: wikiSlug('lore', title),
               title,
               category: 'lore',
               body_markdown: messagesToMarkdown(messages),
               cover_image_url: cover ?? undefined,
               published: true,
-            }, DRY_RUN);
+            });
           }
         }
       }
@@ -891,13 +825,13 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }
-        await wikiUpsert(WEB_BASE, WEB_WRITE_TOKEN, {
+        await wikiClient.upsertPage({
           slug: wikiSlug('lore', `${chanName} archive`),
           title,
           category: 'lore',
           body_markdown: messagesToMarkdown(messages),
           published: true,
-        }, DRY_RUN);
+        });
       }
     }
   }

--- a/apps/bot/src/scripts/notionSync/webWikiClient.ts
+++ b/apps/bot/src/scripts/notionSync/webWikiClient.ts
@@ -1,0 +1,98 @@
+export interface WikiPageData {
+  slug: string;
+  title: string;
+  body_markdown?: string;
+  category?: string;
+  cover_image_url?: string;
+  published?: boolean;
+}
+
+export type CharacterStatus = 'active' | 'deceased' | 'retired';
+
+interface WebWikiClientOptions {
+  webBase: string;
+  writeToken: string;
+  dryRun: boolean;
+  fetchFn?: typeof fetch;
+  log?: (line: string) => void;
+}
+
+/**
+ * Minimal wrapper around web wiki/status write endpoints so sync orchestration
+ * stays focused on Discord/Notion data flow.
+ */
+export class WebWikiClient {
+  private readonly webBase: string;
+  private readonly writeToken: string;
+  private readonly dryRun: boolean;
+  private readonly fetchFn: typeof fetch;
+  private readonly log: (line: string) => void;
+
+  constructor(opts: WebWikiClientOptions) {
+    this.webBase = opts.webBase.replace(/\/+$/, '');
+    this.writeToken = opts.writeToken;
+    this.dryRun = opts.dryRun;
+    this.fetchFn = opts.fetchFn ?? fetch;
+    this.log = opts.log ?? ((line: string) => console.log(line));
+  }
+
+  async setCharacterStatus(characterName: string, status: CharacterStatus): Promise<void> {
+    if (this.dryRun || !this.writeToken) return;
+    try {
+      const res = await this.fetchFn(`${this.webBase}/api/character/${encodeURIComponent(characterName)}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.writeToken}` },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok && res.status !== 404) {
+        this.log(`  [warn] Failed to set status for ${characterName}: ${res.status}`);
+      }
+    } catch (err) {
+      this.log(`  [warn] wikiSetCharacterStatus error for ${characterName}: ${err}`);
+    }
+  }
+
+  async upsertPage(data: WikiPageData): Promise<void> {
+    if (this.dryRun || !this.writeToken) return;
+    try {
+      const res = await this.fetchFn(`${this.webBase}/api/wiki/page`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.writeToken}` },
+        body: JSON.stringify(data),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (res.status === 423) {
+        this.log(`  [wiki] "${data.slug}" is sync-locked — skipped upsert.`);
+      } else if (!res.ok) {
+        this.log(`  [wiki warn] upsert "${data.slug}" → HTTP ${res.status}`);
+      }
+    } catch (err) {
+      this.log(`  [wiki warn] upsert "${data.slug}" failed: ${err}`);
+    }
+  }
+
+  async deletePage(slug: string): Promise<void> {
+    if (this.dryRun || !this.writeToken) {
+      this.log(`  [wiki dry-run] would delete "${slug}"`);
+      return;
+    }
+    try {
+      const res = await this.fetchFn(`${this.webBase}/api/wiki/page/${encodeURIComponent(slug)}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${this.writeToken}` },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (res.status === 404) {
+        this.log(`  [wiki] "${slug}" not found — already deleted or never created.`);
+      } else if (res.status === 423) {
+        this.log(`  [wiki] "${slug}" is sync-locked — skipped delete.`);
+      } else if (!res.ok) {
+        this.log(`  [wiki warn] delete "${slug}" → HTTP ${res.status}`);
+      } else {
+        this.log(`  [wiki] deleted "${slug}"`);
+      }
+    } catch (err) {
+      this.log(`  [wiki warn] delete "${slug}" failed: ${err}`);
+    }
+  }
+}

--- a/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE5.md
+++ b/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE5.md
@@ -1,0 +1,78 @@
+# Release: 2026-04-20 — Wiki Sync Modularization (Phase 5)
+
+Phase 5 extracts web wiki write calls from sync orchestration into a dedicated client module.
+
+## Scope
+
+- Bot-only maintainability refactor.
+- No schema change.
+- No API contract change.
+- No intended behavior change.
+
+## What Changed
+
+### New module: Web wiki client
+
+Added:
+
+- `apps/bot/src/scripts/notionSync/webWikiClient.ts`
+
+This module now owns the bot-side calls to web wiki/status endpoints:
+
+- `POST /api/wiki/page`
+- `DELETE /api/wiki/page/{slug}`
+- `PUT /api/character/{name}/status`
+
+It preserves existing semantics:
+
+- skip on dry-run or missing write token
+- `423` sync-lock handling for wiki upsert/delete
+- non-fatal warnings on HTTP/network failures
+- best-effort status updates for retired characters
+
+### Orchestration update
+
+Updated:
+
+- `apps/bot/src/scripts/discord-notion-sync.ts`
+
+`runNotionSync` now creates a `WebWikiClient` once and calls:
+
+- `wikiClient.upsertPage(...)`
+- `wikiClient.deletePage(...)`
+- `wikiClient.setCharacterStatus(...)`
+
+### New tests
+
+Added:
+
+- `apps/bot/src/__tests__/webWikiClient.test.ts`
+
+Covered behaviors:
+
+- dry-run no-op behavior
+- lock skip logs (`423`) for upserts/deletes
+- `404`/`423`/`200` delete handling
+- status update warnings for non-404 failures
+- network error logging paths
+
+## Validation
+
+From `apps/bot/`:
+
+```bash
+npm run typecheck
+npm run test -- src/__tests__/webWikiClient.test.ts
+```
+
+## Follow-On
+
+`runNotionSync` is now split across helper modules for:
+
+- Discord ingest
+- Notion writes
+- Notion payload builders
+- Wiki helper taxonomy/rendering
+- Web wiki API writes
+
+Next maintainability slice can target higher-level orchestration decomposition and integration-style sync tests.


### PR DESCRIPTION
## Summary
- extract wiki/status API wrappers from `discord-notion-sync.ts` into `apps/bot/src/scripts/notionSync/webWikiClient.ts`
- replace inline `wikiUpsert` / `wikiDelete` / `wikiSetCharacterStatus` calls with a `WebWikiClient` instance
- add focused tests for dry-run behavior, lock-skip semantics, delete status handling, and status-update error handling
- update changelog, release notes, and `apps/bot/BOT_MEMORY.md` to capture phase 5 completion

## Validation
- `cd apps/bot && npm run check`
- `./scripts/check-docs-parity.sh`

## Notes
- no API contract or behavior changes intended; this is maintainability-focused extraction to reduce sync-script orchestration sprawl.
