### PR TITLE
Error dismissal, review notifier channel fallback, wiki campaigns link

### DIFF
--- a/apps/bot/src/services/reviewNotifier.ts
+++ b/apps/bot/src/services/reviewNotifier.ts
@@ -100,12 +100,14 @@ function resolveChannel(
   const exact = channelMap.get(fullKey);
   if (exact) return exact;
 
-  // First-name fallback: find channels whose normalized name equals the
-  // first hyphen-separated segment of the full key.
+  // First-name fallback: find channels whose normalized name is exactly
+  // the first word of the character name (e.g. "sylvester" for "Sylvester Glass").
+  // Prefix matching is intentionally excluded to avoid routing to unrelated
+  // channels that happen to share the same prefix.
   const firstName = fullKey.split('-')[0];
   const candidates: NotificationChannel[] = [];
   for (const [key, ch] of channelMap) {
-    if (key === firstName || key.startsWith(`${firstName}-`)) {
+    if (key === firstName) {
       candidates.push(ch);
     }
   }
@@ -256,6 +258,10 @@ export class ReviewNotifier {
           if (!channel) {
             // Advance cursor so we don't re-attempt on next poll.
             this.seenEventKeys.add(event.eventKey);
+            if (this.seenEventKeys.size > 5000) {
+              const first = this.seenEventKeys.values().next().value;
+              if (first) this.seenEventKeys.delete(first);
+            }
             this.cursorEpoch = event.reviewedAtEpoch;
             this.cursorEventKey = event.eventKey;
             saveCursorState({ cursorEpoch: this.cursorEpoch, cursorEventKey: this.cursorEventKey });

--- a/apps/bot/src/services/reviewNotifier.ts
+++ b/apps/bot/src/services/reviewNotifier.ts
@@ -5,7 +5,7 @@ import type { BotClient } from '../discord';
 import { errorToMessage, logEvent } from '../logger';
 import type { TrackerAdapter } from './adapter';
 import type { ReviewEvent } from '../types';
-import { findCubbyChannel } from './cubbyChannels';
+import { buildCubbyChannelMap, normalizeChannelName, type NotificationChannel } from './cubbyChannels';
 import { liveConfig } from '../liveConfig';
 
 const STATE_PATH = path.resolve('./data/review-notifier-cursor.json');
@@ -82,6 +82,57 @@ export function buildReviewNotificationMessage(event: ReviewEvent): string {
     base.push(`**ST Notes:** ${event.staffNotes.trim()}`);
   }
   return base.join('\n');
+}
+
+/**
+ * Resolve a cubby channel for a character name.
+ * First tries an exact normalized match; if that fails, falls back to
+ * matching on just the first word of the character name.  If the fallback
+ * is ambiguous (multiple channels share the same first-word prefix) the
+ * notification is skipped and an error is logged.
+ */
+function resolveChannel(
+  channelMap: Map<string, NotificationChannel>,
+  characterName: string,
+  eventKey: string,
+): NotificationChannel | null {
+  const fullKey = normalizeChannelName(characterName);
+  const exact = channelMap.get(fullKey);
+  if (exact) return exact;
+
+  // First-name fallback: find channels whose normalized name equals the
+  // first hyphen-separated segment of the full key.
+  const firstName = fullKey.split('-')[0];
+  const candidates: NotificationChannel[] = [];
+  for (const [key, ch] of channelMap) {
+    if (key === firstName || key.startsWith(`${firstName}-`)) {
+      candidates.push(ch);
+    }
+  }
+
+  if (candidates.length === 1) {
+    logEvent('warn', 'review_notifier_channel_first_name_fallback', {
+      characterName,
+      channelName: candidates[0].name,
+      eventKey,
+    });
+    return candidates[0];
+  }
+
+  if (candidates.length > 1) {
+    logEvent('error', 'review_notifier_channel_ambiguous', {
+      characterName,
+      candidates: candidates.map((c) => c.name),
+      eventKey,
+    });
+    return null;
+  }
+
+  logEvent('error', 'review_notifier_channel_missing', {
+    characterName,
+    eventKey,
+  });
+  return null;
 }
 
 export class ReviewNotifier {
@@ -191,6 +242,9 @@ export class ReviewNotifier {
           break;
         }
 
+        // Build channel map once per page to avoid one API round-trip per event.
+        const channelMap = await buildCubbyChannelMap(guild);
+
         for (const event of page.events) {
           if (this.seenEventKeys.has(event.eventKey)) {
             this.cursorEpoch = event.reviewedAtEpoch;
@@ -198,12 +252,13 @@ export class ReviewNotifier {
             continue;
           }
 
-          const channel = await findCubbyChannel(guild, event.characterName);
+          const channel = resolveChannel(channelMap, event.characterName, event.eventKey);
           if (!channel) {
-            logEvent('warn', 'review_notifier_channel_missing', {
-              characterName: event.characterName,
-              eventKey: event.eventKey,
-            });
+            // Advance cursor so we don't re-attempt on next poll.
+            this.seenEventKeys.add(event.eventKey);
+            this.cursorEpoch = event.reviewedAtEpoch;
+            this.cursorEventKey = event.eventKey;
+            saveCursorState({ cursorEpoch: this.cursorEpoch, cursorEventKey: this.cursorEventKey });
             continue;
           }
 

--- a/apps/web/app/blueprints/audit.py
+++ b/apps/web/app/blueprints/audit.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from flask import Blueprint, render_template, request
+from flask import Blueprint, render_template, request, jsonify, abort
 from app import db_service
 from app.sheets_sync import get_recent_sync_errors as _get_recent_sync_errors
 from app.auth import require_staff
@@ -122,6 +122,16 @@ def _parse_error_entries(filename: str, lines: list[str]) -> list[dict]:
     return entries
 
 
+@bp.route('/errors/<int:entry_id>/dismiss', methods=['POST'])
+@require_staff
+def dismiss_error(entry_id: int):
+    from app.db import AppLogEntry, db
+    entry = AppLogEntry.query.get_or_404(entry_id)
+    entry.dismissed = True
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
 @bp.route('/errors')
 @require_staff
 def errors():
@@ -131,7 +141,11 @@ def errors():
     level_filter = request.args.get('level', '').strip().lower()
     event_filter = request.args.get('event', '').strip().lower()
 
+    show_dismissed = request.args.get('show_dismissed', '').lower() in ('1', 'true', 'yes')
+
     query = AppLogEntry.query.order_by(AppLogEntry.created_at.desc())
+    if not show_dismissed:
+        query = query.filter(AppLogEntry.dismissed == False)  # noqa: E712
     if source_filter in ('bot', 'web'):
         query = query.filter(AppLogEntry.source == source_filter)
     if level_filter in ('warn', 'error'):
@@ -142,12 +156,14 @@ def errors():
 
     entries = [
         {
+            'id': e.id,
             'timestamp': e.ts,
             'source': e.source,
             'level': e.level,
             'event': e.event,
             'message': e.message,
             'details': e.details,
+            'dismissed': e.dismissed,
         }
         for e in db_entries
     ]
@@ -172,5 +188,6 @@ def errors():
         source_filter=source_filter,
         level_filter=level_filter,
         event_filter=event_filter,
+        show_dismissed=show_dismissed,
         sync_errors=sync_errors,
     )

--- a/apps/web/app/blueprints/audit.py
+++ b/apps/web/app/blueprints/audit.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from flask import Blueprint, render_template, request, jsonify, abort
+from flask import Blueprint, render_template, request, jsonify
 from app import db_service
 from app.sheets_sync import get_recent_sync_errors as _get_recent_sync_errors
 from app.auth import require_staff

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -164,16 +164,34 @@ def _unique_slug(base: str) -> str:
 
 # ── Public routes ─────────────────────────────────────────────────────────────
 
+def _get_featured_page(slug: str) -> Markup | None:
+    """Return rendered HTML for a featured index section page, or None if not found."""
+    page = WikiPage.query.filter_by(slug=slug, published=True).first()
+    if not page or not page.body_markdown:
+        return None
+    return _render_md(page.body_markdown)
+
+
 @bp.route('/')
 def index():
     recent = (WikiPage.query
               .filter_by(published=True)
               .order_by(WikiPage.updated_at.desc())
-              .limit(8)
+              .limit(6)
               .all())
     counts = {s: WikiPage.query.filter_by(category=s, published=True).count()
               for s, _, _ in CATEGORIES}
-    return render_template('wiki/index.html', recent=recent, counts=counts)
+    chronicle_background = _get_featured_page('chronicle-background')
+    state_of_domain = _get_featured_page('state-of-domain')
+    coteries_page = WikiPage.query.filter_by(slug='domains-and-coteries', published=True).first()
+    return render_template(
+        'wiki/index.html',
+        recent=recent,
+        counts=counts,
+        chronicle_background=chronicle_background,
+        state_of_domain=state_of_domain,
+        coteries_page=coteries_page,
+    )
 
 
 @bp.route('/search')

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -19,6 +19,7 @@ class AppLogEntry(db.Model):
     message = db.Column(Text, default='')
     details = db.Column(Text, default='')
     created_at = db.Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
+    dismissed = db.Column(Boolean, nullable=False, default=False, index=True)
 
 
 class DbCharacter(db.Model):

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -929,6 +929,15 @@ tr.has-clan-color {
     background: rgba(255, 255, 255, 0.06);
 }
 
+.campaigns-link {
+    font-size: 0.8rem !important;
+    opacity: 0.6;
+}
+
+.campaigns-link:hover {
+    opacity: 1 !important;
+}
+
 .wiki-nav-active {
     color: var(--vtm-gold) !important;
     background: rgba(197, 165, 90, 0.1) !important;

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1216,6 +1216,94 @@ a.wiki-cat-badge:hover {
     margin: 2.5rem 0;
 }
 
+/* Featured index sections */
+.wiki-featured-body {
+    font-size: 0.96rem;
+    line-height: 1.85;
+    color: #c8c8d8;
+    max-width: 820px;
+}
+
+.wiki-featured-body h2 {
+    font-size: 1.15rem;
+    color: var(--vtm-gold);
+    margin-top: 1.8rem;
+    margin-bottom: 0.5rem;
+    font-family: 'Cinzel', serif;
+    letter-spacing: 0.03em;
+}
+
+.wiki-featured-body h2:first-child {
+    margin-top: 0;
+}
+
+.wiki-featured-body p {
+    margin-bottom: 1rem;
+}
+
+/* State of the Domain — styled as an IC notice */
+.wiki-domain-notice {
+    border-left: 3px solid rgba(197, 165, 90, 0.5);
+    padding: 1.25rem 1.5rem;
+    background: rgba(197, 165, 90, 0.04);
+    border-radius: 0 6px 6px 0;
+    max-width: 820px;
+}
+
+.wiki-domain-notice .wiki-prose {
+    font-size: 0.96rem;
+    line-height: 1.85;
+    color: #c8c8d8;
+}
+
+.wiki-domain-notice .wiki-prose p {
+    margin-bottom: 0.9rem;
+}
+
+.wiki-domain-notice .wiki-prose p:last-child {
+    margin-bottom: 0;
+}
+
+/* Domains & Coteries featured link card */
+a.wiki-featured-card {
+    display: flex;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(197, 165, 90, 0.25);
+    border-radius: 8px;
+    color: inherit;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+a.wiki-featured-card:hover {
+    background: rgba(197, 165, 90, 0.06);
+    border-color: rgba(197, 165, 90, 0.5);
+    color: inherit;
+}
+
+a.wiki-featured-card h4 {
+    color: var(--vtm-gold);
+}
+
+.wiki-featured-card-cover {
+    width: 80px;
+    height: 80px;
+    border-radius: 6px;
+    background-size: cover;
+    background-position: center;
+}
+
+.wiki-featured-card-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 6px;
+    background: rgba(197, 165, 90, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    color: rgba(197, 165, 90, 0.5);
+}
+
 /* Article body */
 .wiki-article {
     font-size: 0.97rem;

--- a/apps/web/app/templates/audit/errors.html
+++ b/apps/web/app/templates/audit/errors.html
@@ -14,6 +14,11 @@
        target="_blank" rel="noopener" class="btn btn-sm btn-outline-info">
       <i class="bi bi-cloud"></i> Cloud Logs
     </a>
+    {% if show_dismissed %}
+    <a href="{{ request.path }}" class="btn btn-sm btn-outline-secondary">Hide dismissed</a>
+    {% else %}
+    <a href="?show_dismissed=1{% if source_filter %}&source={{ source_filter }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if event_filter %}&event={{ event_filter }}{% endif %}" class="btn btn-sm btn-outline-secondary">Show dismissed</a>
+    {% endif %}
   </div>
 </div>
 
@@ -99,11 +104,12 @@
                 <th style="width: 60px;">Level</th>
                 <th style="width: 200px;">Event</th>
                 <th>Message / Details</th>
+                <th style="width: 40px;"></th>
             </tr>
         </thead>
         <tbody>
             {% for entry in entries %}
-            <tr>
+            <tr id="log-row-{{ entry.id }}">
                 <td class="text-muted small text-nowrap">{{ entry.timestamp[:19] | replace('T', ' ') if entry.timestamp else '' }}</td>
                 <td><span class="badge bg-secondary">{{ entry.source }}</span></td>
                 <td>
@@ -123,6 +129,12 @@
                     </details>
                     {% endif %}
                 </td>
+                <td class="text-center">
+                    <button class="btn btn-sm btn-outline-secondary dismiss-btn" title="Dismiss"
+                            data-id="{{ entry.id }}" data-url="{{ url_for('audit.dismiss_error', entry_id=entry.id) }}">
+                        <i class="bi bi-check-lg"></i>
+                    </button>
+                </td>
             </tr>
             {% endfor %}
         </tbody>
@@ -138,5 +150,25 @@
 <script>
   // Auto-refresh every 30s so new bot log entries appear without manual reload
   setTimeout(() => location.reload(), 30000);
+
+  document.addEventListener('click', function(e) {
+    const btn = e.target.closest('.dismiss-btn');
+    if (!btn) return;
+    const id = btn.dataset.id;
+    const url = btn.dataset.url;
+    btn.disabled = true;
+    const csrf = document.querySelector('meta[name="csrf-token"]')?.content ?? '';
+    fetch(url, { method: 'POST', headers: { 'X-CSRFToken': csrf } })
+      .then(r => r.json())
+      .then(data => {
+        if (data.ok) {
+          const row = document.getElementById('log-row-' + id);
+          if (row) row.remove();
+        } else {
+          btn.disabled = false;
+        }
+      })
+      .catch(() => { btn.disabled = false; });
+  });
 </script>
 {% endblock %}

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -47,6 +47,11 @@
                     </div>
                 </form>
                 <div class="d-flex align-items-center gap-2 mt-2 mt-md-0">
+                    <a class="nav-link campaigns-link px-2 py-1"
+                       href="https://gaming.jkomg.us"
+                       title="All campaigns">
+                        ← All Campaigns
+                    </a>
                     {% if is_staff %}
                     <a href="{{ url_for('wiki.new_page') }}" class="btn btn-sm wiki-btn-new"
                        title="New wiki page">

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -31,7 +31,68 @@
 
 <hr class="wiki-sep">
 
-<!-- Recent Pages -->
+{% if chronicle_background %}
+<!-- Chronicle Background -->
+<section class="mb-5">
+    <div class="d-flex align-items-baseline justify-content-between mb-3">
+        <h2 class="wiki-section-heading mb-0">Chronicle Background</h2>
+        {% if is_staff %}
+        <a href="{{ url_for('wiki.page', slug='chronicle-background') }}" class="text-muted small text-decoration-none">
+            <i class="bi bi-pencil me-1"></i>Edit
+        </a>
+        {% endif %}
+    </div>
+    <div class="wiki-prose wiki-featured-body">
+        {{ chronicle_background }}
+    </div>
+</section>
+
+<hr class="wiki-sep">
+{% endif %}
+
+{% if state_of_domain %}
+<!-- State of the Domain -->
+<section class="mb-5">
+    <div class="d-flex align-items-baseline justify-content-between mb-3">
+        <h2 class="wiki-section-heading mb-0">State of the Domain</h2>
+        {% if is_staff %}
+        <a href="{{ url_for('wiki.page', slug='state-of-domain') }}" class="text-muted small text-decoration-none">
+            <i class="bi bi-pencil me-1"></i>Edit
+        </a>
+        {% endif %}
+    </div>
+    <div class="wiki-domain-notice">
+        <div class="wiki-prose">
+            {{ state_of_domain }}
+        </div>
+    </div>
+</section>
+
+<hr class="wiki-sep">
+{% endif %}
+
+{% if coteries_page %}
+<!-- Domains & Coteries featured link -->
+<section class="mb-5">
+    <h2 class="wiki-section-heading mb-4">Domains &amp; Coteries</h2>
+    <a href="{{ url_for('wiki.page', slug='domains-and-coteries') }}" class="wiki-featured-card text-decoration-none d-flex align-items-center gap-4 p-4">
+        {% if coteries_page.cover_image_url %}
+        <div class="wiki-featured-card-cover flex-shrink-0" style="background-image: url('{{ coteries_page.cover_image_url }}');"></div>
+        {% else %}
+        <div class="wiki-featured-card-icon flex-shrink-0"><i class="bi bi-map"></i></div>
+        {% endif %}
+        <div>
+            <h4 class="mb-1">{{ coteries_page.title }}</h4>
+            <p class="mb-0 text-muted small">View the domain map and active coteries of Nashville</p>
+        </div>
+        <i class="bi bi-arrow-right ms-auto"></i>
+    </a>
+</section>
+
+<hr class="wiki-sep">
+{% endif %}
+
+<!-- Recently Updated -->
 {% if recent %}
 <section class="mb-4">
     <h2 class="wiki-section-heading mb-4">Recently Updated</h2>

--- a/apps/web/migrations/versions/d1a8e3f7c2b5_add_dismissed_to_app_log_entries.py
+++ b/apps/web/migrations/versions/d1a8e3f7c2b5_add_dismissed_to_app_log_entries.py
@@ -1,0 +1,29 @@
+"""add dismissed to app_log_entries
+
+Revision ID: d1a8e3f7c2b5
+Revises: 6d2a4f0be9c1
+Create Date: 2026-04-21
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd1a8e3f7c2b5'
+down_revision = '6d2a4f0be9c1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'app_log_entries',
+        sa.Column('dismissed', sa.Boolean, nullable=False, server_default='0'),
+    )
+    op.create_index('ix_app_log_entries_dismissed', 'app_log_entries', ['dismissed'])
+
+
+def downgrade():
+    op.drop_index('ix_app_log_entries_dismissed', table_name='app_log_entries')
+    op.drop_column('app_log_entries', 'dismissed')


### PR DESCRIPTION
## Summary

- **Error Alerts**: per-entry ✓ dismiss button hides resolved errors; dismissed entries filtered by default with a \"Show dismissed\" toggle; migration adds `dismissed` column to `app_log_entries`
- **ReviewNotifier**: first-name channel fallback — if `sylvester-glass` channel isn't found, tries `sylvester`; ambiguous fallback logs `error`; `review_notifier_channel_missing` upgraded from `warn` → `error`; channel map built once per poll page (not per event)
- **Wiki nav**: \"← All Campaigns\" link to gaming.jkomg.us

## Test plan

- [ ] Deploy and run `flask db upgrade` to apply migration
- [ ] Visit Error Alerts — existing errors show dismiss button, clicking it removes the row
- [ ] \"Show dismissed\" toggle reveals dismissed entries
- [ ] Approve a claim for a character whose cubby is first-name-only — confirm notification delivers and `review_notifier_channel_first_name_fallback` appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)