### PR TITLE
Bot wiki sync: separate Notion and Wiki targets (phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2026-04-20] Wiki Sync Modularization (Phase 6)
+
+### Explicit Target Separation: Notion vs Wiki
+
+- Added explicit target selection support in [`discord-notion-sync.ts`](apps/bot/src/scripts/discord-notion-sync.ts):
+  - `--notion-only`
+  - `--wiki-only`
+- Added `syncToNotion` / `syncToWiki` options to `runNotionSync` so callers can run sinks independently.
+- Extracted target gating logic into [`syncTargets.ts`](apps/bot/src/scripts/notionSync/syncTargets.ts).
+- Sync now fails fast with a clear error when neither target is enabled (for example missing tokens with both targets requested).
+- Added focused tests in [`syncTargets.test.ts`](apps/bot/src/__tests__/syncTargets.test.ts).
+- Added release notes: [`docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE6.md`](docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE6.md).
+
+---
+
 ## [2026-04-20] Wiki Sync Modularization (Phase 5)
 
 ### Bot Web Wiki Client Extraction

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-20
+Last updated: 2026-04-20 (phase 6)
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -99,6 +99,15 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
     wiki upsert/delete and retired status updates.
   - dedicated tests added at
     `apps/bot/src/__tests__/webWikiClient.test.ts`.
+- Sync target separation (phase 6):
+  - target resolution now lives in
+    `apps/bot/src/scripts/notionSync/syncTargets.ts`.
+  - `discord-notion-sync.ts` now supports independent target toggles:
+    `--notion-only` and `--wiki-only`.
+  - Notion and Wiki execution are now explicitly gated via
+    `syncToNotion` / `syncToWiki` options and token availability.
+  - dedicated tests added at
+    `apps/bot/src/__tests__/syncTargets.test.ts`.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.

