### PR TITLE
Fix wiki index section styling and remove unused CSS

### DIFF
--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1216,31 +1216,6 @@ a.wiki-cat-badge:hover {
     margin: 2.5rem 0;
 }
 
-/* Featured index sections */
-.wiki-featured-body {
-    font-size: 0.96rem;
-    line-height: 1.85;
-    color: #c8c8d8;
-    max-width: 820px;
-}
-
-.wiki-featured-body h2 {
-    font-size: 1.15rem;
-    color: var(--vtm-gold);
-    margin-top: 1.8rem;
-    margin-bottom: 0.5rem;
-    font-family: 'Cinzel', serif;
-    letter-spacing: 0.03em;
-}
-
-.wiki-featured-body h2:first-child {
-    margin-top: 0;
-}
-
-.wiki-featured-body p {
-    margin-bottom: 1rem;
-}
-
 /* State of the Domain — styled as an IC notice */
 .wiki-domain-notice {
     border-left: 3px solid rgba(197, 165, 90, 0.5);
@@ -1250,17 +1225,11 @@ a.wiki-cat-badge:hover {
     max-width: 820px;
 }
 
-.wiki-domain-notice .wiki-prose {
+.wiki-domain-notice .wiki-article {
     font-size: 0.96rem;
-    line-height: 1.85;
-    color: #c8c8d8;
 }
 
-.wiki-domain-notice .wiki-prose p {
-    margin-bottom: 0.9rem;
-}
-
-.wiki-domain-notice .wiki-prose p:last-child {
+.wiki-domain-notice .wiki-article p:last-child {
     margin-bottom: 0;
 }
 

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -42,7 +42,7 @@
         </a>
         {% endif %}
     </div>
-    <div class="wiki-prose wiki-featured-body">
+    <div class="wiki-article" style="max-width: 820px;">
         {{ chronicle_background }}
     </div>
 </section>
@@ -62,7 +62,7 @@
         {% endif %}
     </div>
     <div class="wiki-domain-notice">
-        <div class="wiki-prose">
+        <div class="wiki-article">
             {{ state_of_domain }}
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Fix chronicle-background and state-of-domain sections on wiki index to use `wiki-article` class instead of the partial `wiki-featured-body` class — ensures headings, paragraphs, lists, tables and all other elements render with full styling
- Remove the now-unused `wiki-featured-body` CSS block

🤖 Generated with [Claude Code](https://claude.com/claude-code)