### PR TITLE
Merge Domains & Coteries into Coteries category page

### DIFF
--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -192,14 +192,12 @@ def index():
               for s, _, _ in CATEGORIES}
     chronicle_background = _get_featured_page('chronicle-background')
     state_of_domain = _get_featured_page('state-of-the-domain')
-    coteries_page = WikiPage.query.filter_by(slug='domains-and-coteries', published=True).first()
     return render_template(
         'wiki/index.html',
         recent=recent,
         counts=counts,
         chronicle_background=chronicle_background,
         state_of_domain=state_of_domain,
-        coteries_page=coteries_page,
     )
 
 
@@ -278,11 +276,18 @@ def category(category):
             _order.get(char_statuses.get(p.title.lower(), 'active'), 0),
             p.title.lower()
         ))
+    domains_and_coteries_html = None
+    domains_and_coteries_page = None
+    if category == 'coteries':
+        domains_and_coteries_html = _get_featured_page('domains-and-coteries')
+        domains_and_coteries_page = WikiPage.query.filter_by(slug='domains-and-coteries').first()
     return render_template('wiki/category.html',
                            active_category=category,
                            category_name=CATEGORY_DISPLAY[category],
                            pages=pages,
-                           char_statuses=char_statuses)
+                           char_statuses=char_statuses,
+                           domains_and_coteries_html=domains_and_coteries_html,
+                           domains_and_coteries_page=domains_and_coteries_page)
 
 
 def _xp_snapshot(character_name: str) -> tuple[dict | None, list]:
