### PR TITLE
Bot wiki sync: add golden payload/body assertions (phase 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2026-04-20] Wiki Sync Modularization (Phase 10)
+
+### Golden Assertions for Sync Payload and Body Output
+
+- Strengthened [`runNotionSyncTargets.test.ts`](apps/bot/src/__tests__/runNotionSyncTargets.test.ts) with concrete output assertions for both-target sync runs.
+- Added deterministic payload-builder spies for Notion create payloads and asserted key generated values:
+  - location payload includes `locationName: Broadway`
+  - hunting-site payload includes `siteName: Site One`
+  - SPC payload includes `name: SPC Name`
+  - session payload includes `#music-city-histories archive` and retired thread title entries
+- Added concrete wiki upsert assertions for generated page shape/content:
+  - location page slug/category/title
+  - SPC character page slug/category/title/body
+  - lore archive page slug/category/title
+  - location body contains the expected `Hunting Sites` section and site heading
+- Added release notes: [`docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE10.md`](docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE10.md).
+
+---
+
 ## [2026-04-20] Wiki Sync Modularization (Phase 9)
 
 ### Full-Flow Orchestration Coverage: Both-Target Runtime

--- a/apps/bot/BOT_MEMORY.md
+++ b/apps/bot/BOT_MEMORY.md
@@ -1,6 +1,6 @@
 # Bot/Integration Memory (Audit Snapshot)
 
-Last updated: 2026-04-20 (phase 9)
+Last updated: 2026-04-20 (phase 10)
 Scope: bot + web integration surfaces relevant to bot operations and wiki sync
 
 ## Current System Picture
@@ -129,10 +129,15 @@ Scope: bot + web integration surfaces relevant to bot operations and wiki sync
     fixtures (city/lore/SPC text channels + children/retired forums).
   - added explicit both-target (`syncToNotion=true`, `syncToWiki=true`) test
     asserting Notion writes + wiki upsert/delete/status paths execute.
+- Golden payload/body assertions (phase 10):
+  - `runNotionSyncTargets.test.ts` now asserts concrete generated output:
+    - Notion payload-builder inputs (location/hunting/SPC/session titles)
+    - wiki upsert payload fields (slug/category/title/body)
+    - location wiki body includes expected Hunting Sites section content.
 
 ## High-Signal Current Gaps
 - `runNotionSync` orchestration remains large (~1.1k LOC) even after helper extraction and target gating; next split should separate end-to-end step runners (locations/hunting, characters, session log).
-- Bot now has direct orchestration tests for `ConfigSyncWorker`, `WikiSyncScheduler`, and richer `runNotionSync` target/combined runtime paths, but still lacks golden-output style assertions for specific page payload/body content.
+- Bot now has direct orchestration tests for `ConfigSyncWorker`, `WikiSyncScheduler`, and `runNotionSync` target/combined runtime with key payload/body assertions, but still lacks snapshot-style assertions for larger markdown bodies across multi-message threads.
 - Stale-running remediation now exists in web Settings (`/settings/reset-notion-sync`), but there is no automated stale cleanup/alerting yet.
 - Scheduled vs manual sync source + `run_id` are persisted (`BOT_NOTION_SYNC_SOURCE`, `BOT_NOTION_SYNC_RUN_ID`) and mirrored into `notion_sync_events`.
 

--- a/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
+++ b/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
@@ -9,6 +9,13 @@ const webWikiCtor = vi.fn();
 const webWikiUpsertPage = vi.fn(async () => {});
 const webWikiDeletePage = vi.fn(async () => {});
 const webWikiSetCharacterStatus = vi.fn(async () => {});
