### PR TITLE
Bot wiki sync: add both-target full-flow orchestration tests (phase 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2026-04-20] Wiki Sync Modularization (Phase 9)
+
+### Full-Flow Orchestration Coverage: Both-Target Runtime
+
+- Expanded [`runNotionSyncTargets.test.ts`](apps/bot/src/__tests__/runNotionSyncTargets.test.ts) with a richer seeded Discord fixture set (city/text/forum channels, profile threads, retired thread, pins, and lore messages).
+- Added explicit both-target runtime coverage for `runNotionSync` (`syncToNotion=true`, `syncToWiki=true`) asserting:
+  - Notion client/database/page write path executes.
+  - Wiki upsert/delete/status write paths execute.
+- Preserved existing assertions for target-separated runs:
+  - notion-only: no wiki writes
+  - wiki-only: no Notion writes
+- Added release notes: [`docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE9.md`](docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE9.md).
+
+---
+
 ## [2026-04-20] Wiki Sync Modularization (Phase 8)
 
 ### Runtime Efficiency: Skip Disabled Target Work

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-20 (phase 8)
+Last updated: 2026-04-20 (phase 9)
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -124,10 +124,15 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
   - `runNotionSyncTargets.test.ts` now includes fixture-backed assertions for:
     - notion-only: no wiki writes
     - wiki-only: no Notion writes
+- Combined-target orchestration coverage (phase 9):
+  - `runNotionSyncTargets.test.ts` now includes richer seeded channel/thread
+    fixtures (city/lore/SPC text channels + children/retired forums).
+  - added explicit both-target (`syncToNotion=true`, `syncToWiki=true`) test
+    asserting Notion writes + wiki upsert/delete/status paths execute.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction and target gating; next split should separate end-to-end step runners (locations/hunting, characters, session log).
-- Bot now has direct orchestration tests for `ConfigSyncWorker`, `WikiSyncScheduler`, and target-gating behavior in `runNotionSync`, but still lacks deeper full-flow integration tests for rich channel/message datasets.
+- Bot now has direct orchestration tests for `ConfigSyncWorker`, `WikiSyncScheduler`, and richer `runNotionSync` target/combined runtime paths, but still lacks golden-output style assertions for specific page payload/body content.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.
 

