### PR TITLE
Implement issue #174: clickable background blanking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2026-04-20] Clickable Background Blanking (Issue #174)
+
+### Per-Character Tracking + One-Night Blank/Release Cycle
+
+- Added tracked character backgrounds in web DB (`character_backgrounds`) with per-background dot totals and blanked-dot state.
+- Added player-facing Background Blanking UI on character pages:
+  - set/update/remove tracked backgrounds
+  - blank a chosen number of dots for the current night
+  - live display of total/blanked/available dots and scheduled release night
+- Added bot API endpoints for background workflows:
+  - `GET /api/backgrounds/status`
+  - `POST /api/backgrounds/blank`
+  - `POST /api/backgrounds/release-due`
+- Added `/lasombra blank` command with ownership enforcement for players and staff-targeting support.
+- Added automated background release notifications to character cubbies via a new bot release monitor service.
+- Added focused web tests in [`apps/web/tests/test_background_blanking.py`](apps/web/tests/test_background_blanking.py).
+
+---
+
 ## [2026-04-20] Wiki Sync Modularization (Phase 10)
 
 ### Golden Assertions for Sync Payload and Body Output

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -17,7 +17,7 @@ export const name = 'lasombra';
 
 export const data = new SlashCommandBuilder()
   .setName('lasombra')
-  .setDescription('Staff-only commands')
+  .setDescription('Lasombra utility commands')
   .addSubcommand((s) =>
     s
       .setName('broadcast')
@@ -45,6 +45,33 @@ export const data = new SlashCommandBuilder()
           .setRequired(false)
           .setAutocomplete(true),
       ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('blank')
+      .setDescription('Blank a tracked background for one night')
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name (staff may target any character)')
+          .setRequired(false)
+          .setAutocomplete(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('background')
+          .setDescription('Tracked background name')
+          .setRequired(true)
+          .setAutocomplete(true),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName('dots')
+          .setDescription('How many dots to blank')
+          .setRequired(true)
+          .setMinValue(1)
+          .setMaxValue(10),
+      ),
   );
 
 const BROADCAST_MODAL_ID = 'lasombra:broadcast:modal';
