### PR TITLE
Fix state-of-domain slug lookup and push rendering fixes

### DIFF
--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -182,7 +182,7 @@ def index():
     counts = {s: WikiPage.query.filter_by(category=s, published=True).count()
               for s, _, _ in CATEGORIES}
     chronicle_background = _get_featured_page('chronicle-background')
-    state_of_domain = _get_featured_page('state-of-domain')
+    state_of_domain = _get_featured_page('state-of-the-domain')
     coteries_page = WikiPage.query.filter_by(slug='domains-and-coteries', published=True).first()
     return render_template(
         'wiki/index.html',

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -146,7 +146,7 @@ def _render_md(text: str) -> Markup:
     text = _apply_strikethrough(text or '')
     raw_html = md_lib.markdown(
         text,
-        extensions=['extra', 'toc', 'nl2br'],
+        extensions=['extra', 'toc'],
         output_format='html',
     )
     return Markup(_sanitize(raw_html))

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -43,7 +43,7 @@
         {% endif %}
     </div>
     <div class="wiki-article" style="max-width: 820px;">
-        {{ chronicle_background }}
+        {{ chronicle_background | safe }}
     </div>
 </section>
 
@@ -63,7 +63,7 @@
     </div>
     <div class="wiki-domain-notice">
         <div class="wiki-article">
-            {{ state_of_domain }}
+            {{ state_of_domain | safe }}
         </div>
     </div>
 </section>

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -56,7 +56,7 @@
     <div class="d-flex align-items-baseline justify-content-between mb-3">
         <h2 class="wiki-section-heading mb-0">State of the Domain</h2>
         {% if is_staff %}
-        <a href="{{ url_for('wiki.page', slug='state-of-domain') }}" class="text-muted small text-decoration-none">
+        <a href="{{ url_for('wiki.page', slug='state-of-the-domain') }}" class="text-muted small text-decoration-none">
             <i class="bi bi-pencil me-1"></i>Edit
         </a>
         {% endif %}


### PR DESCRIPTION
- Fix route to look for `state-of-the-domain` (auto-generated from title) instead of `state-of-domain`
- Fix Edit staff link to point to correct slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)