### PR TITLE
Wiki bulk delete with sync block

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1280,7 +1280,10 @@ def upsert_wiki_page():
             credentials_file=_app.config.get('GOOGLE_CREDENTIALS_FILE', ''),
         )
 
+    from app.db import WikiSyncBlock
     p = WikiPage.query.filter_by(slug=slug).first()
+    if not p and WikiSyncBlock.query.filter_by(slug=slug).first():
+        return jsonify({'status': 'sync_blocked', 'slug': slug})
     if p:
         if p.sync_locked:
             return jsonify({

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -13,7 +13,7 @@ from flask import (
     Blueprint, render_template, request, redirect, url_for, flash, abort,
 )
 from app.auth import require_staff, get_staff_user, is_staff as _is_staff
-from app.db import db, WikiPage, DbCharacter, DbSpendRequest
+from app.db import db, WikiPage, WikiSyncBlock, DbCharacter, DbSpendRequest
 
 bp = Blueprint('wiki', __name__)
 
@@ -360,6 +360,11 @@ def page(slug):
 
 # ── Staff routes ───────────────────────────────────────────────────────────────
 
+def _block_slug(slug: str) -> None:
+    """Add slug to WikiSyncBlock if not already present."""
+    if not WikiSyncBlock.query.filter_by(slug=slug).first():
+        db.session.add(WikiSyncBlock(slug=slug, blocked_by=get_staff_user()))
+
 @bp.route('/new', methods=['GET', 'POST'])
 @require_staff
 def new_page():
@@ -413,9 +418,30 @@ def edit_page(slug):
 def delete_page(slug):
     p = WikiPage.query.filter_by(slug=slug).first_or_404()
     title = p.title
+    _block_slug(slug)
     db.session.delete(p)
     db.session.commit()
     flash(f'Page "{title}" deleted.', 'success')
+    return redirect(url_for('wiki.index'))
+
+
+@bp.route('/bulk-delete', methods=['POST'])
+@require_staff
+def bulk_delete():
+    slugs = request.form.getlist('slug')
+    if not slugs:
+        flash('No pages selected.', 'warning')
+        return redirect(request.referrer or url_for('wiki.index'))
+    pages = WikiPage.query.filter(WikiPage.slug.in_(slugs)).all()
+    count = len(pages)
+    for p in pages:
+        _block_slug(p.slug)
+        db.session.delete(p)
+    db.session.commit()
+    flash(f'Deleted {count} page{"s" if count != 1 else ""}. Sync is blocked for those slugs.', 'success')
+    return_category = request.form.get('return_category', '')
+    if return_category:
+        return redirect(url_for('wiki.category', category=return_category))
     return redirect(url_for('wiki.index'))
 
 

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -180,6 +180,14 @@ class WikiPage(db.Model):
     updated_by = db.Column(String(100), default='')
 
 
+class WikiSyncBlock(db.Model):
+    """Slugs that the sync is not allowed to recreate (tombstones for manually deleted pages)."""
+    __tablename__ = 'wiki_sync_blocks'
+    slug = db.Column(String(200), primary_key=True)
+    blocked_by = db.Column(String(100), nullable=False, default='')
+    blocked_at = db.Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
 class DbReminderPreference(db.Model):
     __tablename__ = 'reminder_preferences'
     discord_id = db.Column(String(30), primary_key=True)

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1196,6 +1196,43 @@ tr.has-clan-color {
     line-height: 1.4;
 }
 
+/* Bulk delete — card checkbox overlay */
+.wiki-card-col {
+    position: relative;
+}
+
+.wiki-card-select-label {
+    position: absolute;
+    top: 0.45rem;
+    left: 0.85rem;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.wiki-card-checkbox {
+    width: 1.1rem;
+    height: 1.1rem;
+    accent-color: #c5a55a;
+    cursor: pointer;
+    background: rgba(13,17,23,0.75);
+    border-radius: 3px;
+}
+
+.wiki-card-col--selected .wiki-page-card {
+    outline: 2px solid #e05252;
+    outline-offset: 2px;
+}
+
+/* Bulk delete action bar */
+.wiki-bulk-delete-bar {
+    padding: 0.65rem 0;
+    border-top: 1px solid rgba(255,255,255,0.07);
+    display: flex;
+    align-items: center;
+}
+
 /* Category badge */
 .wiki-cat-badge {
     display: inline-block;

--- a/apps/web/app/templates/wiki/category.html
+++ b/apps/web/app/templates/wiki/category.html
@@ -29,9 +29,9 @@
 {% block content %}
 
 {% if is_staff %}
-<div class="d-flex justify-content-end mb-4">
+<div class="d-flex justify-content-end align-items-center gap-2 mb-4">
     {% if domains_and_coteries_page %}
-    <a href="{{ url_for('wiki.edit_page', slug=domains_and_coteries_page.slug) }}" class="btn btn-sm btn-outline-secondary me-2">
+    <a href="{{ url_for('wiki.edit_page', slug=domains_and_coteries_page.slug) }}" class="btn btn-sm btn-outline-secondary">
         <i class="bi bi-pencil me-1"></i>Edit Map &amp; Legend
     </a>
     {% endif %}
@@ -49,41 +49,63 @@
 {% endif %}
 
 {% if pages %}
-<div class="row g-3">
-    {% for p in pages %}
-    {% set cstatus = char_statuses.get(p.title.lower(), 'active') if char_statuses is defined else 'active' %}
-    <div class="col-md-6 col-lg-4">
-        <a href="{{ url_for('wiki.page', slug=p.slug) }}"
-           class="wiki-page-card text-decoration-none {% if cstatus != 'active' %}wiki-page-card--inactive{% endif %}">
-            {% if p.cover_image_url %}
-            <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');
-                 {% if cstatus != 'active' %}filter: grayscale(60%) opacity(0.7);{% endif %}">
-            </div>
+<form id="bulk-delete-form" method="POST" action="{{ url_for('wiki.bulk_delete') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="return_category" value="{{ active_category }}">
+    <div class="row g-3">
+        {% for p in pages %}
+        {% set cstatus = char_statuses.get(p.title.lower(), 'active') if char_statuses is defined else 'active' %}
+        <div class="col-md-6 col-lg-4 wiki-card-col">
+            {% if is_staff %}
+            <label class="wiki-card-select-label">
+                <input type="checkbox" class="wiki-card-checkbox" name="slug" value="{{ p.slug }}" aria-label="Select {{ p.title }}">
+            </label>
             {% endif %}
-            <div class="wiki-card-body">
-                <h5>
-                    {{ p.title }}
-                    {% if cstatus == 'deceased' %}
-                    <span class="wiki-card-status-badge wiki-card-status-badge--deceased">&#9760; Deceased</span>
-                    {% elif cstatus == 'retired' %}
-                    <span class="wiki-card-status-badge wiki-card-status-badge--retired">Retired</span>
-                    {% endif %}
-                </h5>
-                {% if p.summary %}
-                <div class="wiki-card-summary">{{ p.summary }}</div>
-                {% endif %}
-                <div class="meta">
-                    <i class="bi bi-clock me-1"></i>
-                    {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}
-                    {% if not p.published %}
-                    <span class="badge bg-secondary ms-1">Draft</span>
-                    {% endif %}
+            <a href="{{ url_for('wiki.page', slug=p.slug) }}"
+               class="wiki-page-card text-decoration-none {% if cstatus != 'active' %}wiki-page-card--inactive{% endif %}">
+                {% if p.cover_image_url %}
+                <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');
+                     {% if cstatus != 'active' %}filter: grayscale(60%) opacity(0.7);{% endif %}">
                 </div>
-            </div>
-        </a>
+                {% endif %}
+                <div class="wiki-card-body">
+                    <h5>
+                        {{ p.title }}
+                        {% if cstatus == 'deceased' %}
+                        <span class="wiki-card-status-badge wiki-card-status-badge--deceased">&#9760; Deceased</span>
+                        {% elif cstatus == 'retired' %}
+                        <span class="wiki-card-status-badge wiki-card-status-badge--retired">Retired</span>
+                        {% endif %}
+                    </h5>
+                    {% if p.summary %}
+                    <div class="wiki-card-summary">{{ p.summary }}</div>
+                    {% endif %}
+                    <div class="meta">
+                        <i class="bi bi-clock me-1"></i>
+                        {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}
+                        {% if not p.published %}
+                        <span class="badge bg-secondary ms-1">Draft</span>
+                        {% endif %}
+                    </div>
+                </div>
+            </a>
+        </div>
+        {% endfor %}
     </div>
-    {% endfor %}
-</div>
+
+    {% if is_staff %}
+    <div id="bulk-delete-bar" class="wiki-bulk-delete-bar d-none mt-4">
+        <span id="bulk-delete-count" class="text-muted me-3 small"></span>
+        <button type="submit" class="btn btn-sm btn-danger"
+                onclick="return confirm('Permanently delete the selected pages? They will be blocked from sync re-creation.')">
+            <i class="bi bi-trash me-1"></i>Delete selected
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-secondary ms-2" id="bulk-deselect-btn">
+            Clear selection
+        </button>
+    </div>
+    {% endif %}
+</form>
 {% else %}
 <div class="empty-state">
     <i class="bi bi-journal-richtext"></i>
@@ -93,4 +115,40 @@
 </div>
 {% endif %}
 
+{% endblock %}
+
+{% block scripts %}
+{% if is_staff and pages %}
+<script>
+(function () {
+    const checkboxes = document.querySelectorAll('.wiki-card-checkbox');
+    const bar = document.getElementById('bulk-delete-bar');
+    const countEl = document.getElementById('bulk-delete-count');
+    const deselectBtn = document.getElementById('bulk-deselect-btn');
+
+    function updateBar() {
+        const checked = document.querySelectorAll('.wiki-card-checkbox:checked');
+        if (checked.length > 0) {
+            bar.classList.remove('d-none');
+            countEl.textContent = checked.length + ' page' + (checked.length !== 1 ? 's' : '') + ' selected';
+        } else {
+            bar.classList.add('d-none');
+        }
+        // Highlight selected cards
+        checkboxes.forEach(function (cb) {
+            cb.closest('.wiki-card-col').classList.toggle('wiki-card-col--selected', cb.checked);
+        });
+    }
+
+    checkboxes.forEach(function (cb) {
+        cb.addEventListener('change', updateBar);
+    });
+
+    deselectBtn.addEventListener('click', function () {
+        checkboxes.forEach(function (cb) { cb.checked = false; });
+        updateBar();
+    });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/apps/web/migrations/versions/f4c8b2e6a1d9_add_wiki_sync_blocks_table.py
+++ b/apps/web/migrations/versions/f4c8b2e6a1d9_add_wiki_sync_blocks_table.py
@@ -1,0 +1,29 @@
+"""add wiki_sync_blocks table
+
+Revision ID: f4c8b2e6a1d9
+Revises: e2b5a9c1d7f3
+Create Date: 2026-04-21
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f4c8b2e6a1d9'
+down_revision = 'e2b5a9c1d7f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'wiki_sync_blocks',
+        sa.Column('slug', sa.String(200), primary_key=True),
+        sa.Column('blocked_by', sa.String(100), nullable=False, server_default=''),
+        sa.Column('blocked_at', sa.DateTime, nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('wiki_sync_blocks')


### PR DESCRIPTION
## Summary

- **Bulk delete** — staff can select multiple pages on any category page and delete them in one action
- **Sync block** — every deleted page (bulk or single) is added to a new `wiki_sync_blocks` table; the sync API returns `sync_blocked` instead of recreating the page
- Deletion is permanent and blocks are automatic — no manual step needed to keep lore pages gone after a sync

## How it works

- Staff see a checkbox in the top-left corner of each page card on category pages
- Checking one or more reveals a **Delete selected** bar with a confirmation prompt
- On submit, pages are deleted and their slugs written to `wiki_sync_blocks`
- `POST /api/wiki/page` (upsert) now checks `wiki_sync_blocks` before creating — if blocked, returns `{"status": "sync_blocked"}` and skips creation

## Schema change

Migration `f4c8b2e6a1d9` creates the `wiki_sync_blocks` table (slug PK, blocked_by, blocked_at).

## Test plan

- [ ] Lore category: check several cards, delete bar appears with count
- [ ] Confirm prompt shows on submit
- [ ] Deleted pages are gone from the category
- [ ] Syncing the same slugs via API returns `sync_blocked` instead of creating new pages
- [ ] Single-page delete (from page view) also adds to sync block

🤖 Generated with [Claude Code](https://claude.com/claude-code)