--- a/apps/bot/src/__tests__/syncTargets.test.ts
+++ b/apps/bot/src/__tests__/syncTargets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSyncTargets } from '../scripts/notionSync/syncTargets';
+
+describe('resolveSyncTargets', () => {
+  it('enables both targets by default when both tokens are present', () => {
+    const result = resolveSyncTargets({
+      notionToken: 'notion-token',
+      webWriteToken: 'wiki-token',
+    });
+
+    expect(result.notionEnabled).toBe(true);
+    expect(result.wikiEnabled).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('supports notion-only runs', () => {
+    const result = resolveSyncTargets({
+      notionToken: 'notion-token',
+      webWriteToken: 'wiki-token',
+      syncToNotion: true,
+      syncToWiki: false,
+    });
+
+    expect(result.notionEnabled).toBe(true);
+    expect(result.wikiEnabled).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('supports wiki-only runs', () => {
+    const result = resolveSyncTargets({
+      notionToken: 'notion-token',
+      webWriteToken: 'wiki-token',
+      syncToNotion: false,
+      syncToWiki: true,
+    });
+
+    expect(result.notionEnabled).toBe(false);
+    expect(result.wikiEnabled).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns when requested target token is missing', () => {
+    const result = resolveSyncTargets({
+      syncToNotion: true,
+      syncToWiki: true,
+    });
+
+    expect(result.notionEnabled).toBe(false);
+    expect(result.wikiEnabled).toBe(false);
+    expect(result.warnings).toContain('NOTION_TOKEN not set — Notion target disabled.');
+    expect(result.warnings).toContain('WEB_APP_API_WRITE_TOKEN not set — Wiki target disabled.');
+  });
+
+  it('does not warn for explicitly disabled targets', () => {
+    const result = resolveSyncTargets({
+      syncToNotion: false,
+      syncToWiki: false,
+    });
+
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -6,11 +6,13 @@
  * Usage (from apps/bot/):
  *   npx tsx src/scripts/discord-notion-sync.ts
  *   npx tsx src/scripts/discord-notion-sync.ts --dry-run
+ *   npx tsx src/scripts/discord-notion-sync.ts --notion-only
+ *   npx tsx src/scripts/discord-notion-sync.ts --wiki-only
  *
  * Required env vars (in apps/bot/.env):
  *   BOT_TOKEN          Discord bot token
  *   DISCORD_GUILD_ID   Target server ID (falls back to TEST_GUILD_ID)
- *   NOTION_TOKEN       Notion integration token (create at notion.so/profile/integrations)
+ *   NOTION_TOKEN       Notion integration token (required unless using --wiki-only)
  *
  * Optional env vars:
  *   WEB_APP_BASE_URL          Web app URL for active-roster API (default: http://127.0.0.1:5001)
@@ -71,6 +73,7 @@ import {
   wikiSlug,
 } from './notionSync/wikiSyncHelpers';
 import { WebWikiClient } from './notionSync/webWikiClient';
+import { resolveSyncTargets } from './notionSync/syncTargets';
 
 // ---------------------------------------------------------------------------
 // Public API — call this from the bot process or from the CLI
@@ -79,12 +82,16 @@ import { WebWikiClient } from './notionSync/webWikiClient';
 export interface NotionSyncOptions {
   botToken: string;
   guildId: string;
-  /** Notion integration token. If omitted, all Notion writes are skipped. */
+  /** Notion integration token. Required only when notion target is enabled. */
   notionToken?: string;
   webBase?: string;
   webReadToken?: string;
   /** Write token for Chronicle Wiki upsert API (WEB_APP_API_WRITE_TOKEN). */
   webWriteToken?: string;
+  /** Explicitly enable/disable Notion target. Defaults to true. */
+  syncToNotion?: boolean;
+  /** Explicitly enable/disable Wiki target. Defaults to true. */
+  syncToWiki?: boolean;
   msgLimit?: number;
   dryRun?: boolean;
   /** If true, archive all Notion pages that were NOT created by this sync before importing. */
@@ -139,6 +146,12 @@ const CH_FORUM = 15;
 
 if (require.main === module) {
   dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+  const notionOnly = process.argv.includes('--notion-only');
+  const wikiOnly = process.argv.includes('--wiki-only');
+  if (notionOnly && wikiOnly) {
+    console.error('Choose only one target flag: --notion-only or --wiki-only.');
+    process.exit(1);
+  }
   const cliOpts: NotionSyncOptions = {
     botToken: process.env.BOT_TOKEN ?? '',
     guildId: process.env.DISCORD_GUILD_ID ?? process.env.TEST_GUILD_ID ?? '',
@@ -149,10 +162,11 @@ if (require.main === module) {
     msgLimit: Number.parseInt(process.env.NOTION_SYNC_MSG_LIMIT ?? '200', 10),
     dryRun: process.argv.includes('--dry-run'),
     cleanup: process.argv.includes('--cleanup'),
+    syncToNotion: notionOnly ? true : (wikiOnly ? false : undefined),
+    syncToWiki: wikiOnly ? true : (notionOnly ? false : undefined),
   };
   if (!cliOpts.botToken) { console.error('BOT_TOKEN is required'); process.exit(1); }
   if (!cliOpts.guildId) { console.error('DISCORD_GUILD_ID (or TEST_GUILD_ID) is required'); process.exit(1); }
-  if (!cliOpts.notionToken) { console.log('NOTION_TOKEN not set — Notion sync disabled.'); }
   runNotionSync(cliOpts).then((result) => {
     if (!result.success) { console.error('Sync failed:', result.error); process.exit(1); }
   }).catch((err) => { console.error('Fatal:', err); process.exit(1); });
@@ -330,25 +344,40 @@ async function main(opts: NotionSyncOptions) {
   const WEB_BASE = (opts.webBase ?? 'http://127.0.0.1:5001').replace(/\/+$/, '');
   const WEB_READ_TOKEN = opts.webReadToken ?? '';
   const WEB_WRITE_TOKEN = opts.webWriteToken ?? '';
-  if (WEB_WRITE_TOKEN) {
-    console.log('  Wiki sync enabled — pages will be upserted to Chronicle Wiki.');
-  } else {
-    console.log('  Wiki sync disabled — set WEB_APP_API_WRITE_TOKEN to enable.');
-  }
-  const wikiClient = new WebWikiClient({
-    webBase: WEB_BASE,
-    writeToken: WEB_WRITE_TOKEN,
-    dryRun: DRY_RUN,
+  const syncTargets = resolveSyncTargets({
+    notionToken: opts.notionToken,
+    webWriteToken: WEB_WRITE_TOKEN,
+    syncToNotion: opts.syncToNotion,
+    syncToWiki: opts.syncToWiki,
   });
 
   const flags = [DRY_RUN && 'DRY RUN', CLEANUP && 'CLEANUP'].filter(Boolean).join(' + ');
   console.log(`discord-notion-sync${flags ? ` [${flags}]` : ''}`);
   console.log(`Guild: ${GUILD_ID} | Limit: ${MSG_LIMIT} messages/posts per source`);
+  for (const warning of syncTargets.warnings) console.log(`  [warn] ${warning}`);
 
-  const NOTION_ENABLED = !!opts.notionToken;
+  if (syncTargets.notionEnabled) {
+    console.log('  Notion target enabled — pages will be written to configured Notion databases.');
+  } else {
+    console.log('  Notion target disabled.');
+  }
+  if (syncTargets.wikiEnabled) {
+    console.log('  Wiki target enabled — pages will be upserted to Chronicle Wiki.');
+  } else {
+    console.log('  Wiki target disabled.');
+  }
+  if (!syncTargets.notionEnabled && !syncTargets.wikiEnabled) {
+    throw new Error('No sync targets enabled. Provide required tokens or choose at least one target.');
+  }
+
+  const NOTION_ENABLED = syncTargets.notionEnabled;
   const rest = new REST({ version: '10' }).setToken(opts.botToken);
   const notion = NOTION_ENABLED ? new NotionClient({ auth: opts.notionToken!, timeoutMs: 120_000 }) : null;
-  if (!NOTION_ENABLED) console.log('  Notion sync disabled — set NOTION_TOKEN to enable.');
+  const wikiClient = new WebWikiClient({
+    webBase: WEB_BASE,
+    writeToken: syncTargets.wikiEnabled ? WEB_WRITE_TOKEN : '',
+    dryRun: DRY_RUN,
+  });
 
   // ------------------------------------------------------------------
   // 0. Ensure Source property exists on all databases

--- a/apps/bot/src/scripts/notionSync/syncTargets.ts
+++ b/apps/bot/src/scripts/notionSync/syncTargets.ts
@@ -1,0 +1,36 @@
+export interface SyncTargetResolutionInput {
+  notionToken?: string;
+  webWriteToken?: string;
+  syncToNotion?: boolean;
+  syncToWiki?: boolean;
+}
+
+export interface SyncTargetResolution {
+  notionEnabled: boolean;
+  wikiEnabled: boolean;
+  warnings: string[];
+}
+
+/**
+ * Determine which downstream targets should run for this sync invocation.
+ * Defaults keep current behavior: both targets are requested, gated by token presence.
+ */
+export function resolveSyncTargets(input: SyncTargetResolutionInput): SyncTargetResolution {
+  const requestedNotion = input.syncToNotion ?? true;
+  const requestedWiki = input.syncToWiki ?? true;
+  const notionToken = (input.notionToken ?? '').trim();
+  const wikiToken = (input.webWriteToken ?? '').trim();
+
+  const notionEnabled = requestedNotion && notionToken.length > 0;
+  const wikiEnabled = requestedWiki && wikiToken.length > 0;
+
+  const warnings: string[] = [];
+  if (requestedNotion && !notionToken) {
+    warnings.push('NOTION_TOKEN not set — Notion target disabled.');
+  }
+  if (requestedWiki && !wikiToken) {
+    warnings.push('WEB_APP_API_WRITE_TOKEN not set — Wiki target disabled.');
+  }
+
+  return { notionEnabled, wikiEnabled, warnings };
+}

--- a/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE6.md
+++ b/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE6.md
@@ -1,0 +1,78 @@
+# Release: 2026-04-20 — Wiki Sync Modularization (Phase 6)
+
+Phase 6 adds explicit execution separation between Notion and Wiki targets in the sync pipeline.
+
+## Scope
+
+- Bot sync orchestration behavior controls.
+- No schema change.
+- No web API contract change.
+
+## What Changed
+
+### Explicit target toggles
+
+`discord-notion-sync.ts` now supports running sinks independently:
+
+- `--notion-only`
+- `--wiki-only`
+
+Programmatic callers can also set:
+
+- `syncToNotion?: boolean`
+- `syncToWiki?: boolean`
+
+in `runNotionSync` options.
+
+### Target resolution extracted
+
+Added:
+
+- `apps/bot/src/scripts/notionSync/syncTargets.ts`
+
+This module resolves whether each target is active based on:
+
+- requested target toggles
+- token availability (`NOTION_TOKEN`, `WEB_APP_API_WRITE_TOKEN`)
+
+and returns warnings for disabled requested targets.
+
+### Fail-fast guard
+
+If neither target is enabled for a run, the sync now exits with a clear error instead of doing silent no-op work.
+
+## Tests
+
+Added:
+
+- `apps/bot/src/__tests__/syncTargets.test.ts`
+
+Coverage includes:
+
+- default both-target behavior
+- notion-only behavior
+- wiki-only behavior
+- missing-token warnings
+- explicit all-targets-disabled behavior
+
+## Validation
+
+From `apps/bot/`:
+
+```bash
+npm run check
+```
+
+From repo root:
+
+```bash
+./scripts/check-docs-parity.sh
+```
+
+## Operational Result
+
+Sync target execution is now explicitly separated:
+
+- Notion writes can run without wiki writes.
+- Wiki writes can run without Notion writes.
+- Combined runs still work as before when both targets are enabled.


### PR DESCRIPTION
## Summary
- add explicit sync target resolution in `apps/bot/src/scripts/notionSync/syncTargets.ts`
- add independent target controls to `runNotionSync` (`syncToNotion`, `syncToWiki`)
- add CLI target flags for one-target runs: `--notion-only` and `--wiki-only`
- enforce fail-fast when no targets are enabled (instead of silent no-op)
- update changelog, release notes, and `apps/bot/BOT_MEMORY.md` for phase 6

## Validation
- `cd apps/bot && npm run check`
- `./scripts/check-docs-parity.sh`

## Notes
- this is a control-plane separation change: Notion and Wiki sinks can now be run independently while preserving combined-run behavior.