--- a/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
+++ b/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
@@ -100,9 +100,11 @@ vi.mock('../scripts/notionSync/webWikiClient', () => {
 import { runNotionSync } from '../scripts/discord-notion-sync';
 import {
   fetchAllMessages,
+  fetchForumThreads,
   fetchPins,
   type DiscordChannel,
   type DiscordMessage,
+  type DiscordThread,
 } from '../scripts/notionSync/discordIngest';
 
 describe('runNotionSync target orchestration', () => {
@@ -116,6 +118,8 @@ describe('runNotionSync target orchestration', () => {
       { id: 'chan-locations', type: 0, name: 'broadway', parent_id: 'cat-city' } as DiscordChannel,
       { id: 'chan-spc', type: 0, name: 'spc-profiles' } as DiscordChannel,
       { id: 'chan-lore', type: 0, name: 'music-city-histories' } as DiscordChannel,
+      { id: 'forum-children', type: 15, name: 'children-of-the-night' } as DiscordChannel,
+      { id: 'forum-retired', type: 15, name: 'retired' } as DiscordChannel,
     ];
     restGet.mockResolvedValue(channels);
 
@@ -131,12 +135,27 @@ describe('runNotionSync target orchestration', () => {
       attachments: [],
     } as DiscordMessage);
 
+    const thread = (id: string, name: string): DiscordThread => ({
+      id,
+      name,
+      thread_metadata: {
+        archive_timestamp: '2026-01-01T00:00:00.000Z',
+      } as DiscordThread['thread_metadata'],
+    } as DiscordThread);
+
     vi.mocked(fetchPins).mockResolvedValue([
       defaultMessage('### Site One\nPinned hunting details'),
     ]);
+    vi.mocked(fetchForumThreads).mockImplementation(async (_rest, _guildId, channelId) => {
+      if (channelId === 'forum-children') return [thread('thread-children-1', 'Aludra')];
+      if (channelId === 'forum-retired') return [thread('thread-retired-1', 'Retired One')];
+      return [];
+    });
     vi.mocked(fetchAllMessages).mockImplementation(async (_rest, channelId) => {
       if (channelId === 'chan-spc') return [defaultMessage('SPC Name\nSPC profile body')];
       if (channelId === 'chan-lore') return [defaultMessage('Lore archive text')];
+      if (channelId === 'thread-children-1') return [defaultMessage('Aludra profile body')];
+      if (channelId === 'thread-retired-1') return [defaultMessage('Retired profile body')];
       return [];
     });
   }
@@ -192,5 +211,27 @@ describe('runNotionSync target orchestration', () => {
     expect(webWikiCtor).toHaveBeenCalledWith(
       expect.objectContaining({ writeToken: 'wiki-write-token' }),
     );
+  });
+
+  it('runs both targets together and performs both notion and wiki write paths', async () => {
+    seedChannels();
+    const result = await runNotionSync({
+      botToken: 'bot-token',
+      guildId: 'guild-1',
+      notionToken: 'notion-token',
+      webWriteToken: 'wiki-write-token',
+      syncToNotion: true,
+      syncToWiki: true,
+      dryRun: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(notionCtor).toHaveBeenCalledTimes(1);
+    expect(notionDbUpdate).toHaveBeenCalledTimes(5);
+    expect(notionPagesCreate).toHaveBeenCalled();
+
+    expect(webWikiUpsertPage).toHaveBeenCalled();
+    expect(webWikiDeletePage).toHaveBeenCalled();
+    expect(webWikiSetCharacterStatus).toHaveBeenCalledWith('Retired One', 'retired');
   });
 });

--- a/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE9.md
+++ b/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE9.md
@@ -1,0 +1,61 @@
+# Release: 2026-04-20 — Wiki Sync Modularization (Phase 9)
+
+Phase 9 deepens orchestration coverage by testing both-target execution against richer Discord fixture data.
+
+## Scope
+
+- Bot sync orchestration tests only.
+- No runtime logic changes.
+- No schema change.
+- No web API contract change.
+
+## What Changed
+
+### Expanded `runNotionSync` fixture coverage
+
+Updated:
+
+- `apps/bot/src/__tests__/runNotionSyncTargets.test.ts`
+
+The fixture now includes:
+
+- City category + location text channel
+- lore text channel
+- SPC text channel
+- `children-of-the-night` forum channel + profile thread
+- `retired` forum channel + retired character thread
+- pinned hunting-site content
+
+### Added both-target orchestration assertion
+
+A new test validates `runNotionSync` with both targets enabled and verifies all expected write surfaces are exercised:
+
+- Notion database and page writes
+- wiki upserts
+- wiki stale-page delete path
+- retired-character status updates
+
+### Existing separation assertions retained
+
+The same test file continues to assert:
+
+- notion-only runs do not write to wiki
+- wiki-only runs do not write to Notion
+
+## Validation
+
+From `apps/bot/`:
+
+```bash
+npm run check
+```
+
+From repo root:
+
+```bash
+./scripts/check-docs-parity.sh
+```
+
+## Operational Result
+
+The sync test suite now covers target separation and combined-target orchestration behavior using realistic seeded channel/thread message shapes.


### PR DESCRIPTION
## Summary
- expand runNotionSync target tests with richer seeded Discord fixtures (text + forum + pins + retired/profile threads)
- add explicit both-target runtime coverage to assert Notion writes and wiki upsert/delete/status paths all execute
- retain and verify separated-target assertions (notion-only skips wiki writes, wiki-only skips Notion writes)
- update changelog, release note, and bot memory for Phase 9

## Validation
- cd apps/bot && npm run check
- ./scripts/check-docs-parity.sh