@@ -369,6 +374,7 @@ def new_page():
         p = WikiPage(
             slug=slug,
             title=title,
+            summary=request.form.get('summary', '').strip(),
             body_markdown=request.form.get('body_markdown', ''),
             category=request.form.get('category', '').strip(),
             cover_image_url=request.form.get('cover_image_url', '').strip(),
@@ -389,6 +395,7 @@ def edit_page(slug):
     p = WikiPage.query.filter_by(slug=slug).first_or_404()
     if request.method == 'POST':
         p.title = request.form.get('title', p.title).strip() or p.title
+        p.summary = request.form.get('summary', '').strip()
         p.category = request.form.get('category', p.category).strip()
         p.body_markdown = request.form.get('body_markdown', '')
         p.cover_image_url = request.form.get('cover_image_url', '').strip()

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -166,6 +166,7 @@ class WikiPage(db.Model):
     id = db.Column(Integer, primary_key=True)
     slug = db.Column(String(200), nullable=False, unique=True, index=True)
     title = db.Column(String(300), nullable=False)
+    summary = db.Column(String(300), default='')
     body_markdown = db.Column(Text, default='')
     category = db.Column(String(100), default='', index=True)
     cover_image_url = db.Column(Text, default='')

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1189,6 +1189,13 @@ tr.has-clan-color {
     color: #666;
 }
 
+.wiki-card-summary {
+    font-size: 0.78rem;
+    color: #9ca3af;
+    margin-bottom: 0.35rem;
+    line-height: 1.4;
+}
+
 /* Category badge */
 .wiki-cat-badge {
     display: inline-block;

--- a/apps/web/app/templates/wiki/category.html
+++ b/apps/web/app/templates/wiki/category.html
@@ -30,10 +30,22 @@
 
 {% if is_staff %}
 <div class="d-flex justify-content-end mb-4">
+    {% if domains_and_coteries_page %}
+    <a href="{{ url_for('wiki.edit_page', slug=domains_and_coteries_page.slug) }}" class="btn btn-sm btn-outline-secondary me-2">
+        <i class="bi bi-pencil me-1"></i>Edit Map &amp; Legend
+    </a>
+    {% endif %}
     <a href="{{ url_for('wiki.new_page') }}" class="btn btn-sm wiki-btn-new">
         <i class="bi bi-plus-circle me-1"></i>New Page
     </a>
 </div>
+{% endif %}
+
+{% if domains_and_coteries_html %}
+<div class="wiki-article mb-5">
+    {{ domains_and_coteries_html | safe }}
+</div>
+<hr class="wiki-sep mb-5">
 {% endif %}
 
 {% if pages %}
@@ -57,6 +69,9 @@
                     <span class="wiki-card-status-badge wiki-card-status-badge--retired">Retired</span>
                     {% endif %}
                 </h5>
+                {% if p.summary %}
+                <div class="wiki-card-summary">{{ p.summary }}</div>
+                {% endif %}
                 <div class="meta">
                     <i class="bi bi-clock me-1"></i>
                     {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}

--- a/apps/web/app/templates/wiki/edit.html
+++ b/apps/web/app/templates/wiki/edit.html
@@ -111,6 +111,17 @@
                     </select>
                 </div>
 
+                <!-- Summary -->
+                <div class="col-12">
+                    <label class="form-label wiki-form-label" for="summary">
+                        Summary <span class="text-muted">(optional — shown on category cards, e.g. territory or affiliation)</span>
+                    </label>
+                    <input type="text" class="form-control wiki-form-input" id="summary" name="summary"
+                           value="{{ page.summary if page else '' }}"
+                           placeholder="e.g. Territory: Midtown · Allied with the Invictus"
+                           maxlength="300">
+                </div>
+
                 <!-- Cover Image URL -->
                 <div class="col-12">
                     <label class="form-label wiki-form-label" for="cover_image_url">

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -71,27 +71,6 @@
 <hr class="wiki-sep">
 {% endif %}
 
-{% if coteries_page %}
-<!-- Domains & Coteries featured link -->
-<section class="mb-5">
-    <h2 class="wiki-section-heading mb-4">Domains &amp; Coteries</h2>
-    <a href="{{ url_for('wiki.page', slug='domains-and-coteries') }}" class="wiki-featured-card text-decoration-none d-flex align-items-center gap-4 p-4">
-        {% if coteries_page.cover_image_url %}
-        <div class="wiki-featured-card-cover flex-shrink-0" style="background-image: url('{{ coteries_page.cover_image_url }}');"></div>
-        {% else %}
-        <div class="wiki-featured-card-icon flex-shrink-0"><i class="bi bi-map"></i></div>
-        {% endif %}
-        <div>
-            <h4 class="mb-1">{{ coteries_page.title }}</h4>
-            <p class="mb-0 text-muted small">View the domain map and active coteries of Nashville</p>
-        </div>
-        <i class="bi bi-arrow-right ms-auto"></i>
-    </a>
-</section>
-
-<hr class="wiki-sep">
-{% endif %}
-
 <!-- Recently Updated -->
 {% if recent %}
 <section class="mb-4">

--- a/apps/web/migrations/versions/e2b5a9c1d7f3_add_summary_to_wiki_pages.py
+++ b/apps/web/migrations/versions/e2b5a9c1d7f3_add_summary_to_wiki_pages.py
@@ -1,0 +1,27 @@
+"""add summary to wiki_pages
+
+Revision ID: e2b5a9c1d7f3
+Revises: d1a8e3f7c2b5
+Create Date: 2026-04-21
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e2b5a9c1d7f3'
+down_revision = 'd1a8e3f7c2b5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'wiki_pages',
+        sa.Column('summary', sa.String(300), nullable=True, server_default=''),
+    )
+
+
+def downgrade():
+    op.drop_column('wiki_pages', 'summary')


### PR DESCRIPTION
## Summary

- Embeds the **Domains & Coteries** wiki page (map + legend) at the top of the Coteries category page — so the map, legend, and coterie page cards are all in one place
- Adds a **Summary** field to wiki pages (String 300) — shown on category cards for territory/affiliation info (e.g. \"Territory: Midtown · Allied with the Invictus\")
- Removes the D&C featured block from the wiki index — that content now lives under the Coteries category
- Staff get an \"Edit Map & Legend\" shortcut button on the Coteries category page

## Schema change

Migration `e2b5a9c1d7f3` adds `summary` column to `wiki_pages`.

## After merge / deploy

1. Edit the **Domains & Coteries** wiki page — remove the \"Active Coteries\" table section (keep map + legend)
2. Edit each coterie wiki page and fill in the **Summary** field with territory/affiliation info

## Test plan

- [ ] Coteries category shows D&C map+legend above the card grid
- [ ] Coterie cards show summary text when set
- [ ] Wiki index no longer shows D&C featured block
- [ ] Summary field appears in wiki edit form (new and existing pages)
- [ ] Staff \"Edit Map & Legend\" button visible on Coteries category page

🤖 Generated with [Claude Code](https://claude.com/claude-code)