@@ -60,7 +87,7 @@ type PendingBroadcast = {
 // Keyed by user ID — a user can only have one modal open at a time.
 const pendingBroadcasts = new Map<string, PendingBroadcast>();
 
-export async function execute(interaction: ChatInputCommandInteraction, _ctx: CommandContext): Promise<void> {
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
   const sub = interaction.options.getSubcommand();
 
   if (sub === 'broadcast') {
@@ -96,19 +123,92 @@ export async function execute(interaction: ChatInputCommandInteraction, _ctx: Co
     modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
 
     await interaction.showModal(modal);
+    return;
+  }
+
+  if (sub === 'blank') {
+    const isStaff = config.testerDiscordIds.has(interaction.user.id);
+    const requestedCharacter = interaction.options.getString('character')?.trim() ?? '';
+    const backgroundName = interaction.options.getString('background', true).trim();
+    const dots = interaction.options.getInteger('dots', true);
+
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const allNames = new Set(roster.characters.map((c) => c.name.toLowerCase()));
+    const owned = roster.characters.filter((c) => c.discordId === interaction.user.id).map((c) => c.name);
+
+    let characterName = '';
+    if (requestedCharacter) {
+      if (!allNames.has(requestedCharacter.toLowerCase())) {
+        await interaction.reply({ content: `Unknown character: ${requestedCharacter}`, ephemeral: true });
+        return;
+      }
+      if (!isStaff && !owned.some((n) => n.toLowerCase() === requestedCharacter.toLowerCase())) {
+        await interaction.reply({
+          content: 'You can only blank backgrounds for your own linked character.',
+          ephemeral: true,
+        });
+        return;
+      }
+      characterName = roster.characters.find((c) => c.name.toLowerCase() === requestedCharacter.toLowerCase())?.name ?? requestedCharacter;
+    } else {
+      if (owned.length === 1) {
+        characterName = owned[0];
+      } else if (owned.length > 1) {
+        await interaction.reply({
+          content: 'You have multiple linked characters. Please provide the `character` option.',
+          ephemeral: true,
+        });
+        return;
+      } else {
+        await interaction.reply({
+          content: 'No linked active character found. Use the web player page to link first.',
+          ephemeral: true,
+        });
+        return;
+      }
+    }
+
+    const requester = {
+      requesterDiscordId: interaction.user.id,
+      requesterDiscordName: interaction.user.username,
+    };
+
+    const result = await ctx.adapter.blankBackground(requester, {
+      characterName,
+      backgroundName,
+      dots,
+    });
+    if (!result.ok || !result.result) {
+      await interaction.reply({
+        content: `Could not blank background: ${result.message}`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    await interaction.reply({
+      content: [
+        `Blanked **${result.result.dots_blanked_now}** dot(s) of **${result.result.background_name}** for **${result.result.character_name}**.`,
+        `Available now: **${result.result.dots_available}**/${result.result.dots_total}.`,
+        `Release: **Night ${result.result.release_night_number}**${result.currentNight ? ` (current: ${result.currentNight})` : ''}.`,
+      ].join('\n'),
+      ephemeral: true,
+    });
+    return;
   }
 }
 
 export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
-  if (!config.testerDiscordIds.has(interaction.user.id)) {
-    await interaction.respond([]);
-    return;
-  }
-
+  const isStaff = config.testerDiscordIds.has(interaction.user.id);
+  const sub = interaction.options.getSubcommand(false) ?? '';
   const focused = interaction.options.getFocused(true);
   const query = focused.value.toLowerCase();
 
   if (focused.name === 'target') {
+    if (!isStaff || sub !== 'broadcast') {
+      await interaction.respond([]);
+      return;
+    }
     const choices: Array<{ name: string; value: string }> = [];
 
     // Static targets
@@ -156,12 +256,73 @@ export async function autocomplete(interaction: AutocompleteInteraction, ctx: Co
   }
 
   if (focused.name === 'mention-character') {
+    if (!isStaff || sub !== 'broadcast') {
+      await interaction.respond([]);
+      return;
+    }
     try {
       const roster = await ctx.adapter.getActiveRosterWithIds();
       const choices = roster.characters
         .filter((c) => c.discordId && c.name.toLowerCase().includes(query))
         .slice(0, 25)
         .map((c) => ({ name: c.name, value: c.discordId as string }));
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  if (sub === 'blank' && focused.name === 'character') {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      const candidates = isStaff
+        ? roster.characters.map((c) => c.name)
+        : roster.characters.filter((c) => c.discordId === interaction.user.id).map((c) => c.name);
+      const choices = candidates
+        .filter((name) => name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((name) => ({ name, value: name }));
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  if (sub === 'blank' && focused.name === 'background') {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      const requestedCharacter = interaction.options.getString('character')?.trim();
+      const owned = roster.characters.filter((c) => c.discordId === interaction.user.id).map((c) => c.name);
+      let characterName = requestedCharacter || '';
+      if (!characterName) {
+        if (owned.length === 1) {
+          characterName = owned[0];
+        } else {
+          await interaction.respond([]);
+          return;
+        }
+      }
+      if (!isStaff && !owned.some((name) => name.toLowerCase() === characterName.toLowerCase())) {
+        await interaction.respond([]);
+        return;
+      }
+
+      const requester = {
+        requesterDiscordId: interaction.user.id,
+        requesterDiscordName: interaction.user.username,
+      };
+      const status = await ctx.adapter.getBackgroundStatus(characterName, requester);
+      if (!status) {
+        await interaction.respond([]);
+        return;
+      }
+      const choices = status.backgrounds
+        .map((bg) => bg.background_name)
+        .filter((name) => name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((name) => ({ name, value: name }));
       await interaction.respond(choices);
     } catch {
       await interaction.respond([]);

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -39,6 +39,7 @@ import {
 import { ConfigSyncWorker } from './services/configSyncWorker';
 import { BotHeartbeatService } from './services/botHeartbeatService';
 import { liveConfig } from './liveConfig';
+import { BackgroundBlankReleaseService } from './services/backgroundBlankReleaseService';
 
 // Seed liveConfig from .env values so services start with the correct initial state.
 liveConfig.reviewNotifierEnabled = config.reviewNotifierEnabled;
@@ -186,6 +187,12 @@ void applyStartupConfigOverrides().then(() => {
     config.botHeartbeatIntervalMs,
     { notionSyncCapable },
   );
+  const backgroundBlankReleaseService = new BackgroundBlankReleaseService(
+    client,
+    adapter,
+    config.claimReminderGuildId ?? config.reviewNotifierGuildId ?? config.discordGuildId,
+    Math.max(60_000, config.botHeartbeatIntervalMs),
+  );
   const botLogForwarder = new BotLogForwarder(adapter);
 
   // Build hunt consequence config, respecting test mode
@@ -208,6 +215,7 @@ void applyStartupConfigOverrides().then(() => {
     await registerCommands(client);
     configSyncWorker.start();
     botHeartbeatService.start();
+    backgroundBlankReleaseService.start();
     botLogForwarder.start();
     reviewNotifier.start();
     autoPeriodCreator.start();

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -3,6 +3,9 @@ import { randomUUID } from 'node:crypto';
 import { errorToMessage, logEvent } from '../logger';
 import type {
   AdapterHealthReport,
+  BackgroundBlankResult,
+  BackgroundReleaseEvent,
+  BackgroundStatusResponse,
   ClaimContext,
   ClaimReminderSnapshot,
   ClaimPayload,
@@ -35,6 +38,12 @@ export interface TrackerAdapter {
   getClaimContext(requester: RequesterContext, opts?: { forceRefresh?: boolean }): Promise<ClaimContext>;
   getActiveRoster(): Promise<{ characters: string[] }>;
   getActiveRosterWithIds(): Promise<{ characters: Array<{ name: string; discordId: string | null }> }>;
+  getBackgroundStatus(characterName: string, requester: RequesterContext): Promise<BackgroundStatusResponse | null>;
+  blankBackground(
+    requester: RequesterContext,
+    payload: { characterName: string; backgroundName: string; dots: number },
+  ): Promise<{ ok: boolean; message: string; result?: BackgroundBlankResult; currentNight?: string }>;
+  releaseDueBackgroundBlanks(): Promise<{ ok: boolean; currentNight: string | null; released: BackgroundReleaseEvent[] }>;
   getClaimReminderTargets(): Promise<ClaimReminderSnapshot>;
   getReviewEvents(opts?: {
     sinceEpoch?: number;
@@ -176,6 +185,48 @@ const claimReminderTargetsSchema = z.object({
       characterName: z.string(),
     }),
   ),
+});
+
+const backgroundStatusSchema = z.object({
+  characterName: z.string(),
+  currentNight: z.string().nullable(),
+  currentNightNumber: z.number().nullable(),
+  backgrounds: z.array(z.object({
+    background_name: z.string(),
+    dots_total: z.number(),
+    dots_blanked: z.number(),
+    dots_available: z.number(),
+    blanked: z.boolean(),
+    blanked_at_night_number: z.number().nullable(),
+    release_night_number: z.number().nullable(),
+    updated_at: z.string(),
+    updated_by: z.string(),
+  })),
+});
+
+const blankBackgroundResponseSchema = z.object({
+  ok: z.boolean(),
+  currentNight: z.string(),
+  result: z.object({
+    character_name: z.string(),
+    background_name: z.string(),
+    dots_blanked_now: z.number(),
+    dots_total: z.number(),
+    dots_blanked_total: z.number(),
+    dots_available: z.number(),
+    release_night_number: z.number(),
+  }),
+});
+
+const releaseDueBackgroundsSchema = z.object({
+  ok: z.boolean(),
+  currentNight: z.string().nullable(),
+  released: z.array(z.object({
+    character_name: z.string(),
+    background_name: z.string(),
+    dots_released: z.number(),
+    player_discord: z.string(),
+  })),
 });
 
 const autoCreatePeriodSchema = z.object({
@@ -331,6 +382,94 @@ export class WebAppAdapter implements TrackerAdapter {
     }
     const raw = await resp.json();
     return activeRosterWithIdsSchema.parse(raw);
+  }
+
+  async getBackgroundStatus(characterName: string, requester: RequesterContext): Promise<BackgroundStatusResponse | null> {
+    const params = new URLSearchParams({
+      requesterDiscordId: requester.requesterDiscordId,
+      characterName,
+    });
+    if (requester.requesterDiscordName) {
+      params.set('requesterDiscordName', requester.requesterDiscordName);
+    }
+    if (requester.testMode) {
+      params.set('testMode', 'true');
+    }
+    if (requester.testAsDiscordId) {
+      params.set('testAsDiscordId', requester.testAsDiscordId);
+    }
+
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/backgrounds/status?${params.toString()}`, {
+      headers: this.readAuthHeaders(),
+    }).catch(() => null);
+    if (!resp || resp.status === 404) {
+      return null;
+    }
+    if (!resp.ok) {
+      throw new Error(`Web app backgrounds/status API failed (${resp.status})`);
+    }
+    const raw = await resp.json();
+    return backgroundStatusSchema.parse(raw);
+  }
+
+  async blankBackground(
+    requester: RequesterContext,
+    payload: { characterName: string; backgroundName: string; dots: number },
+  ): Promise<{ ok: boolean; message: string; result?: BackgroundBlankResult; currentNight?: string }> {
+    const requestTimestamp = Math.floor(Date.now() / 1000).toString();
+    const requestNonce = randomUUID();
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/backgrounds/blank`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Timestamp': requestTimestamp,
+        'X-Request-Nonce': requestNonce,
+        ...this.writeAuthHeaders(),
+      },
+      body: JSON.stringify({
+        requesterDiscordId: requester.requesterDiscordId,
+        requesterDiscordName: requester.requesterDiscordName,
+        testMode: requester.testMode ?? false,
+        testAsDiscordId: requester.testAsDiscordId,
+        ...payload,
+      }),
+    }).catch(() => null);
+
+    if (!resp) {
+      return { ok: false, message: 'Unable to reach web app API.' };
+    }
+    if (!resp.ok) {
+      const bodyPreview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      const userMessage = bodyPreview || `Request was rejected by the web API (status ${resp.status}).`;
+      return { ok: false, message: userMessage };
+    }
+    const parsed = blankBackgroundResponseSchema.parse(await resp.json());
+    return {
+      ok: true,
+      message: 'Background blanked.',
+      result: parsed.result,
+      currentNight: parsed.currentNight,
+    };
+  }
+
+  async releaseDueBackgroundBlanks(): Promise<{ ok: boolean; currentNight: string | null; released: BackgroundReleaseEvent[] }> {
+    const requestTimestamp = Math.floor(Date.now() / 1000).toString();
+    const requestNonce = randomUUID();
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/backgrounds/release-due`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Timestamp': requestTimestamp,
+        'X-Request-Nonce': requestNonce,
+        ...this.writeAuthHeaders(),
+      },
+      body: JSON.stringify({}),
+    }).catch(() => null);
+    if (!resp || !resp.ok) {
+      return { ok: false, currentNight: null, released: [] };
+    }
+    const parsed = releaseDueBackgroundsSchema.parse(await resp.json());
+    return { ok: parsed.ok, currentNight: parsed.currentNight, released: parsed.released };
   }
 
   async getClaimReminderTargets(): Promise<ClaimReminderSnapshot> {

--- a/apps/bot/src/services/backgroundBlankReleaseService.ts
+++ b/apps/bot/src/services/backgroundBlankReleaseService.ts
@@ -1,0 +1,73 @@
+import type { Client } from 'discord.js';
+import { errorToMessage, logEvent } from '../logger';
+import { buildCubbyChannelMap, normalizeChannelName } from './cubbyChannels';
+import type { TrackerAdapter } from './adapter';
+
+export class BackgroundBlankReleaseService {
+  private readonly client: Client;
+  private readonly adapter: TrackerAdapter;
+  private readonly guildId?: string;
+  private readonly intervalMs: number;
+
+  constructor(client: Client, adapter: TrackerAdapter, guildId?: string, intervalMs = 120_000) {
+    this.client = client;
+    this.adapter = adapter;
+    this.guildId = guildId;
+    this.intervalMs = intervalMs;
+  }
+
+  async tick(): Promise<void> {
+    if (!this.guildId) {
+      return;
+    }
+
+    try {
+      const releaseBatch = await this.adapter.releaseDueBackgroundBlanks();
+      if (!releaseBatch.ok || releaseBatch.released.length === 0) {
+        return;
+      }
+
+      const guild = await this.client.guilds.fetch(this.guildId).catch(() => null);
+      if (!guild) {
+        logEvent('warn', 'background_release_guild_not_found', { guildId: this.guildId });
+        return;
+      }
+
+      const channelMap = await buildCubbyChannelMap(guild);
+      let sent = 0;
+      for (const release of releaseBatch.released) {
+        const channel = channelMap.get(normalizeChannelName(release.character_name));
+        if (!channel) {
+          logEvent('warn', 'background_release_cubby_missing', { characterName: release.character_name });
+          continue;
+        }
+
+        const mention = /^\d{17,20}$/.test(release.player_discord)
+          ? `<@${release.player_discord}>`
+          : release.character_name;
+
+        await channel.send({
+          content: [
+            `${mention} your background refresh is ready.`,
+            `Released **${release.dots_released}** dot(s) of **${release.background_name}**.`,
+            releaseBatch.currentNight ? `Current night: **${releaseBatch.currentNight}**.` : '',
+          ].filter(Boolean).join('\n'),
+        });
+        sent += 1;
+      }
+
+      logEvent('info', 'background_release_notified', {
+        currentNight: releaseBatch.currentNight,
+        released: releaseBatch.released.length,
+        sent,
+      });
+    } catch (error) {
+      logEvent('warn', 'background_release_tick_failed', { error: errorToMessage(error) });
+    }
+  }
+
+  start(): void {
+    void this.tick();
+    setInterval(() => void this.tick(), this.intervalMs).unref();
+  }
+}

--- a/apps/bot/src/services/backgroundBlankReleaseService.ts
+++ b/apps/bot/src/services/backgroundBlankReleaseService.ts
@@ -35,31 +35,43 @@ export class BackgroundBlankReleaseService {
 
       const channelMap = await buildCubbyChannelMap(guild);
       let sent = 0;
+      let failed = 0;
       for (const release of releaseBatch.released) {
-        const channel = channelMap.get(normalizeChannelName(release.character_name));
-        if (!channel) {
-          logEvent('warn', 'background_release_cubby_missing', { characterName: release.character_name });
-          continue;
+        try {
+          const channel = channelMap.get(normalizeChannelName(release.character_name));
+          if (!channel) {
+            failed += 1;
+            logEvent('warn', 'background_release_cubby_missing', { characterName: release.character_name });
+            continue;
+          }
+
+          const mention = /^\d{17,20}$/.test(release.player_discord)
+            ? `<@${release.player_discord}>`
+            : release.character_name;
+
+          await channel.send({
+            content: [
+              `${mention} your background refresh is ready.`,
+              `Released **${release.dots_released}** dot(s) of **${release.background_name}**.`,
+              releaseBatch.currentNight ? `Current night: **${releaseBatch.currentNight}**.` : '',
+            ].filter(Boolean).join('\n'),
+          });
+          sent += 1;
+        } catch (error) {
+          failed += 1;
+          logEvent('warn', 'background_release_notify_failed', {
+            characterName: release.character_name,
+            backgroundName: release.background_name,
+            error: errorToMessage(error),
+          });
         }
-
-        const mention = /^\d{17,20}$/.test(release.player_discord)
-          ? `<@${release.player_discord}>`
-          : release.character_name;
-
-        await channel.send({
-          content: [
-            `${mention} your background refresh is ready.`,
-            `Released **${release.dots_released}** dot(s) of **${release.background_name}**.`,
-            releaseBatch.currentNight ? `Current night: **${releaseBatch.currentNight}**.` : '',
-          ].filter(Boolean).join('\n'),
-        });
-        sent += 1;
       }
 
       logEvent('info', 'background_release_notified', {
         currentNight: releaseBatch.currentNight,
         released: releaseBatch.released.length,
         sent,
+        failed,
       });
     } catch (error) {
       logEvent('warn', 'background_release_tick_failed', { error: errorToMessage(error) });

--- a/apps/bot/src/types.ts
+++ b/apps/bot/src/types.ts
@@ -137,3 +137,39 @@ export type SpendSubmissionEvent = SubmissionEventBase & {
 };
 
 export type SubmissionEvent = ClaimSubmissionEvent | SpendSubmissionEvent;
+
+export type CharacterBackgroundStatus = {
+  background_name: string;
+  dots_total: number;
+  dots_blanked: number;
+  dots_available: number;
+  blanked: boolean;
+  blanked_at_night_number: number | null;
+  release_night_number: number | null;
+  updated_at: string;
+  updated_by: string;
+};
+
+export type BackgroundStatusResponse = {
+  characterName: string;
+  currentNight: string | null;
+  currentNightNumber: number | null;
+  backgrounds: CharacterBackgroundStatus[];
+};
+
+export type BackgroundBlankResult = {
+  character_name: string;
+  background_name: string;
+  dots_blanked_now: number;
+  dots_total: number;
+  dots_blanked_total: number;
+  dots_available: number;
+  release_night_number: number;
+};
+
+export type BackgroundReleaseEvent = {
+  character_name: string;
+  background_name: string;
+  dots_released: number;
+  player_discord: string;
+};

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -173,6 +173,11 @@ def _open_periods_desc():
     return periods
 
 
+def _current_open_night():
+    periods = _open_periods_desc()
+    return periods[0] if periods else None
+
+
 def _requester_from_query():
     requester_discord_id = str(request.args.get('requesterDiscordId', '')).strip()
     requester_discord_name = str(request.args.get('requesterDiscordName', '')).strip()
@@ -342,6 +347,141 @@ def active_roster():
             ]
         })
     return jsonify({'characters': [c.character_name for c in characters]})
+
+
+@bp.route('/backgrounds/status', methods=['GET'])
+@require_bot_scope('read')
+@_limit("60 per minute")
+def backgrounds_status():
+    backend = _require_db()
+    if backend:
+        return backend
+
+    _, _, effective_discord_id, _, _, error = _requester_from_query()
+    if error:
+        return error
+
+    character_name = str(request.args.get('characterName', '')).strip()
+    if not character_name:
+        return jsonify({'error': 'characterName is required'}), 400
+
+    char = db_service.get_character(character_name)
+    if not char:
+        return jsonify({'error': 'Character not found'}), 404
+    if not _requester_can_access_character(char, effective_discord_id):
+        return _forbidden()
+
+    current_night = _current_open_night()
+    backgrounds = db_service.get_character_backgrounds(character_name)
+    return jsonify({
+        'characterName': char.character_name,
+        'currentNight': current_night.period_label if current_night else None,
+        'currentNightNumber': current_night.night_number if current_night else None,
+        'backgrounds': backgrounds,
+    })
+
+
+@bp.route('/backgrounds/blank', methods=['POST'])
+@require_bot_scope('write')
+@require_replay_protection
+@_limit("30 per minute")
+def blank_background():
+    backend = _require_db()
+    if backend:
+        return backend
+
+    payload = request.get_json(silent=True) or {}
+    _, _, effective_discord_id, effective_discord_name, _, error = _requester_from_payload(payload)
+    if error:
+        return error
+
+    character_name = str(payload.get('characterName', '')).strip()
+    background_name = str(payload.get('backgroundName', '')).strip()
+    try:
+        dots = int(payload.get('dots', 1) or 1)
+    except (TypeError, ValueError):
+        return jsonify({'error': 'dots must be an integer'}), 400
+    if not character_name:
+        return jsonify({'error': 'characterName is required'}), 400
+    if not background_name:
+        return jsonify({'error': 'backgroundName is required'}), 400
+    if dots <= 0:
+        return jsonify({'error': 'dots must be greater than 0'}), 400
+
+    char = db_service.get_character(character_name)
+    if not char:
+        return jsonify({'error': 'Character not found'}), 404
+    if not _requester_can_access_character(char, effective_discord_id):
+        return _forbidden()
+
+    current_night = _current_open_night()
+    if not current_night:
+        return jsonify({'error': 'No active open night found'}), 409
+
+    actor = f'bot:{effective_discord_name or effective_discord_id}'
+    try:
+        result = db_service.blank_character_background(
+            char.character_name,
+            background_name,
+            dots,
+            current_night.night_number,
+            actor,
+        )
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    db_service.log_action(
+        staff_user=actor,
+        action_type='bot_background_blank',
+        target=char.character_name,
+        details=(
+            f'{result["background_name"]}: blanked {result["dots_blanked_now"]} dot(s), '
+            f'release night {result["release_night_number"]}'
+        ),
+    )
+    if sheets_sync:
+        sheets_sync.sync_log_action(
+            staff_user=actor,
+            action_type='bot_background_blank',
+            target=char.character_name,
+            details=(
+                f'{result["background_name"]}: blanked {result["dots_blanked_now"]} dot(s), '
+                f'release night {result["release_night_number"]}'
+            ),
+        )
+
+    return jsonify({
+        'ok': True,
+        'currentNight': current_night.period_label,
+        'result': result,
+    })
+
+
+@bp.route('/backgrounds/release-due', methods=['POST'])
+@require_bot_scope('write')
+@require_replay_protection
+@_limit("30 per minute")
+def release_due_backgrounds():
+    backend = _require_db()
+    if backend:
+        return backend
+
+    current_night = _current_open_night()
+    if not current_night:
+        return jsonify({'ok': True, 'currentNight': None, 'released': []})
+
+    released = db_service.release_due_background_blanks(current_night.night_number)
+    for item in released:
+        db_service.log_action(
+            staff_user='system:background-release',
+            action_type='background_blank_release',
+            target=item.get('character_name', ''),
+            details=(
+                f'{item.get("background_name", "")}: released '
+                f'{int(item.get("dots_released", 0))} dot(s) on {current_night.period_label}'
+            ),
+        )
+    return jsonify({'ok': True, 'currentNight': current_night.period_label, 'released': released})
 
 
 @bp.route('/characters/<string:name>/summary', methods=['GET'])

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -174,6 +174,8 @@ def character(name):
         c.play_period for c in claims
         if c.status.lower() != 'denied'
     }
+    backgrounds = db_service.get_character_backgrounds(name)
+    current_night = open_periods[0] if open_periods else None
 
     return render_template(
         'player/character.html',
@@ -193,7 +195,95 @@ def character(name):
         open_periods=open_periods,
         claimed_periods=claimed_periods,
         spend_categories=SPEND_CATEGORIES,
+        backgrounds=backgrounds,
+        current_night=current_night,
     )
+
+
+@bp.route('/<name>/backgrounds/set', methods=['POST'])
+@require_character_owner
+@_limit("20 per minute")
+def set_background(name):
+    char = db_service.get_character(name)
+    if not char or not char.active:
+        abort(404)
+
+    background_name = request.form.get('background_name', '').strip()
+    try:
+        dots_total = int(request.form.get('dots_total', '0') or '0')
+    except (ValueError, TypeError):
+        dots_total = 0
+    dots_total = max(0, min(dots_total, 10))
+
+    actor = f'player:{session.get("discord_name", "unknown")}'
+    try:
+        result = db_service.set_character_background(name, background_name, dots_total, actor)
+        if result.get('deleted'):
+            flash(f'Removed background "{result["background"]}".', 'success')
+        else:
+            flash(f'Updated background "{result["background"]}" to {dots_total} dot(s).', 'success')
+        db_service.log_action(
+            staff_user=actor,
+            action_type='player_background_set',
+            target=name,
+            details=f'{result["background"]} => {dots_total} dots',
+        )
+    except ValueError as e:
+        flash(str(e), 'danger')
+
+    return redirect(url_for('player.character', name=name))
+
+
+@bp.route('/<name>/backgrounds/blank', methods=['POST'])
+@require_character_owner
+@_limit("20 per minute")
+def blank_background(name):
+    char = db_service.get_character(name)
+    if not char or not char.active:
+        abort(404)
+
+    background_name = request.form.get('background_name', '').strip()
+    try:
+        dots = int(request.form.get('dots', '1') or '1')
+    except (ValueError, TypeError):
+        dots = 1
+    dots = max(1, min(dots, 10))
+
+    all_periods = db_service.get_all_periods()
+    open_periods = [p for p in all_periods if p.submissions_open and p.active]
+    open_periods.sort(key=lambda p: p.night_number, reverse=True)
+    current_night = open_periods[0] if open_periods else None
+    if not current_night:
+        flash('Cannot blank backgrounds without an active night.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
+    actor = f'player:{session.get("discord_name", "unknown")}'
+    try:
+        result = db_service.blank_character_background(
+            name,
+            background_name,
+            dots,
+            current_night.night_number,
+            actor,
+        )
+        flash(
+            f'Blanked {result["dots_blanked_now"]} dot(s) of {result["background_name"]}. '
+            f'Release scheduled for Night {result["release_night_number"]}.',
+            'success',
+        )
+        db_service.log_action(
+            staff_user=actor,
+            action_type='player_background_blank',
+            target=name,
+            details=(
+                f'{result["background_name"]}: blanked {result["dots_blanked_now"]} dot(s), '
+                f'release night {result["release_night_number"]}'
+            ),
+        )
+    except ValueError as e:
+        flash(str(e), 'danger')
+
+    return redirect(url_for('player.character', name=name))
 
 
 @bp.route('/<name>/claim', methods=['POST'])

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -184,3 +184,22 @@ class DbReminderPreference(db.Model):
     opt_out = db.Column(Boolean, default=False, nullable=False)
     snooze_until_epoch = db.Column(Integer, default=0, nullable=False)
     updated_at = db.Column(String(20), default='')
+
+
+class DbCharacterBackground(db.Model):
+    __tablename__ = 'character_backgrounds'
+    __table_args__ = (
+        db.UniqueConstraint('character_name', 'background_key', name='uq_character_background_key'),
+        db.Index('ix_character_backgrounds_character', 'character_name'),
+        db.Index('ix_character_backgrounds_release_night', 'release_night_number'),
+    )
+    id = db.Column(Integer, primary_key=True)
+    character_name = db.Column(String(200), nullable=False)
+    background_key = db.Column(String(120), nullable=False)
+    background_name = db.Column(String(120), nullable=False)
+    dots_total = db.Column(Integer, nullable=False, default=0)
+    dots_blanked = db.Column(Integer, nullable=False, default=0)
+    blanked_at_night_number = db.Column(Integer, nullable=True)
+    release_night_number = db.Column(Integer, nullable=True)
+    updated_at = db.Column(String(20), nullable=False, default='')
+    updated_by = db.Column(String(100), nullable=False, default='')

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -16,7 +16,18 @@ from typing import Optional
 
 from sqlalchemy import func
 
-from app.db import db, DbCharacter, DbPlayPeriod, DbXPClaim, DbSpendRequest, DbLedgerEntry, DbAuditLog, DbReminderPreference, DbSheetsSyncError
+from app.db import (
+    db,
+    DbCharacter,
+    DbPlayPeriod,
+    DbXPClaim,
+    DbSpendRequest,
+    DbLedgerEntry,
+    DbAuditLog,
+    DbReminderPreference,
+    DbSheetsSyncError,
+    DbCharacterBackground,
+)
 from app.models import Character, PlayPeriod, XPClaim, SpendRequest, LedgerEntry, AuditEntry
 
 
@@ -88,6 +99,12 @@ def _parse_yyyymmdd(value: str) -> Optional[datetime]:
 
 def _short_md(value: datetime) -> str:
     return f'{value.month}/{value.day}'
+
+
+def _background_key(value: str) -> str:
+    normalized = re.sub(r'[^a-z0-9]+', '-', str(value or '').strip().lower())
+    normalized = normalized.strip('-')
+    return normalized[:120]
 
 
 def _row_to_character(row: DbCharacter) -> Character:
@@ -1142,6 +1159,160 @@ class DBService:
             'other_spends': other_spends,
             'summary': xp,
         }
+
+    # ── Background Blanking ──────────────────────────────────────────────────
+
+    def get_character_backgrounds(self, name: str) -> list[dict]:
+        rows = DbCharacterBackground.query.filter(
+            func.lower(DbCharacterBackground.character_name) == name.lower(),
+        ).order_by(DbCharacterBackground.background_name.asc()).all()
+        result: list[dict] = []
+        for row in rows:
+            total = max(0, int(row.dots_total or 0))
+            blanked = max(0, min(total, int(row.dots_blanked or 0)))
+            available = max(0, total - blanked)
+            result.append({
+                'id': row.id,
+                'background_name': row.background_name,
+                'dots_total': total,
+                'dots_blanked': blanked,
+                'dots_available': available,
+                'blanked': blanked > 0,
+                'blanked_at_night_number': row.blanked_at_night_number,
+                'release_night_number': row.release_night_number,
+                'updated_at': row.updated_at or '',
+                'updated_by': row.updated_by or '',
+            })
+        return result
+
+    def set_character_background(self, character_name: str, background_name: str, dots_total: int, updated_by: str) -> dict:
+        bg_name = str(background_name or '').strip()[:120]
+        if not bg_name:
+            raise ValueError('Background name is required.')
+        bg_key = _background_key(bg_name)
+        if not bg_key:
+            raise ValueError('Background name is required.')
+
+        row = DbCharacterBackground.query.filter(
+            func.lower(DbCharacterBackground.character_name) == character_name.lower(),
+            DbCharacterBackground.background_key == bg_key,
+        ).first()
+        total = max(0, int(dots_total))
+        if not row:
+            if total == 0:
+                return {'deleted': False, 'background': bg_name}
+            row = DbCharacterBackground(
+                character_name=character_name,
+                background_key=bg_key,
+                background_name=bg_name,
+                dots_total=total,
+                dots_blanked=0,
+                blanked_at_night_number=None,
+                release_night_number=None,
+                updated_at=_now_str(),
+                updated_by=updated_by[:100],
+            )
+            db.session.add(row)
+            db.session.commit()
+            return {'deleted': False, 'background': row.background_name}
+
+        if total == 0:
+            db.session.delete(row)
+            db.session.commit()
+            return {'deleted': True, 'background': row.background_name}
+
+        row.background_name = bg_name
+        row.dots_total = total
+        row.dots_blanked = max(0, min(total, int(row.dots_blanked or 0)))
+        if row.dots_blanked == 0:
+            row.blanked_at_night_number = None
+            row.release_night_number = None
+        row.updated_at = _now_str()
+        row.updated_by = updated_by[:100]
+        db.session.commit()
+        return {'deleted': False, 'background': row.background_name}
+
+    def blank_character_background(
+        self,
+        character_name: str,
+        background_name: str,
+        dots_to_blank: int,
+        current_night_number: int,
+        updated_by: str,
+    ) -> dict:
+        bg_key = _background_key(background_name)
+        if not bg_key:
+            raise ValueError('Background name is required.')
+        if current_night_number <= 0:
+            raise ValueError('Current night number is required for blanking.')
+
+        row = DbCharacterBackground.query.filter(
+            func.lower(DbCharacterBackground.character_name) == character_name.lower(),
+            DbCharacterBackground.background_key == bg_key,
+        ).first()
+        if not row:
+            raise ValueError(f'Background "{background_name}" is not tracked for {character_name}.')
+
+        dots = int(dots_to_blank)
+        if dots <= 0:
+            raise ValueError('Dots to blank must be at least 1.')
+        total = max(0, int(row.dots_total or 0))
+        blanked = max(0, min(total, int(row.dots_blanked or 0)))
+        available = total - blanked
+        if dots > available:
+            raise ValueError(
+                f'Cannot blank {dots} dot(s) from {row.background_name}; only {available} available.',
+            )
+
+        row.dots_blanked = blanked + dots
+        row.blanked_at_night_number = current_night_number
+        row.release_night_number = current_night_number + 1
+        row.updated_at = _now_str()
+        row.updated_by = updated_by[:100]
+        db.session.commit()
+        return {
+            'character_name': row.character_name,
+            'background_name': row.background_name,
+            'dots_blanked_now': dots,
+            'dots_total': row.dots_total,
+            'dots_blanked_total': row.dots_blanked,
+            'dots_available': max(0, row.dots_total - row.dots_blanked),
+            'release_night_number': row.release_night_number,
+        }
+
+    def release_due_background_blanks(self, current_night_number: int) -> list[dict]:
+        if current_night_number <= 0:
+            return []
+
+        rows = DbCharacterBackground.query.filter(
+            DbCharacterBackground.dots_blanked > 0,
+            DbCharacterBackground.release_night_number.isnot(None),
+            DbCharacterBackground.release_night_number <= current_night_number,
+        ).all()
+        if not rows:
+            return []
+
+        releases: list[dict] = []
+        for row in rows:
+            released = int(row.dots_blanked or 0)
+            if released <= 0:
+                continue
+            char = DbCharacter.query.filter(
+                func.lower(DbCharacter.character_name) == row.character_name.lower(),
+            ).first()
+            releases.append({
+                'character_name': row.character_name,
+                'background_name': row.background_name,
+                'dots_released': released,
+                'player_discord': (char.player_discord if char else '') or '',
+            })
+            row.dots_blanked = 0
+            row.blanked_at_night_number = None
+            row.release_night_number = None
+            row.updated_at = _now_str()
+            row.updated_by = 'system:release'
+        db.session.commit()
+        return releases
 
     # ── Reminder Preferences ──────────────────────────────────────────────────
 

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -1264,6 +1264,15 @@ class DBService:
                 f'Cannot blank {dots} dot(s) from {row.background_name}; only {available} available.',
             )
 
+        # If an older blank is already due this night (or earlier), release it
+        # before adding the new blank so one-night expiry is preserved.
+        existing_release_night = int(row.release_night_number or 0)
+        if blanked > 0 and existing_release_night > 0 and existing_release_night <= current_night_number:
+            row.dots_blanked = 0
+            row.blanked_at_night_number = None
+            row.release_night_number = None
+            blanked = 0
+
         row.dots_blanked = blanked + dots
         row.blanked_at_night_number = current_night_number
         row.release_night_number = current_night_number + 1

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -101,6 +101,89 @@
 </div>
 {% endif %}
 
+<!-- Backgrounds -->
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0"><i class="bi bi-check2-square"></i> Background Blanking</h5>
+        {% if current_night %}
+        <span class="badge bg-secondary">Current: {{ current_night.period_label }}</span>
+        {% endif %}
+    </div>
+    <div class="card-body">
+        {% if backgrounds %}
+        <div class="table-responsive mb-3">
+            <table class="table table-dark table-sm align-middle">
+                <thead>
+                    <tr>
+                        <th>Background</th>
+                        <th>Total</th>
+                        <th>Blanked</th>
+                        <th>Available</th>
+                        <th>Release</th>
+                        <th>Blank</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for bg in backgrounds %}
+                    <tr>
+                        <td>{{ bg.background_name }}</td>
+                        <td>{{ bg.dots_total }}</td>
+                        <td>{{ bg.dots_blanked }}</td>
+                        <td>
+                            <span class="{% if bg.dots_available > 0 %}text-success{% else %}text-muted{% endif %}">
+                                {{ bg.dots_available }}
+                            </span>
+                        </td>
+                        <td>
+                            {% if bg.release_night_number %}
+                            Night {{ bg.release_night_number }}
+                            {% else %}
+                            —
+                            {% endif %}
+                        </td>
+                        <td>
+                            <form method="POST" action="{{ url_for('player.blank_background', name=char.character_name) }}" class="d-flex gap-2">
+                                <input type="hidden" name="background_name" value="{{ bg.background_name }}">
+                                <input
+                                    type="number"
+                                    name="dots"
+                                    class="form-control form-control-sm"
+                                    style="width: 80px;"
+                                    min="1"
+                                    max="{{ bg.dots_available if bg.dots_available > 0 else 1 }}"
+                                    value="1"
+                                    {% if bg.dots_available <= 0 %}disabled{% endif %}
+                                >
+                                <button class="btn btn-sm btn-outline-warning" {% if bg.dots_available <= 0 %}disabled{% endif %}>
+                                    Blank
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-muted">No backgrounds tracked yet. Add one below to start blanking per night.</p>
+        {% endif %}
+
+        <form method="POST" action="{{ url_for('player.set_background', name=char.character_name) }}" class="row g-2 align-items-end">
+            <div class="col-md-6">
+                <label class="form-label fw-bold mb-1">Background</label>
+                <input type="text" name="background_name" class="form-control form-control-sm" placeholder="e.g., Allies" required>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label fw-bold mb-1">Dots (0 removes)</label>
+                <input type="number" name="dots_total" class="form-control form-control-sm" min="0" max="10" value="1" required>
+            </div>
+            <div class="col-md-3">
+                <button class="btn btn-sm btn-outline-secondary w-100">Set Background</button>
+            </div>
+        </form>
+    </div>
+</div>
+
 <!-- ═══ Submission Forms ═══ -->
 <div class="row mb-4">
 

--- a/apps/web/migrations/versions/6d2a4f0be9c1_add_character_backgrounds_table.py
+++ b/apps/web/migrations/versions/6d2a4f0be9c1_add_character_backgrounds_table.py
@@ -1,0 +1,42 @@
+"""add character backgrounds table
+
+Revision ID: 6d2a4f0be9c1
+Revises: c9b4e1d8f2a0
+Create Date: 2026-04-20
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6d2a4f0be9c1'
+down_revision = 'c9b4e1d8f2a0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'character_backgrounds',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('character_name', sa.String(length=200), nullable=False),
+        sa.Column('background_key', sa.String(length=120), nullable=False),
+        sa.Column('background_name', sa.String(length=120), nullable=False),
+        sa.Column('dots_total', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('dots_blanked', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('blanked_at_night_number', sa.Integer(), nullable=True),
+        sa.Column('release_night_number', sa.Integer(), nullable=True),
+        sa.Column('updated_at', sa.String(length=20), nullable=False, server_default=''),
+        sa.Column('updated_by', sa.String(length=100), nullable=False, server_default=''),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('character_name', 'background_key', name='uq_character_background_key'),
+    )
+    op.create_index('ix_character_backgrounds_character', 'character_backgrounds', ['character_name'])
+    op.create_index('ix_character_backgrounds_release_night', 'character_backgrounds', ['release_night_number'])
+
+
+def downgrade():
+    op.drop_index('ix_character_backgrounds_release_night', table_name='character_backgrounds')
+    op.drop_index('ix_character_backgrounds_character', table_name='character_backgrounds')
+    op.drop_table('character_backgrounds')

--- a/apps/web/tests/test_background_blanking.py
+++ b/apps/web/tests/test_background_blanking.py
@@ -1,0 +1,140 @@
+import time
+
+import pytest
+from flask import Flask
+
+import app as app_module
+from app.blueprints.api import bp as api_bp
+import app.blueprints.api as api_module
+from app.db import DbCharacter, DbPlayPeriod, db
+from app.db_service import DBService
+
+
+@pytest.fixture()
+def app_ctx():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WEB_APP_API_TOKEN'] = 'legacy-token'
+    app.config['WEB_APP_API_READ_TOKEN'] = 'read-token'
+    app.config['WEB_APP_API_WRITE_TOKEN'] = 'write-token'
+    app.config['BOT_API_REPLAY_PROTECTION_ENABLED'] = True
+    app.config['BOT_API_REPLAY_WINDOW_SECONDS'] = 300
+    app.config['BOT_API_NONCE_TTL_SECONDS'] = 600
+    app.config['BOT_API_NONCE_CACHE_SIZE'] = 1000
+    app.config['ALLOWED_DISCORD_IDS'] = {'999999999999999999'}
+    db.init_app(app)
+    app.register_blueprint(api_bp, url_prefix='/api')
+    with app.app_context():
+        db.create_all()
+        app_module.db_service = DBService()
+        api_module.db_service = app_module.db_service
+        yield app
+
+
+def _write_headers(token='write-token', nonce='n1'):
+    return {
+        'Authorization': f'Bearer {token}',
+        'X-Request-Timestamp': str(int(time.time())),
+        'X-Request-Nonce': nonce,
+    }
+
+
+def _seed_character_period():
+    db.session.add(DbCharacter(character_name='Aludra', player_discord='111111111111111111', active=True, status='active'))
+    db.session.add(DbPlayPeriod(period_label='Night 101 - 4/20 - 5/4', night_number=101, submissions_open=True, active=True))
+    db.session.commit()
+
+
+def test_blank_and_release_cycle(app_ctx):
+    svc = DBService()
+    _seed_character_period()
+
+    svc.set_character_background('Aludra', 'Allies', 3, 'test')
+    result = svc.blank_character_background('Aludra', 'Allies', 2, 101, 'test')
+    assert result['dots_blanked_total'] == 2
+    assert result['release_night_number'] == 102
+
+    rows = svc.get_character_backgrounds('Aludra')
+    assert rows[0]['dots_available'] == 1
+
+    released_none = svc.release_due_background_blanks(101)
+    assert released_none == []
+
+    released = svc.release_due_background_blanks(102)
+    assert len(released) == 1
+    assert released[0]['background_name'] == 'Allies'
+    assert released[0]['dots_released'] == 2
+
+    rows_after = svc.get_character_backgrounds('Aludra')
+    assert rows_after[0]['dots_blanked'] == 0
+    assert rows_after[0]['dots_available'] == 3
+
+
+def test_blank_background_api_enforces_owner(app_ctx):
+    svc = DBService()
+    _seed_character_period()
+    svc.set_character_background('Aludra', 'Resources', 2, 'test')
+
+    with app_ctx.test_client() as client:
+        # non-owner requester
+        res = client.post(
+            '/api/backgrounds/blank',
+            headers=_write_headers(nonce='owner-1'),
+            json={
+                'requesterDiscordId': '222222222222222222',
+                'requesterDiscordName': 'player2',
+                'characterName': 'Aludra',
+                'backgroundName': 'Resources',
+                'dots': 1,
+            },
+        )
+        assert res.status_code == 403
+
+        # owner requester
+        ok = client.post(
+            '/api/backgrounds/blank',
+            headers=_write_headers(nonce='owner-2'),
+            json={
+                'requesterDiscordId': '111111111111111111',
+                'requesterDiscordName': 'player1',
+                'characterName': 'Aludra',
+                'backgroundName': 'Resources',
+                'dots': 1,
+            },
+        )
+        assert ok.status_code == 200
+        data = ok.get_json()
+        assert data['ok'] is True
+        assert data['result']['dots_blanked_now'] == 1
+
+
+def test_release_due_backgrounds_api_returns_released(app_ctx):
+    svc = DBService()
+    _seed_character_period()
+    svc.set_character_background('Aludra', 'Contacts', 2, 'test')
+    svc.blank_character_background('Aludra', 'Contacts', 1, 101, 'test')
+
+    with app_ctx.test_client() as client:
+        res = client.post('/api/backgrounds/release-due', headers=_write_headers(nonce='release-1'))
+        assert res.status_code == 200
+        payload = res.get_json()
+        # current night is still 101 so nothing due yet
+        assert payload['released'] == []
+
+    # simulate next night opening
+    with app_ctx.app_context():
+        period = DbPlayPeriod.query.filter_by(period_label='Night 101 - 4/20 - 5/4').first()
+        assert period is not None
+        period.submissions_open = False
+        db.session.add(DbPlayPeriod(period_label='Night 102 - 5/5 - 5/19', night_number=102, submissions_open=True, active=True))
+        db.session.commit()
+
+    with app_ctx.test_client() as client:
+        res = client.post('/api/backgrounds/release-due', headers=_write_headers(nonce='release-2'))
+        assert res.status_code == 200
+        payload = res.get_json()
+        assert len(payload['released']) == 1
+        assert payload['released'][0]['background_name'] == 'Contacts'
+        assert payload['released'][0]['dots_released'] == 1

--- a/apps/web/tests/test_background_blanking.py
+++ b/apps/web/tests/test_background_blanking.py
@@ -72,6 +72,23 @@ def test_blank_and_release_cycle(app_ctx):
     assert rows_after[0]['dots_available'] == 3
 
 
+def test_blank_consecutive_nights_preserves_one_night_release(app_ctx):
+    svc = DBService()
+    _seed_character_period()
+    svc.set_character_background('Aludra', 'Allies', 3, 'test')
+
+    # Night 101 blank: due on 102
+    first = svc.blank_character_background('Aludra', 'Allies', 1, 101, 'test')
+    assert first['release_night_number'] == 102
+
+    # Night 102 blank without running release worker first:
+    # previous due blank should auto-release, new blank due on 103.
+    second = svc.blank_character_background('Aludra', 'Allies', 1, 102, 'test')
+    assert second['release_night_number'] == 103
+    assert second['dots_blanked_total'] == 1
+    assert second['dots_available'] == 2
+
+
 def test_blank_background_api_enforces_owner(app_ctx):
     svc = DBService()
     _seed_character_period()


### PR DESCRIPTION
## Summary
- add DB-backed per-character background tracking with blanked-dot state and release-night scheduling
- add player UI on character pages to set/remove backgrounds and blank dots for the current night
- add bot API endpoints for background status, blank action, and due-release processing
- add `/lasombra blank` command with player ownership enforcement and staff targeting support
- add automated cubby release notifications when blanked dots refresh next night

## Schema
- adds migration: `apps/web/migrations/versions/6d2a4f0be9c1_add_character_backgrounds_table.py`

## Validation
- `npm run check` (apps/bot)
- `pytest -q` (apps/web)
- `pytest -q apps/web/tests/test_background_blanking.py`
