### PR TITLE
Add Ghoul Discipline spend category (10 XP, 0→1)

### DIFF
--- a/packages/api-contract/spend_categories.json
+++ b/packages/api-contract/spend_categories.json
@@ -8,5 +8,6 @@
   "Blood Sorcery Ritual",
   "Thin-Blood Alchemy Formula",
   "Advantage (Merit/Background)",
-  "Loresheet"
+  "Loresheet",
+  "Ghoul Discipline"
 ]

--- a/packages/rules/xp_costs.json
+++ b/packages/rules/xp_costs.json
@@ -58,5 +58,11 @@
     "description": "Purchased dot × 3 (non-sequential allowed)",
     "min_dots": 0,
     "max_dots": 5
+  },
+  "Ghoul Discipline": {
+    "flat_cost": 10,
+    "description": "10 XP (0 → 1, requires resonance + kindred blood)",
+    "min_dots": 0,
+    "max_dots": 1
   }
 }


### PR DESCRIPTION
## Summary

- Adds **Ghoul Discipline** as a new XP spend category to `packages/api-contract/spend_categories.json` and `packages/rules/xp_costs.json`
- Flat cost of 10 XP for a single 0→1 purchase, with the description *"requires resonance + kindred blood"*
- Only allows 0→1 (enforced by `flat_cost` path in `xp_rules.py`, same mechanism as *New Skill*)
- No code changes required — the rules engine and bot both load categories dynamically from the shared JSON files

## Test plan

- [ ] Submit a Ghoul Discipline spend via bot; verify cost shows 10 XP and is validated correctly
- [ ] Verify trying to submit 1→2 is rejected by the rules engine
- [ ] Confirm category appears in bot spend category picker after bot restart
- [ ] Check staff review page shows the correct cost description

🤖 Generated with [Claude Code](https://claude.com/claude-code)