### PR TITLE
Include commit subject in Discord deploy notification

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -133,17 +133,18 @@ jobs:
 
           SHORT_SHA="${SHA:0:7}"
           COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${SHA}"
+          COMMIT_MSG=$(git log -1 --format="%s" "$SHA")
 
           if [ "$STATUS" = "success" ]; then
             COLOR=3066993
             ICON="✅"
             TITLE="Web deployed"
-            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) is live on Cloud Run."
+            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) is live on Cloud Run.\n${COMMIT_MSG}"
           else
             COLOR=15158332
             ICON="❌"
             TITLE="Deploy failed"
-            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) did not deploy. [View logs](${RUN_URL})."
+            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) did not deploy. [View logs](${RUN_URL}).\n${COMMIT_MSG}"
           fi
 
           curl -s -X POST "$WEBHOOK" \


### PR DESCRIPTION
## Summary

- Adds the commit subject line to the deploy success/failure Discord notification so you can see what landed at a glance without clicking through

Before: `` [`a1b2c3d`](…) is live on Cloud Run. ``
After: `` [`a1b2c3d`](…) is live on Cloud Run. ``
`Fix Ghoul Discipline spend form: cost preview and dot constraints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)