### PR TITLE
Add Google Maps iframe embed support + fix nl2br/slug issues

### DIFF
--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -51,15 +51,22 @@ _ALLOWED_TAGS = frozenset({
     'blockquote', 'pre', 'code',
     'table', 'thead', 'tbody', 'tr', 'th', 'td',
     'div', 'span',
+    'iframe',
 })
 _ALLOWED_ATTRS: dict[str, list[str]] = {
-    'a':   ['href', 'title', 'rel'],
-    'img': ['src', 'alt', 'title', 'width', 'height'],
-    '*':   ['class', 'id'],
+    'a':      ['href', 'title', 'rel'],
+    'img':    ['src', 'alt', 'title', 'width', 'height'],
+    'iframe': ['src', 'width', 'height', 'title', 'frameborder',
+               'allowfullscreen', 'loading', 'referrerpolicy', 'style'],
+    '*':      ['class', 'id'],
 }
 _VOID_TAGS = frozenset({'br', 'hr', 'img'})
 _URL_ATTRS = frozenset({'href', 'src'})
 _JS_RE = re.compile(r'^\s*javascript:', re.I)
+# Only these src domains are permitted for iframes
+_IFRAME_SRC_ALLOWLIST_RE = re.compile(
+    r'^https://(www\.google\.com/maps/|maps\.google\.com/)', re.I
+)
 
 
 class _HtmlSanitizer(HTMLParser):
@@ -89,6 +96,8 @@ class _HtmlSanitizer(HTMLParser):
                 continue
             value = value or ''
             if name in _URL_ATTRS and _JS_RE.match(value):
+                continue
+            if tag == 'iframe' and name == 'src' and not _IFRAME_SRC_ALLOWLIST_RE.match(value):
                 continue
             safe += f' {name}="{_html_mod.escape(value)}"'
         self._out.append(f'<{tag}{safe}>')

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1388,6 +1388,14 @@ a.wiki-featured-card h4 {
     margin: 0.75rem 0;
 }
 
+.wiki-article iframe {
+    max-width: 100%;
+    border-radius: 6px;
+    border: 1px solid rgba(197, 165, 90, 0.2);
+    margin: 1rem 0;
+    display: block;
+}
+
 /* Sidebar panel */
 .wiki-sidebar-panel {
     position: sticky;


### PR DESCRIPTION
## Summary

- Remove `nl2br` from wiki markdown renderer — it was preventing `##` headings from parsing correctly when not preceded by a blank line
- Fix `state-of-domain` slug lookup to match auto-generated `state-of-the-domain`
- Add `iframe` to wiki sanitizer allowlist, restricted to `google.com/maps` and `maps.google.com` src domains only
- Add responsive iframe CSS styling

## Embedding a map
In the Domains & Coteries page, use raw HTML in the editor:
\`\`\`html
<iframe src="https://www.google.com/maps/embed?pb=..." width="100%" height="450"></iframe>
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)