### PR TITLE
Bot wiki sync: skip disabled-target runtime work (phase 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2026-04-20] Wiki Sync Modularization (Phase 8)
+
+### Runtime Efficiency: Skip Disabled Target Work
+
+- Tightened target separation in [`discord-notion-sync.ts`](apps/bot/src/scripts/discord-notion-sync.ts) so Notion-only runs skip wiki-only execution paths instead of invoking wiki client no-op calls.
+- Added explicit `WIKI_ENABLED` gating for:
+  - location wiki upserts in hunting-site pass
+  - SPC/PC/lore wiki writes
+  - stale lore wiki cleanup
+  - coteries/factions wiki generation
+  - retired-character wiki/status updates
+  - PC profile map fetch for children-of-the-night
+- Corrected coterie/faction created-count logging to report actual writes performed.
+- Expanded orchestration tests in [`runNotionSyncTargets.test.ts`](apps/bot/src/__tests__/runNotionSyncTargets.test.ts) with seeded channel/message fixtures:
+  - notion-only runs now assert zero wiki write calls
+  - wiki-only runs now assert zero Notion write calls while wiki writes continue
+- Added release notes: [`docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE8.md`](docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE8.md).
+
+---
+
 ## [2026-04-20] Wiki Sync Modularization (Phase 7)
 
 ### Bot Sync Orchestration Coverage: Targeted Runtime Gating

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-20 (phase 7)
+Last updated: 2026-04-20 (phase 8)
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -115,9 +115,18 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
     - fail-fast when no targets are enabled
     - notion-only target wiring
     - wiki-only target wiring
+- Runtime target-efficiency hardening (phase 8):
+  - `discord-notion-sync.ts` now gates wiki-only execution by `WIKI_ENABLED`
+    instead of relying on no-op wiki client token behavior.
+  - notion-only runs skip wiki-only work paths (profile-map enrichment,
+    stale wiki cleanup, coteries/factions generation, retired updates, and
+    wiki upsert/delete/status calls).
+  - `runNotionSyncTargets.test.ts` now includes fixture-backed assertions for:
+    - notion-only: no wiki writes
+    - wiki-only: no Notion writes
 
 ## High-Signal Current Gaps
-- `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction; next split should separate Discord ingest, Notion writes, and wiki upsert/cleanup execution paths.
+- `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction and target gating; next split should separate end-to-end step runners (locations/hunting, characters, session log).
 - Bot now has direct orchestration tests for `ConfigSyncWorker`, `WikiSyncScheduler`, and target-gating behavior in `runNotionSync`, but still lacks deeper full-flow integration tests for rich channel/message datasets.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.

--- a/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
+++ b/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const restSetToken = vi.fn();
 const restGet = vi.fn(async () => []);
 const notionCtor = vi.fn();
+const notionPagesCreate = vi.fn(async () => ({ id: 'page-1' }));
+const notionDbUpdate = vi.fn(async () => ({}));
 const webWikiCtor = vi.fn();
