### PR TITLE
Fix Ghoul Discipline spend form: cost preview and dot constraints

### DIFF
--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -851,6 +851,7 @@ document.addEventListener('DOMContentLoaded', function() {
         'Thin-Blood Alchemy Formula':  { level_mult: 3, min: 0, max: 5 },
         'Advantage (Merit/Background)':{ per_dot: 3, min: 0, max: 5 },
         'Loresheet':                   { level_mult: 3, min: 0, max: 5 },
+        'Ghoul Discipline':            { flat: 10, min: 0, max: 1 },
     };
 
     function calcCost() {
@@ -871,7 +872,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         if (rules.flat !== undefined) {
             cost = rules.flat;
-            formula = '3 XP flat';
+            formula = rules.flat + ' XP flat';
         } else if (rules.level_mult !== undefined) {
             cost = nw * rules.level_mult;
             formula = nw + ' × ' + rules.level_mult;
@@ -935,8 +936,8 @@ document.addEventListener('DOMContentLoaded', function() {
             newDots.disabled = false;
         }
 
-        // Show/hide In-Clan checkbox
-        const isDiscipline = cat.toLowerCase().includes('discipline');
+        // Show/hide In-Clan checkbox (not applicable for Ghoul Discipline)
+        const isDiscipline = cat === 'Discipline (In-Clan)' || cat === 'Discipline (Out-of-Clan)' || cat === 'Caitiff Discipline';
         if (inClanGroup) {
             if (isDiscipline) {
                 inClanGroup.classList.remove('d-none');
@@ -972,6 +973,7 @@ document.addEventListener('DOMContentLoaded', function() {
         'Thin-Blood Alchemy Formula':  { level_mult: 3 },
         'Advantage (Merit/Background)':{ per_dot: 3 },
         'Loresheet':                   { level_mult: 3 },
+        'Ghoul Discipline':            { flat: 10 },
     };
 
     function wlCost(cat, from, to) {


### PR DESCRIPTION
## Summary

Follow-up to #186 — the JSON changes merged but the web form still needed fixing:

- Add `Ghoul Discipline` to the hardcoded `XP_RULES` and `WL_RULES` JS objects so estimated cost shows correctly (10 XP)
- Fix flat-cost formula label from hardcoded `'3 XP flat'` to dynamic `rules.flat + ' XP flat'`
- Lock dots to 0→1 (same behaviour as New Skill)
- Scope In-Clan checkbox to Kindred discipline categories only — won't appear for Ghoul Discipline

## Test plan

- [ ] Ghoul Discipline shows 10 XP estimated cost
- [ ] Dots locked to 0→1, fields disabled
- [ ] No In-Clan checkbox shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)