### PR TITLE
Bot wiki sync: add runNotionSync target-gating tests (phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2026-04-20] Wiki Sync Modularization (Phase 7)
+
+### Bot Sync Orchestration Coverage: Targeted Runtime Gating
+
+- Added direct orchestration tests for `runNotionSync` in [`runNotionSyncTargets.test.ts`](apps/bot/src/__tests__/runNotionSyncTargets.test.ts).
+- Added fail-fast coverage when neither Notion nor Wiki target is enabled.
+- Added execution coverage for:
+  - Notion-only runs (`syncToNotion=true`, `syncToWiki=false`)
+  - Wiki-only runs (`syncToNotion=false`, `syncToWiki=true`)
+- Tests use mocked Discord/Notion/wiki clients to validate target gating behavior without external network dependencies.
+- Added release notes: [`docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE7.md`](docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE7.md).
+
+---
+
 ## [2026-04-20] Wiki Sync Modularization (Phase 6)
 
 ### Explicit Target Separation: Notion vs Wiki

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-20 (phase 6)
+Last updated: 2026-04-20 (phase 7)
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -108,10 +108,17 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
     `syncToNotion` / `syncToWiki` options and token availability.
   - dedicated tests added at
     `apps/bot/src/__tests__/syncTargets.test.ts`.
+- Sync orchestration gating coverage (phase 7):
+  - added direct `runNotionSync` orchestration tests at
+    `apps/bot/src/__tests__/runNotionSyncTargets.test.ts`.
+  - coverage now explicitly verifies:
+    - fail-fast when no targets are enabled
+    - notion-only target wiring
+    - wiki-only target wiring
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
-- Bot now has direct orchestration tests for `ConfigSyncWorker` and `WikiSyncScheduler` lock/ack flows, but still lacks higher-level integration tests around the full `runNotionSync` path.
+- Bot now has direct orchestration tests for `ConfigSyncWorker`, `WikiSyncScheduler`, and target-gating behavior in `runNotionSync`, but still lacks deeper full-flow integration tests for rich channel/message datasets.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.
 