+const payloadBuilderSpies = vi.hoisted(() => ({
+  buildHuntingSiteCreatePayload: vi.fn((args: Record<string, unknown>) => ({ __kind: 'hunting', ...args })),
+  buildLocationCreatePayload: vi.fn((args: Record<string, unknown>) => ({ __kind: 'location', ...args })),
+  buildPcTrackerCreatePayload: vi.fn((args: Record<string, unknown>) => ({ __kind: 'pc', ...args })),
+  buildSessionLogCreatePayload: vi.fn((args: Record<string, unknown>) => ({ __kind: 'session', ...args })),
+  buildSpcCreatePayload: vi.fn((args: Record<string, unknown>) => ({ __kind: 'spc', ...args })),
+}));
 
 vi.mock('discord.js', () => {
   class MockREST {
@@ -58,11 +65,11 @@ vi.mock('../scripts/notionSync/notionWrites', () => ({
 }));
 
 vi.mock('../scripts/notionSync/notionPayloadBuilders', () => ({
-  buildHuntingSiteCreatePayload: vi.fn(() => ({})),
-  buildLocationCreatePayload: vi.fn(() => ({})),
-  buildPcTrackerCreatePayload: vi.fn(() => ({})),
-  buildSessionLogCreatePayload: vi.fn(() => ({})),
-  buildSpcCreatePayload: vi.fn(() => ({})),
+  buildHuntingSiteCreatePayload: payloadBuilderSpies.buildHuntingSiteCreatePayload,
+  buildLocationCreatePayload: payloadBuilderSpies.buildLocationCreatePayload,
+  buildPcTrackerCreatePayload: payloadBuilderSpies.buildPcTrackerCreatePayload,
+  buildSessionLogCreatePayload: payloadBuilderSpies.buildSessionLogCreatePayload,
+  buildSpcCreatePayload: payloadBuilderSpies.buildSpcCreatePayload,
 }));
 
 vi.mock('../scripts/notionSync/wikiSyncHelpers', () => ({
@@ -229,9 +236,56 @@ describe('runNotionSync target orchestration', () => {
     expect(notionCtor).toHaveBeenCalledTimes(1);
     expect(notionDbUpdate).toHaveBeenCalledTimes(5);
     expect(notionPagesCreate).toHaveBeenCalled();
+    expect(payloadBuilderSpies.buildLocationCreatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({ locationName: 'Broadway' }),
+    );
+    expect(payloadBuilderSpies.buildHuntingSiteCreatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({ siteName: 'Site One' }),
+    );
+    expect(payloadBuilderSpies.buildSpcCreatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'SPC Name' }),
+    );
+    expect(payloadBuilderSpies.buildSessionLogCreatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({ title: '#music-city-histories archive' }),
+    );
+    expect(payloadBuilderSpies.buildSessionLogCreatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Retired One' }),
+    );
+
+    const notionPayloads = notionPagesCreate.mock.calls.map(([payload]) => payload as Record<string, unknown>);
+    expect(notionPayloads).toEqual(expect.arrayContaining([
+      expect.objectContaining({ __kind: 'location', locationName: 'Broadway' }),
+      expect.objectContaining({ __kind: 'hunting', siteName: 'Site One' }),
+      expect.objectContaining({ __kind: 'spc', name: 'SPC Name' }),
+      expect.objectContaining({ __kind: 'session', title: '#music-city-histories archive' }),
+    ]));
 
     expect(webWikiUpsertPage).toHaveBeenCalled();
     expect(webWikiDeletePage).toHaveBeenCalled();
     expect(webWikiSetCharacterStatus).toHaveBeenCalledWith('Retired One', 'retired');
+
+    const wikiUpserts = webWikiUpsertPage.mock.calls.map(([payload]) => payload as Record<string, unknown>);
+    expect(wikiUpserts).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        slug: 'locations-Broadway',
+        category: 'locations',
+        title: 'Broadway',
+      }),
+      expect.objectContaining({
+        slug: 'characters-SPC Name',
+        category: 'characters',
+        title: 'SPC Name',
+        body_markdown: 'SPC Name\nSPC profile body',
+      }),
+      expect.objectContaining({
+        slug: 'lore-music-city-histories archive',
+        category: 'lore',
+        title: '#music-city-histories archive',
+      }),
+    ]));
+
+    const broadwayUpsert = wikiUpserts.find((p) => p.slug === 'locations-Broadway');
+    expect(String(broadwayUpsert?.body_markdown ?? '')).toContain('## Hunting Sites');
+    expect(String(broadwayUpsert?.body_markdown ?? '')).toContain('Site One');
   });
 });

--- a/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE10.md
+++ b/docs/RELEASE_2026-04-20_WIKI_SYNC_MODULARIZATION_PHASE10.md
@@ -1,0 +1,51 @@
+# Release: 2026-04-20 — Wiki Sync Modularization (Phase 10)
+
+Phase 10 adds golden-style assertions for generated Notion payloads and wiki body output in sync orchestration tests.
+
+## Scope
+
+- Bot sync test hardening only.
+- No runtime behavior changes.
+- No schema change.
+- No web API contract change.
+
+## What Changed
+
+### Deterministic Notion payload assertions
+
+Updated:
+
+- `apps/bot/src/__tests__/runNotionSyncTargets.test.ts`
+
+The test now uses deterministic payload-builder spies and asserts concrete generated values in both-target runs, including:
+
+- location payload uses `locationName: Broadway`
+- hunting payload uses `siteName: Site One`
+- SPC payload uses `name: SPC Name`
+- session payload includes archive and retired-thread titles
+
+### Concrete wiki output assertions
+
+The same orchestration test now verifies wiki upsert payload shape/content, including:
+
+- expected slug/category/title for location/character/lore pages
+- expected SPC body markdown
+- expected location body sections (Hunting Sites heading + site content)
+
+## Validation
+
+From `apps/bot/`:
+
+```bash
+npm run check
+```
+
+From repo root:
+
+```bash
+./scripts/check-docs-parity.sh
+```
+
+## Operational Result
+
+`runNotionSync` tests now protect not only execution paths but also key generated page payload/body semantics for combined-target runs.


### PR DESCRIPTION
## Summary
- strengthen `runNotionSyncTargets.test.ts` with golden-style assertions for generated Notion payload values and wiki upsert body content
- add deterministic payload-builder spies to assert key generated payload semantics (location/hunting/SPC/session)
- assert concrete wiki output for location/character/lore page payloads and location hunting section content
- update changelog, release note, and bot memory for Phase 10

## Validation
- `cd apps/bot && npm run check`
- `./scripts/check-docs-parity.sh`
