### PR TITLE
Fix schema drift: idempotent migrations + upgrade() on startup

### DIFF
--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -108,14 +108,25 @@ def create_app():
     with app.app_context():
         # db.create_all() handles the baseline schema for fresh installs
         # (the Alembic baseline migration is a no-op).  For existing databases
-        # it's a no-op for any table that already exists.
+        # it's a no-op for tables that already exist.
         db.create_all()
-        # upgrade() applies any pending migrations (ADD COLUMN, new tables, etc.)
-        # and keeps alembic_version accurate.  All create_table migrations are
-        # written with IF NOT EXISTS guards so they're safe even when
-        # db.create_all() already created the table above.
-        from flask_migrate import upgrade as _db_upgrade
-        _db_upgrade()
+
+        from flask_migrate import upgrade as _db_upgrade, stamp as _db_stamp
+        from alembic.migration import MigrationContext
+
+        with db.engine.connect() as _conn:
+            _current_rev = MigrationContext.configure(_conn).get_current_revision()
+
+        if _current_rev is None:
+            # Fresh install: db.create_all() already built the full schema.
+            # Stamp to head so future upgrades start from the right baseline.
+            _db_stamp('head')
+        else:
+            # Existing install: apply any pending migrations (ADD COLUMN, etc.)
+            # and keep alembic_version accurate.  All create_table migrations
+            # have IF NOT EXISTS guards so they're safe if the table already
+            # exists from a prior db.create_all() run.
+            _db_upgrade()
 
     # Register blueprints
     from .blueprints.dashboard import bp as dashboard_bp

--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -105,9 +105,17 @@ def create_app():
     if sheets_client:
         sheets_sync = SheetsSyncWorker(sheets_client, flask_app=app, db_service=db_service)
 
-    # Create DB tables if they don't exist
     with app.app_context():
+        # db.create_all() handles the baseline schema for fresh installs
+        # (the Alembic baseline migration is a no-op).  For existing databases
+        # it's a no-op for any table that already exists.
         db.create_all()
+        # upgrade() applies any pending migrations (ADD COLUMN, new tables, etc.)
+        # and keeps alembic_version accurate.  All create_table migrations are
+        # written with IF NOT EXISTS guards so they're safe even when
+        # db.create_all() already created the table above.
+        from flask_migrate import upgrade as _db_upgrade
+        _db_upgrade()
 
     # Register blueprints
     from .blueprints.dashboard import bp as dashboard_bp

--- a/apps/web/migrations/versions/6d2a4f0be9c1_add_character_backgrounds_table.py
+++ b/apps/web/migrations/versions/6d2a4f0be9c1_add_character_backgrounds_table.py
@@ -16,7 +16,17 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
 def upgrade():
+    if _table_exists('character_backgrounds'):
+        return
     op.create_table(
         'character_backgrounds',
         sa.Column('id', sa.Integer(), nullable=False),

--- a/apps/web/migrations/versions/a6e9d2c7f4b1_add_notion_sync_events_table.py
+++ b/apps/web/migrations/versions/a6e9d2c7f4b1_add_notion_sync_events_table.py
@@ -16,7 +16,17 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
 def upgrade():
+    if _table_exists('notion_sync_events'):
+        return
     op.create_table(
         'notion_sync_events',
         sa.Column('id', sa.Integer, primary_key=True),

--- a/apps/web/migrations/versions/c3e5f8a12b7d_add_sheets_sync_errors_table.py
+++ b/apps/web/migrations/versions/c3e5f8a12b7d_add_sheets_sync_errors_table.py
@@ -16,7 +16,17 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
 def upgrade():
+    if _table_exists('sheets_sync_errors'):
+        return
     op.create_table(
         'sheets_sync_errors',
         sa.Column('id', sa.Integer(), nullable=False),

--- a/apps/web/migrations/versions/d4f1e9c23a8b_add_wiki_pages_table.py
+++ b/apps/web/migrations/versions/d4f1e9c23a8b_add_wiki_pages_table.py
@@ -15,7 +15,17 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
 def upgrade():
+    if _table_exists('wiki_pages'):
+        return
     op.create_table(
         'wiki_pages',
         sa.Column('id', sa.Integer(), nullable=False),

--- a/apps/web/migrations/versions/f3a7b91e45c2_add_app_log_entries_table.py
+++ b/apps/web/migrations/versions/f3a7b91e45c2_add_app_log_entries_table.py
@@ -16,7 +16,17 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
 def upgrade():
+    if _table_exists('app_log_entries'):
+        return
     op.create_table(
         'app_log_entries',
         sa.Column('id', sa.Integer, primary_key=True),

--- a/apps/web/migrations/versions/f4c8b2e6a1d9_add_wiki_sync_blocks_table.py
+++ b/apps/web/migrations/versions/f4c8b2e6a1d9_add_wiki_sync_blocks_table.py
@@ -16,7 +16,17 @@ branch_labels = None
 depends_on = None
 
 
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
 def upgrade():
+    if _table_exists('wiki_sync_blocks'):
+        return
     op.create_table(
         'wiki_sync_blocks',
         sa.Column('slug', sa.String(200), primary_key=True),


### PR DESCRIPTION
## Problem

`db.create_all()` on startup creates new tables (from newly added models) without updating `alembic_version`. The next `flask db upgrade` then fails with `table already exists`, the version pointer stays behind, and ADD COLUMN migrations for _subsequent_ releases silently don't run — causing outages like today's wiki downtime.

## Fix

**`app/__init__.py`**: run both on startup:
1. `db.create_all()` — creates the baseline tables for fresh installs (the Alembic baseline migration is a no-op)
2. `upgrade()` — applies any pending migrations and keeps `alembic_version` accurate

**All `create_table` migrations**: add a `_table_exists()` guard so they skip gracefully if the table is already there (from `db.create_all()` or a prior run). Affected migrations:
- `f3a7b91e45c2` app_log_entries
- `a6e9d2c7f4b1` notion_sync_events
- `c3e5f8a12b7d` sheets_sync_errors
- `d4f1e9c23a8b` wiki_pages
- `6d2a4f0be9c1` character_backgrounds
- `f4c8b2e6a1d9` wiki_sync_blocks

## Result

After this merges, every deploy automatically applies pending migrations on startup. No more manual `flask db upgrade` runs, no more outages from missing columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)