### PR TITLE
Fix _db_stamp keyword arg (unblocks CI on #190, #191, #192)

### DIFF
--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -120,7 +120,7 @@ def create_app():
         if _current_rev is None:
             # Fresh install: db.create_all() already built the full schema.
             # Stamp to head so future upgrades start from the right baseline.
-            _db_stamp('head')
+            _db_stamp(revision='head')
         else:
             # Existing install: apply any pending migrations (ADD COLUMN, etc.)
             # and keep alembic_version accurate.  All create_table migrations


### PR DESCRIPTION
## Summary

- `_db_stamp('head')` was passing `'head'` as the `directory` positional argument to Flask-Migrate's `stamp()`, not as `revision`
- Alembic tried to use `'head'` as a filesystem path → `"Path doesn't exist: head"`
- Only surfaces on a fresh DB (no `alembic_version` table), which is exactly what the CI Docker smoke test uses
- Production is unaffected (existing DB always has `alembic_version`, so `_db_upgrade()` is called instead)

Fix: `_db_stamp(revision='head')`

Unblocks PRs #190, #191, #192 which all fail the `docker-and-docs-hygiene` smoke test due to this bug.

## Test plan

- [ ] CI `docker-and-docs-hygiene` passes (Docker smoke start completes without migration error)
- [ ] Merge this before or alongside #190, #191, #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)