+const webWikiUpsertPage = vi.fn(async () => {});
+const webWikiDeletePage = vi.fn(async () => {});
+const webWikiSetCharacterStatus = vi.fn(async () => {});
 
 vi.mock('discord.js', () => {
   class MockREST {
@@ -27,6 +32,9 @@ vi.mock('discord.js', () => {
 
 vi.mock('@notionhq/client', () => {
   class MockNotionClient {
+    pages = { create: notionPagesCreate };
+    databases = { update: notionDbUpdate };
+
     constructor(opts: unknown) {
       notionCtor(opts);
     }
@@ -73,20 +81,65 @@ vi.mock('../scripts/notionSync/webWikiClient', () => {
       webWikiCtor(opts);
     }
 
-    async upsertPage() {}
-    async deletePage() {}
-    async setCharacterStatus() {}
+    async upsertPage(payload: unknown) {
+      await webWikiUpsertPage(payload);
+    }
+
+    async deletePage(slug: string) {
+      await webWikiDeletePage(slug);
+    }
+
+    async setCharacterStatus(name: string, status: string) {
+      await webWikiSetCharacterStatus(name, status);
+    }
   }
 
   return { WebWikiClient: MockWebWikiClient };
 });
 
 import { runNotionSync } from '../scripts/discord-notion-sync';
+import {
+  fetchAllMessages,
+  fetchPins,
+  type DiscordChannel,
+  type DiscordMessage,
+} from '../scripts/notionSync/discordIngest';
 
 describe('runNotionSync target orchestration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  function seedChannels(): void {
+    const channels: DiscordChannel[] = [
+      { id: 'cat-city', type: 4, name: 'City of Nashville' } as DiscordChannel,
+      { id: 'chan-locations', type: 0, name: 'broadway', parent_id: 'cat-city' } as DiscordChannel,
+      { id: 'chan-spc', type: 0, name: 'spc-profiles' } as DiscordChannel,
+      { id: 'chan-lore', type: 0, name: 'music-city-histories' } as DiscordChannel,
+    ];
+    restGet.mockResolvedValue(channels);
+
+    const defaultAuthor = {
+      username: 'user-1',
+      global_name: 'User One',
+    };
+    const defaultMessage = (content: string): DiscordMessage => ({
+      id: `msg-${Math.random()}`,
+      content,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      author: defaultAuthor as DiscordMessage['author'],
+      attachments: [],
+    } as DiscordMessage);
+
+    vi.mocked(fetchPins).mockResolvedValue([
+      defaultMessage('### Site One\nPinned hunting details'),
+    ]);
+    vi.mocked(fetchAllMessages).mockImplementation(async (_rest, channelId) => {
+      if (channelId === 'chan-spc') return [defaultMessage('SPC Name\nSPC profile body')];
+      if (channelId === 'chan-lore') return [defaultMessage('Lore archive text')];
+      return [];
+    });
+  }
 
   it('fails fast when no sync targets are enabled', async () => {
     const result = await runNotionSync({
@@ -100,7 +153,8 @@ describe('runNotionSync target orchestration', () => {
     expect(restSetToken).not.toHaveBeenCalled();
   });
 
-  it('supports notion-only runs and disables wiki write token', async () => {
+  it('supports notion-only runs and skips wiki writes', async () => {
+    seedChannels();
     const result = await runNotionSync({
       botToken: 'bot-token',
       guildId: 'guild-1',
@@ -108,26 +162,33 @@ describe('runNotionSync target orchestration', () => {
       webWriteToken: 'wiki-write-token',
       syncToNotion: true,
       syncToWiki: false,
-      dryRun: true,
+      dryRun: false,
     });
 
     expect(result.success).toBe(true);
     expect(notionCtor).toHaveBeenCalledTimes(1);
+    expect(notionPagesCreate).toHaveBeenCalled();
+    expect(webWikiUpsertPage).not.toHaveBeenCalled();
+    expect(webWikiDeletePage).not.toHaveBeenCalled();
+    expect(webWikiSetCharacterStatus).not.toHaveBeenCalled();
     expect(webWikiCtor).toHaveBeenCalledWith(expect.objectContaining({ writeToken: '' }));
   });
 
   it('supports wiki-only runs without constructing Notion client', async () => {
+    seedChannels();
     const result = await runNotionSync({
       botToken: 'bot-token',
       guildId: 'guild-1',
       webWriteToken: 'wiki-write-token',
       syncToNotion: false,
       syncToWiki: true,
-      dryRun: true,
+      dryRun: false,
     });
 
     expect(result.success).toBe(true);
     expect(notionCtor).not.toHaveBeenCalled();
+    expect(notionPagesCreate).not.toHaveBeenCalled();
+    expect(webWikiUpsertPage).toHaveBeenCalled();
     expect(webWikiCtor).toHaveBeenCalledWith(
       expect.objectContaining({ writeToken: 'wiki-write-token' }),
     );

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -371,11 +371,12 @@ async function main(opts: NotionSyncOptions) {
   }
 
   const NOTION_ENABLED = syncTargets.notionEnabled;
+  const WIKI_ENABLED = syncTargets.wikiEnabled;
   const rest = new REST({ version: '10' }).setToken(opts.botToken);
   const notion = NOTION_ENABLED ? new NotionClient({ auth: opts.notionToken!, timeoutMs: 120_000 }) : null;
   const wikiClient = new WebWikiClient({
     webBase: WEB_BASE,
-    writeToken: syncTargets.wikiEnabled ? WEB_WRITE_TOKEN : '',
+    writeToken: WIKI_ENABLED ? WEB_WRITE_TOKEN : '',
     dryRun: DRY_RUN,
   });
 
@@ -501,17 +502,19 @@ async function main(opts: NotionSyncOptions) {
     }
 
     // Wiki upsert: topic as intro, pins as Hunting Sites section
-    const bodyParts = [
-      ch.topic ?? '',
-      pinSections.length ? `## Hunting Sites\n\n${pinSections.join('\n\n---\n\n')}` : '',
-    ].filter(Boolean);
-    await wikiClient.upsertPage({
-      slug: wikiSlug('locations', locationName),
-      title: locationName,
-      category: 'locations',
-      body_markdown: bodyParts.join('\n\n---\n\n'),
-      published: true,
-    });
+    if (WIKI_ENABLED) {
+      const bodyParts = [
+        ch.topic ?? '',
+        pinSections.length ? `## Hunting Sites\n\n${pinSections.join('\n\n---\n\n')}` : '',
+      ].filter(Boolean);
+      await wikiClient.upsertPage({
+        slug: wikiSlug('locations', locationName),
+        title: locationName,
+        category: 'locations',
+        body_markdown: bodyParts.join('\n\n---\n\n'),
+        published: true,
+      });
+    }
   }
   console.log(`  Created ${huntingTotal} hunting site entries.`);
 
@@ -550,14 +553,16 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }
-        await wikiClient.upsertPage({
-          slug: wikiSlug('characters', name),
-          title: name,
-          category: 'characters',
-          body_markdown: messagesToMarkdown(messages),
-          cover_image_url: cover ?? undefined,
-          published: true,
-        });
+        if (WIKI_ENABLED) {
+          await wikiClient.upsertPage({
+            slug: wikiSlug('characters', name),
+            title: name,
+            category: 'characters',
+            body_markdown: messagesToMarkdown(messages),
+            cover_image_url: cover ?? undefined,
+            published: true,
+          });
+        }
       }
       count++;
     }
@@ -587,13 +592,15 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion!, page.id, textToBlocks(msg.content));
         }
-        await wikiClient.upsertPage({
-          slug: wikiSlug('characters', name),
-          title: name,
-          category: 'characters',
-          body_markdown: msg.content.trim(),
-          published: true,
-        });
+        if (WIKI_ENABLED) {
+          await wikiClient.upsertPage({
+            slug: wikiSlug('characters', name),
+            title: name,
+            category: 'characters',
+            body_markdown: msg.content.trim(),
+            published: true,
+          });
+        }
       }
       count++;
     }
@@ -604,8 +611,12 @@ async function main(opts: NotionSyncOptions) {
   // 5.5 Build PC profile map from #children-of-the-night forum
   // ------------------------------------------------------------------
   console.log('\n[5.5/7] Building PC profile map from #children-of-the-night…');
-  const pcProfileMap = await buildPcProfileMap(rest, GUILD_ID, channelByName);
-  console.log(`  Found profiles for ${pcProfileMap.size} character(s).`);
+  const pcProfileMap = WIKI_ENABLED ? await buildPcProfileMap(rest, GUILD_ID, channelByName) : new Map();
+  if (!WIKI_ENABLED) {
+    console.log('  Wiki target disabled — skipping profile map build.');
+  } else {
+    console.log(`  Found profiles for ${pcProfileMap.size} character(s).`);
+  }
 
   // ------------------------------------------------------------------
   // 5.6 Remove stale lore pages created from #children-of-the-night
@@ -614,10 +625,14 @@ async function main(opts: NotionSyncOptions) {
   // ------------------------------------------------------------------
   console.log('\n[5.6/7] Removing stale PC lore pages…');
   let deletedCount = 0;
-  for (const threadName of pcProfileMap.keys()) {
-    const slug = wikiSlug('lore', threadName);
-    await wikiClient.deletePage(slug);
-    deletedCount++;
+  if (WIKI_ENABLED) {
+    for (const threadName of pcProfileMap.keys()) {
+      const slug = wikiSlug('lore', threadName);
+      await wikiClient.deletePage(slug);
+      deletedCount++;
+    }
+  } else {
+    console.log('  Wiki target disabled — skipping stale page cleanup.');
   }
   console.log(`  Processed ${deletedCount} potential stale page(s).`);
 
@@ -657,25 +672,27 @@ async function main(opts: NotionSyncOptions) {
             })),
           );
         }
-        const pcProfile = lookupPcProfile(pcProfileMap, name);
-        const metaParts = [
-          clan && `**Clan:** ${clan}`,
-          sect && `**Sect:** ${sect}`,
-          coterie && `**Coterie:** ${coterie}`,
-          playerName && `**Player:** ${playerName}`,
-        ].filter(Boolean) as string[];
-        const bodyMarkdown = [
-          metaParts.join('\n\n'),
-          pcProfile?.markdown,
-        ].filter(Boolean).join('\n\n---\n\n');
-        await wikiClient.upsertPage({
-          slug: wikiSlug('characters', name),
-          title: name,
-          category: 'characters',
-          body_markdown: bodyMarkdown,
-          cover_image_url: pcProfile?.image ?? undefined,
-          published: true,
-        });
+        if (WIKI_ENABLED) {
+          const pcProfile = lookupPcProfile(pcProfileMap, name);
+          const metaParts = [
+            clan && `**Clan:** ${clan}`,
+            sect && `**Sect:** ${sect}`,
+            coterie && `**Coterie:** ${coterie}`,
+            playerName && `**Player:** ${playerName}`,
+          ].filter(Boolean) as string[];
+          const bodyMarkdown = [
+            metaParts.join('\n\n'),
+            pcProfile?.markdown,
+          ].filter(Boolean).join('\n\n---\n\n');
+          await wikiClient.upsertPage({
+            slug: wikiSlug('characters', name),
+            title: name,
+            category: 'characters',
+            body_markdown: bodyMarkdown,
+            cover_image_url: pcProfile?.image ?? undefined,
+            published: true,
+          });
+        }
       }
     }
     console.log(`  Created ${activeRoster.length} PC entries.`);
@@ -685,49 +702,61 @@ async function main(opts: NotionSyncOptions) {
   // 6.5 Coteries wiki pages (built from static COTERIE_MEMBERS map)
   // ------------------------------------------------------------------
   console.log('\n[6.5/7] Populating Coteries wiki pages…');
-  for (const [coterieName, members] of Object.entries(COTERIE_MEMBERS)) {
-    const memberList = members.map((m) => `- [${toTitleCase(m)}](/wiki/${wikiSlug('characters', m)})`).join('\n');
-    const body = `## Members\n\n${memberList}`;
-    console.log(`  → ${coterieName} (${members.length} members)`);
-    await wikiClient.upsertPage({
-      slug: wikiSlug('coteries', coterieName),
-      title: coterieName,
-      category: 'coteries',
-      body_markdown: body,
-      published: true,
-    });
+  let coterieCreatedCount = 0;
+  if (!WIKI_ENABLED) {
+    console.log('  Wiki target disabled — skipping coteries pages.');
+  } else {
+    for (const [coterieName, members] of Object.entries(COTERIE_MEMBERS)) {
+      const memberList = members.map((m) => `- [${toTitleCase(m)}](/wiki/${wikiSlug('characters', m)})`).join('\n');
+      const body = `## Members\n\n${memberList}`;
+      console.log(`  → ${coterieName} (${members.length} members)`);
+      await wikiClient.upsertPage({
+        slug: wikiSlug('coteries', coterieName),
+        title: coterieName,
+        category: 'coteries',
+        body_markdown: body,
+        published: true,
+      });
+      coterieCreatedCount++;
+    }
   }
-  console.log(`  Created ${Object.keys(COTERIE_MEMBERS).length} coterie pages.`);
+  console.log(`  Created ${coterieCreatedCount} coterie pages.`);
 
   // ------------------------------------------------------------------
   // 6.6 Factions wiki pages (built from active roster sect field)
   // ------------------------------------------------------------------
   console.log('\n[6.6/7] Populating Factions wiki pages…');
-  for (const faction of FACTIONS) {
-    const factionMembers = activeRoster.filter(
-      (c) => c.sect && faction.sectAliases.includes(c.sect.toLowerCase()),
-    );
-    const memberLines = factionMembers.map((c) => {
-      const coterie = CHAR_TO_COTERIE.get(c.name.toLowerCase());
-      return `- [${c.name}](/wiki/${wikiSlug('characters', c.name)})${c.clan ? ` — ${c.clan}` : ''}${coterie ? ` *(${coterie})*` : ''}`;
-    });
-    const loreLinks = faction.loreChannels.map(
-      (ch) => `- [#${ch} archive](/wiki/${wikiSlug('lore', `${ch} archive`)})`,
-    );
-    const bodyParts: string[] = [];
-    if (memberLines.length) bodyParts.push(`## Members\n\n${memberLines.join('\n')}`);
-    if (loreLinks.length) bodyParts.push(`## Lore\n\n${loreLinks.join('\n')}`);
-    const bodyMarkdown = bodyParts.join('\n\n') || '_No members found._';
-    console.log(`  → ${faction.name} (${factionMembers.length} members)`);
-    await wikiClient.upsertPage({
-      slug: wikiSlug('factions', faction.name),
-      title: faction.name,
-      category: 'factions',
-      body_markdown: bodyMarkdown,
-      published: true,
-    });
+  let factionCreatedCount = 0;
+  if (!WIKI_ENABLED) {
+    console.log('  Wiki target disabled — skipping factions pages.');
+  } else {
+    for (const faction of FACTIONS) {
+      const factionMembers = activeRoster.filter(
+        (c) => c.sect && faction.sectAliases.includes(c.sect.toLowerCase()),
+      );
+      const memberLines = factionMembers.map((c) => {
+        const coterie = CHAR_TO_COTERIE.get(c.name.toLowerCase());
+        return `- [${c.name}](/wiki/${wikiSlug('characters', c.name)})${c.clan ? ` — ${c.clan}` : ''}${coterie ? ` *(${coterie})*` : ''}`;
+      });
+      const loreLinks = faction.loreChannels.map(
+        (ch) => `- [#${ch} archive](/wiki/${wikiSlug('lore', `${ch} archive`)})`,
+      );
+      const bodyParts: string[] = [];
+      if (memberLines.length) bodyParts.push(`## Members\n\n${memberLines.join('\n')}`);
+      if (loreLinks.length) bodyParts.push(`## Lore\n\n${loreLinks.join('\n')}`);
+      const bodyMarkdown = bodyParts.join('\n\n') || '_No members found._';
+      console.log(`  → ${faction.name} (${factionMembers.length} members)`);
+      await wikiClient.upsertPage({
+        slug: wikiSlug('factions', faction.name),
+        title: faction.name,
+        category: 'factions',
+        body_markdown: bodyMarkdown,
+        published: true,
+      });
+      factionCreatedCount++;
+    }
   }
-  console.log(`  Created ${FACTIONS.length} faction pages.`);
+  console.log(`  Created ${factionCreatedCount} faction pages.`);
 
   // ------------------------------------------------------------------
   // 6.7 Retired characters from #retired forum
@@ -737,7 +766,9 @@ async function main(opts: NotionSyncOptions) {
   // ------------------------------------------------------------------
   console.log('\n[6.7/7] Processing retired characters from #retired…');
   const retiredCh = channelByName.get('retired');
-  if (!retiredCh || retiredCh.type !== CH_FORUM) {
+  if (!WIKI_ENABLED) {
+    console.log('  Wiki target disabled — skipping retired character updates.');
+  } else if (!retiredCh || retiredCh.type !== CH_FORUM) {
     console.log('  #retired forum channel not found — skipping.');
   } else {
     let retiredThreads: DiscordThread[] = [];
@@ -813,7 +844,7 @@ async function main(opts: NotionSyncOptions) {
           }
           // children-of-the-night threads are PC profiles — merged into character
           // pages in step 6, not duplicated as lore wiki pages.
-          if (chanName !== 'children-of-the-night') {
+          if (WIKI_ENABLED && chanName !== 'children-of-the-night') {
             await wikiClient.upsertPage({
               slug: wikiSlug('lore', title),
               title,
@@ -854,13 +885,15 @@ async function main(opts: NotionSyncOptions) {
           );
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }
-        await wikiClient.upsertPage({
-          slug: wikiSlug('lore', `${chanName} archive`),
-          title,
-          category: 'lore',
-          body_markdown: messagesToMarkdown(messages),
-          published: true,
-        });
+        if (WIKI_ENABLED) {
+          await wikiClient.upsertPage({
+            slug: wikiSlug('lore', `${chanName} archive`),
+            title,
+            category: 'lore',
+            body_markdown: messagesToMarkdown(messages),
+            published: true,
+          });
+        }
       }
     }
   }

--- a/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE8.md
+++ b/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE8.md
@@ -1,0 +1,57 @@
+# Release: 2026-04-20 — Wiki Sync Modularization (Phase 8)
+
+Phase 8 improves sync runtime efficiency by skipping disabled-target work during execution.
+
+## Scope
+
+- Bot sync orchestration runtime behavior.
+- No schema change.
+- No web API contract change.
+
+## What Changed
+
+### Skip wiki-only work when Wiki target is disabled
+
+`discord-notion-sync.ts` now explicitly gates wiki-only operations behind `WIKI_ENABLED` instead of relying on no-op write token behavior in the wiki client.
+
+This now skips:
+
+- location wiki upserts in the hunting-site pass
+- SPC/PC/lore wiki page writes
+- stale lore cleanup deletes
+- coteries and factions page generation
+- retired character wiki/status updates
+- children-of-the-night profile-map fetch used for wiki character enrichment
+
+### Corrected write-count logs
+
+Coteries/factions completion logs now report the actual number of pages written during the run.
+
+### Expanded orchestration target tests
+
+Updated:
+
+- `apps/bot/src/__tests__/runNotionSyncTargets.test.ts`
+
+New fixture-backed assertions verify:
+
+- notion-only runs perform no wiki write/delete/status calls
+- wiki-only runs perform no Notion write calls while still executing wiki writes
+
+## Validation
+
+From `apps/bot/`:
+
+```bash
+npm run check
+```
+
+From repo root:
+
+```bash
+./scripts/check-docs-parity.sh
+```
+
+## Operational Result
+
+Target separation is now both semantic and runtime-efficient: disabled targets are skipped earlier, reducing unnecessary sync work.


### PR DESCRIPTION
## Summary
- improve runtime efficiency in `runNotionSync` by gating wiki-only execution paths behind `WIKI_ENABLED`
- ensure notion-only runs do not perform wiki upsert/delete/status work
- keep wiki-only behavior unchanged while still ensuring Notion writes are skipped
- correct coteries/factions completion counts to report actual pages written
- expand `runNotionSyncTargets.test.ts` with seeded fixture coverage for target-specific write behavior
- update changelog, release note, and bot memory for Phase 8

## Validation
- `cd apps/bot && npm run check`
- `./scripts/check-docs-parity.sh`