--- a/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
+++ b/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const restSetToken = vi.fn();
+const restGet = vi.fn(async () => []);
+const notionCtor = vi.fn();
+const webWikiCtor = vi.fn();
+
+vi.mock('discord.js', () => {
+  class MockREST {
+    setToken(token: string) {
+      restSetToken(token);
+      return this;
+    }
+
+    async get(_route: string) {
+      return restGet();
+    }
+  }
+
+  return {
+    REST: MockREST,
+    Routes: {
+      guildChannels: (guildId: string) => `/guilds/${guildId}/channels`,
+    },
+  };
+});
+
+vi.mock('@notionhq/client', () => {
+  class MockNotionClient {
+    constructor(opts: unknown) {
+      notionCtor(opts);
+    }
+  }
+
+  return { Client: MockNotionClient };
+});
+
+vi.mock('../scripts/notionSync/discordIngest', () => ({
+  fetchAllMessages: vi.fn(async () => []),
+  fetchForumThreads: vi.fn(async () => []),
+  fetchGuildMember: vi.fn(async () => null),
+  fetchPins: vi.fn(async () => []),
+}));
+
+vi.mock('../scripts/notionSync/notionWrites', () => ({
+  appendBodyBlocks: vi.fn(async () => {}),
+  cleanupPreImportEntries: vi.fn(async () => {}),
+  notionCall: async <T>(fn: () => Promise<T>) => fn(),
+  SOURCE_TAG: 'discord',
+}));
+
+vi.mock('../scripts/notionSync/notionPayloadBuilders', () => ({
+  buildHuntingSiteCreatePayload: vi.fn(() => ({})),
+  buildLocationCreatePayload: vi.fn(() => ({})),
+  buildPcTrackerCreatePayload: vi.fn(() => ({})),
+  buildSessionLogCreatePayload: vi.fn(() => ({})),
+  buildSpcCreatePayload: vi.fn(() => ({})),
+}));
+
+vi.mock('../scripts/notionSync/wikiSyncHelpers', () => ({
+  CHAR_TO_COTERIE: new Map<string, string>(),
+  COTERIE_MEMBERS: {},
+  FACTIONS: [],
+  inferSpcType: vi.fn(() => 'other'),
+  mapDomain: vi.fn(() => null),
+  messagesToMarkdown: vi.fn(() => ''),
+  wikiSlug: vi.fn((category: string, value: string) => `${category}-${value}`),
+}));
+
+vi.mock('../scripts/notionSync/webWikiClient', () => {
+  class MockWebWikiClient {
+    constructor(opts: unknown) {
+      webWikiCtor(opts);
+    }
+
+    async upsertPage() {}
+    async deletePage() {}
+    async setCharacterStatus() {}
+  }
+
+  return { WebWikiClient: MockWebWikiClient };
+});
+
+import { runNotionSync } from '../scripts/discord-notion-sync';
+
+describe('runNotionSync target orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fails fast when no sync targets are enabled', async () => {
+    const result = await runNotionSync({
+      botToken: 'bot-token',
+      guildId: 'guild-1',
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No sync targets enabled');
+    expect(restSetToken).not.toHaveBeenCalled();
+  });
+
+  it('supports notion-only runs and disables wiki write token', async () => {
+    const result = await runNotionSync({
+      botToken: 'bot-token',
+      guildId: 'guild-1',
+      notionToken: 'notion-token',
+      webWriteToken: 'wiki-write-token',
+      syncToNotion: true,
+      syncToWiki: false,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(notionCtor).toHaveBeenCalledTimes(1);
+    expect(webWikiCtor).toHaveBeenCalledWith(expect.objectContaining({ writeToken: '' }));
+  });
+
+  it('supports wiki-only runs without constructing Notion client', async () => {
+    const result = await runNotionSync({
+      botToken: 'bot-token',
+      guildId: 'guild-1',
+      webWriteToken: 'wiki-write-token',
+      syncToNotion: false,
+      syncToWiki: true,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(notionCtor).not.toHaveBeenCalled();
+    expect(webWikiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ writeToken: 'wiki-write-token' }),
+    );
+  });
+});

--- a/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE7.md
+++ b/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE7.md
@@ -1,0 +1,46 @@
+# Release: 2026-04-20 — Wiki Sync Modularization (Phase 7)
+
+Phase 7 adds direct orchestration tests around `runNotionSync` target gating behavior.
+
+## Scope
+
+- Bot sync orchestration test coverage.
+- No runtime behavior changes.
+- No schema change.
+- No web API contract change.
+
+## What Changed
+
+### Added direct `runNotionSync` target tests
+
+Added:
+
+- `apps/bot/src/__tests__/runNotionSyncTargets.test.ts`
+
+Coverage includes:
+
+- fail-fast when no sync targets are enabled
+- Notion-only target execution wiring
+- Wiki-only target execution wiring
+
+### External dependencies are mocked
+
+The new tests mock Discord REST, Notion client construction, and wiki client construction so they can validate orchestration gating semantics without live API calls.
+
+## Validation
+
+From `apps/bot/`:
+
+```bash
+npm run check
+```
+
+From repo root:
+
+```bash
+./scripts/check-docs-parity.sh
+```
+
+## Operational Result
+
+The target-separation work from phase 6 now has direct orchestration-level regression coverage in addition to helper-level unit coverage.


### PR DESCRIPTION
## Summary
- add direct orchestration tests for `runNotionSync` target gating behavior
- cover fail-fast when no sync targets are enabled
- cover notion-only and wiki-only execution wiring with mocked external clients
- update changelog, release note, and bot memory for Phase 7

## Validation
- `cd apps/bot && npm run check`
- `./scripts/check-docs-parity.sh`

## Notes
- no runtime behavior changes; test/documentation hardening only
