### PR TITLE
Wiki page status: draft / active / upcoming / archived

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1299,7 +1299,11 @@ def upsert_wiki_page():
         if 'cover_image_url' in data:
             p.cover_image_url = _resolve_cover(data['cover_image_url'], slug)
         if 'published' in data:
-            p.published = bool(data['published'])
+            # Bot sync sends published bool; map to status only when page is
+            # in a sync-managed state (draft/active). Upcoming/archived are
+            # staff-managed and should not be overridden by the bot.
+            if p.status in ('draft', 'active'):
+                p.status = 'active' if data['published'] else 'draft'
         p.source = data.get('source', p.source)
         p.updated_by = data.get('updated_by', 'api-sync')
         p.updated_at = datetime.now(timezone.utc)
@@ -1313,7 +1317,7 @@ def upsert_wiki_page():
         category=data.get('category', ''),
         cover_image_url=_resolve_cover(data.get('cover_image_url', ''), slug),
         source=data.get('source', 'api-sync'),
-        published=bool(data.get('published', True)),
+        status='active' if data.get('published', True) else 'draft',
         updated_by=data.get('updated_by', 'api-sync'),
     )
     db.session.add(p)

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -17,6 +17,16 @@ from app.db import db, WikiPage, WikiSyncBlock, DbCharacter, DbSpendRequest
 
 bp = Blueprint('wiki', __name__)
 
+WIKI_STATUSES = ('draft', 'active', 'upcoming', 'archived')
+WIKI_STATUS_LABELS = {
+    'draft':    'Draft',
+    'active':   'Active',
+    'upcoming': 'Upcoming',
+    'archived': 'Archived',
+}
+# Statuses visible to players (non-staff)
+WIKI_PUBLIC_STATUSES = ('active', 'upcoming')
+
 CATEGORIES: list[tuple[str, str, str]] = [
     ('locations',   'Locations',   'bi-geo-alt-fill'),
     ('characters',  'Characters',  'bi-person-fill'),
@@ -32,7 +42,12 @@ _RESERVED_SLUGS = frozenset({'new', 'edit', 'category', 'search'})
 
 @bp.context_processor
 def _wiki_context():
-    return {'wiki_categories': CATEGORIES, 'wiki_category_display': CATEGORY_DISPLAY}
+    return {
+        'wiki_categories': CATEGORIES,
+        'wiki_category_display': CATEGORY_DISPLAY,
+        'wiki_statuses': WIKI_STATUSES,
+        'wiki_status_labels': WIKI_STATUS_LABELS,
+    }
 
 
 def _slugify(text: str) -> str:
@@ -175,7 +190,7 @@ def _unique_slug(base: str) -> str:
 
 def _get_featured_page(slug: str) -> Markup | None:
     """Return rendered HTML for a featured index section page, or None if not found."""
-    page = WikiPage.query.filter_by(slug=slug, published=True).first()
+    page = WikiPage.query.filter_by(slug=slug).filter(WikiPage.status == 'active').first()
     if not page or not page.body_markdown:
         return None
     return _render_md(page.body_markdown)
@@ -184,11 +199,12 @@ def _get_featured_page(slug: str) -> Markup | None:
 @bp.route('/')
 def index():
     recent = (WikiPage.query
-              .filter_by(published=True)
+              .filter(WikiPage.status.in_(WIKI_PUBLIC_STATUSES))
               .order_by(WikiPage.updated_at.desc())
               .limit(6)
               .all())
-    counts = {s: WikiPage.query.filter_by(category=s, published=True).count()
+    counts = {s: WikiPage.query.filter_by(category=s).filter(
+                  WikiPage.status.in_(WIKI_PUBLIC_STATUSES)).count()
               for s, _, _ in CATEGORIES}
     chronicle_background = _get_featured_page('chronicle-background')
     state_of_domain = _get_featured_page('state-of-the-domain')
@@ -206,7 +222,7 @@ def search():
     q = request.args.get('q', '').strip()
     results = []
     if q:
-        visible = [WikiPage.published == True]  # noqa: E712
+        visible = [WikiPage.status.in_(WIKI_PUBLIC_STATUSES)]
         if _is_staff():
             visible = []
         pattern = f'%{q}%'
@@ -253,10 +269,10 @@ def _excerpt(body: str, query: str, context: int = 160) -> str:
 def category(category):
     if category not in CATEGORY_DISPLAY:
         abort(404)
-    pages = (WikiPage.query
-             .filter_by(category=category, published=True)
-             .order_by(WikiPage.title.asc())
-             .all())
+    query = WikiPage.query.filter_by(category=category)
+    if not _is_staff():
+        query = query.filter(WikiPage.status.in_(WIKI_PUBLIC_STATUSES))
+    pages = query.order_by(WikiPage.title.asc()).all()
     # For the characters category, look up status for each page from DbCharacter
     char_statuses: dict[str, str] = {}
     if category == 'characters':
@@ -342,7 +358,7 @@ def _xp_snapshot(character_name: str) -> tuple[dict | None, list]:
 @bp.route('/<slug>')
 def page(slug):
     p = WikiPage.query.filter_by(slug=slug).first_or_404()
-    if not p.published and not _is_staff():
+    if p.status not in WIKI_PUBLIC_STATUSES and not _is_staff():
         abort(404)
     body_html = _render_md(p.body_markdown)
     xp_snapshot, approved_spends, char_status = None, [], None
@@ -376,6 +392,9 @@ def new_page():
         custom_slug = request.form.get('slug', '').strip()
         base_slug = _slugify(custom_slug) if custom_slug else _slugify(title)
         slug = _unique_slug(base_slug)
+        new_status = request.form.get('status', 'active').strip()
+        if new_status not in WIKI_STATUSES:
+            new_status = 'active'
         p = WikiPage(
             slug=slug,
             title=title,
@@ -383,7 +402,7 @@ def new_page():
             body_markdown=request.form.get('body_markdown', ''),
             category=request.form.get('category', '').strip(),
             cover_image_url=request.form.get('cover_image_url', '').strip(),
-            published=request.form.get('published') == '1',
+            status=new_status,
             source='manual',
             updated_by=get_staff_user(),
         )
@@ -404,7 +423,9 @@ def edit_page(slug):
         p.category = request.form.get('category', p.category).strip()
         p.body_markdown = request.form.get('body_markdown', '')
         p.cover_image_url = request.form.get('cover_image_url', '').strip()
-        p.published = request.form.get('published') == '1'
+        new_status = request.form.get('status', p.status).strip()
+        if new_status in WIKI_STATUSES:
+            p.status = new_status
         p.updated_by = get_staff_user()
         p.updated_at = datetime.now(timezone.utc)
         db.session.commit()
@@ -472,4 +493,20 @@ def unlock_page(slug):
     p.sync_locked_at = None
     db.session.commit()
     flash(f'Page "{p.title}" sync lock removed. Bot sync can update it again.', 'success')
+    return redirect(url_for('wiki.page', slug=slug))
+
+
+@bp.route('/set-status/<slug>', methods=['POST'])
+@require_staff
+def set_status(slug):
+    p = WikiPage.query.filter_by(slug=slug).first_or_404()
+    new_status = request.form.get('status', '').strip()
+    if new_status not in WIKI_STATUSES:
+        flash('Invalid status.', 'danger')
+        return redirect(url_for('wiki.page', slug=slug))
+    p.status = new_status
+    p.updated_by = get_staff_user()
+    p.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'"{p.title}" status set to {WIKI_STATUS_LABELS[new_status]}.', 'success')
     return redirect(url_for('wiki.page', slug=slug))

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -171,7 +171,9 @@ class WikiPage(db.Model):
     category = db.Column(String(100), default='', index=True)
     cover_image_url = db.Column(Text, default='')
     source = db.Column(String(50), default='')
-    published = db.Column(Boolean, default=True, index=True)
+    # status: 'draft' | 'active' | 'upcoming' | 'archived'
+    # draft/archived are staff-only; active/upcoming are player-visible.
+    status = db.Column(String(20), default='active', nullable=False, index=True)
     sync_locked = db.Column(Boolean, default=False, nullable=False, index=True)
     sync_locked_by = db.Column(String(100), default='')
     sync_locked_at = db.Column(DateTime, nullable=True)

--- a/apps/web/app/templates/wiki/category.html
+++ b/apps/web/app/templates/wiki/category.html
@@ -21,6 +21,16 @@
         {% endfor %}
         <p class="wiki-cat-hero-count text-muted mt-1">
             {{ pages | length }} page{{ 's' if pages | length != 1 }}
+            {% if is_staff %}
+                {% set hidden_count = pages | selectattr('status', 'in', ['draft', 'archived']) | list | length %}
+                {% set upcoming_count = pages | selectattr('status', 'equalto', 'upcoming') | list | length %}
+                {% if hidden_count > 0 %}
+                <span class="badge bg-secondary ms-1">{{ hidden_count }} hidden</span>
+                {% endif %}
+                {% if upcoming_count > 0 %}
+                <span class="badge bg-info ms-1">{{ upcoming_count }} upcoming</span>
+                {% endif %}
+            {% endif %}
         </p>
     </div>
 </div>
@@ -65,11 +75,12 @@
                         <input type="checkbox" class="wiki-card-checkbox" name="slug" value="{{ p.slug }}" aria-label="Select {{ p.title }}">
                     </label>
                     {% endif %}
+                    {% set page_inactive = (cstatus != 'active') or (p.status in ('archived', 'draft')) %}
                     <a href="{{ url_for('wiki.page', slug=p.slug) }}"
-                       class="wiki-page-card text-decoration-none {% if cstatus != 'active' %}wiki-page-card--inactive{% endif %}">
+                       class="wiki-page-card text-decoration-none {% if page_inactive %}wiki-page-card--inactive{% endif %}">
                         {% if p.cover_image_url %}
                         <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');
-                             {% if cstatus != 'active' %}filter: grayscale(60%) opacity(0.7);{% endif %}">
+                             {% if page_inactive %}filter: grayscale(60%) opacity(0.7);{% endif %}">
                         </div>
                         {% endif %}
                         <div class="wiki-card-body">
@@ -87,8 +98,12 @@
                             <div class="meta">
                                 <i class="bi bi-clock me-1"></i>
                                 {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}
-                                {% if not p.published %}
+                                {% if p.status == 'draft' %}
                                 <span class="badge bg-secondary ms-1">Draft</span>
+                                {% elif p.status == 'upcoming' %}
+                                <span class="badge bg-info ms-1">Upcoming</span>
+                                {% elif p.status == 'archived' %}
+                                <span class="badge bg-dark ms-1">Archived</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/apps/web/app/templates/wiki/edit.html
+++ b/apps/web/app/templates/wiki/edit.html
@@ -138,14 +138,23 @@
                     {% endif %}
                 </div>
 
-                <!-- Published toggle -->
-                <div class="col-12">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="published" name="published" value="1"
-                               {% if page is none or page.published %}checked{% endif %}>
-                        <label class="form-check-label text-light" for="published">
-                            Published <span class="text-muted">(uncheck to save as draft)</span>
-                        </label>
+                <!-- Status -->
+                <div class="col-md-4">
+                    <label class="form-label wiki-form-label" for="status">Status</label>
+                    <select class="form-select wiki-form-input" id="status" name="status">
+                        {% for s in wiki_statuses %}
+                        <option value="{{ s }}"
+                            {% if page and page.status == s %}selected
+                            {% elif page is none and s == 'active' %}selected
+                            {% endif %}>
+                            {{ wiki_status_labels[s] }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                    <div class="form-text text-muted">
+                        Draft/Archived: staff only.
+                        Active: visible to all.
+                        Upcoming: visible to all, shown as "coming soon".
                     </div>
                 </div>
             </div>

--- a/apps/web/app/templates/wiki/page.html
+++ b/apps/web/app/templates/wiki/page.html
@@ -50,10 +50,20 @@
 
     <!-- Article -->
     <div class="col-lg-9">
-        {% if not page.published %}
+        {% if page.status == 'draft' %}
         <div class="alert alert-secondary d-flex align-items-center gap-2 mb-4">
-            <i class="bi bi-eye-slash-fill"></i>
+            <i class="bi bi-pencil-fill"></i>
             <span>This page is a <strong>draft</strong> — only staff can see it.</span>
+        </div>
+        {% elif page.status == 'upcoming' %}
+        <div class="alert alert-info d-flex align-items-center gap-2 mb-4">
+            <i class="bi bi-hourglass-split"></i>
+            <span><strong>Coming Soon</strong> — this page is visible to players as a preview.</span>
+        </div>
+        {% elif page.status == 'archived' %}
+        <div class="alert alert-secondary d-flex align-items-center gap-2 mb-4">
+            <i class="bi bi-archive-fill"></i>
+            <span>This page is <strong>archived</strong> — only staff can see it.</span>
         </div>
         {% endif %}
 
@@ -150,6 +160,20 @@
                     <span class="wiki-meta-value">{{ page.updated_by }}</span>
                 </div>
                 {% endif %}
+                <div class="wiki-meta-row">
+                    <span class="wiki-meta-label">Status</span>
+                    <span class="wiki-meta-value">
+                        {% if page.status == 'active' %}
+                        <span class="badge text-bg-success">Active</span>
+                        {% elif page.status == 'upcoming' %}
+                        <span class="badge text-bg-info">Upcoming</span>
+                        {% elif page.status == 'draft' %}
+                        <span class="badge text-bg-secondary">Draft</span>
+                        {% elif page.status == 'archived' %}
+                        <span class="badge text-bg-dark">Archived</span>
+                        {% endif %}
+                    </span>
+                </div>
                 {% if page.source and page.source != 'manual' %}
                 <div class="wiki-meta-row">
                     <span class="wiki-meta-label">Source</span>
@@ -181,6 +205,20 @@
                    class="btn btn-sm wiki-btn-edit">
                     <i class="bi bi-pencil-square me-1"></i>Edit Page
                 </a>
+                <form method="post" action="{{ url_for('wiki.set_status', slug=page.slug) }}" class="d-flex gap-1">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <select name="status" class="form-select form-select-sm wiki-form-input flex-grow-1"
+                            aria-label="Page status">
+                        {% for s in wiki_statuses %}
+                        <option value="{{ s }}" {% if page.status == s %}selected{% endif %}>
+                            {{ wiki_status_labels[s] }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                    <button type="submit" class="btn btn-sm btn-outline-secondary" title="Apply status">
+                        <i class="bi bi-check-lg"></i>
+                    </button>
+                </form>
                 {% if page.sync_locked %}
                 <form method="post" action="{{ url_for('wiki.unlock_page', slug=page.slug) }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/apps/web/app/templates/wiki/search.html
+++ b/apps/web/app/templates/wiki/search.html
@@ -46,8 +46,12 @@
                             {{ wiki_category_display.get(r.page.category, r.page.category) }}
                         </span>
                         {% endif %}
-                        {% if not r.page.published %}
+                        {% if r.page.status == 'draft' %}
                         <span class="badge bg-secondary flex-shrink-0">Draft</span>
+                        {% elif r.page.status == 'upcoming' %}
+                        <span class="badge bg-info flex-shrink-0">Upcoming</span>
+                        {% elif r.page.status == 'archived' %}
+                        <span class="badge bg-dark flex-shrink-0">Archived</span>
                         {% endif %}
                     </div>
                     {% if r.excerpt %}

--- a/apps/web/migrations/versions/b5c8d2e1a9f6_add_status_to_wiki_pages.py
+++ b/apps/web/migrations/versions/b5c8d2e1a9f6_add_status_to_wiki_pages.py
@@ -1,0 +1,57 @@
+"""Add status column to wiki_pages (replaces published boolean)
+
+Adds a status string column with values: draft, active, upcoming, archived.
+Migrates existing data: published=0 → draft, published=1 → active.
+The published column is left in place as dead weight (SQLite can't drop columns
+easily and it costs nothing to keep).
+
+Revision ID: b5c8d2e1a9f6
+Revises: a3c7d1e9f2b4
+Create Date: 2026-04-25
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'b5c8d2e1a9f6'
+down_revision = 'a3c7d1e9f2b4'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    conn = op.get_bind()
+    rows = conn.execute(sa.text(f'PRAGMA table_info("{table_name}")')).fetchall()
+    return any(row[1] == column_name for row in rows)
+
+
+def _index_exists(index_name: str) -> bool:
+    conn = op.get_bind()
+    row = conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='index' AND name=:n"),
+        {'n': index_name},
+    ).fetchone()
+    return row is not None
+
+
+def upgrade():
+    if not _column_exists('wiki_pages', 'status'):
+        op.add_column(
+            'wiki_pages',
+            sa.Column('status', sa.String(20), nullable=False, server_default='active'),
+        )
+        # Migrate existing data: unpublished pages become drafts
+        op.execute(sa.text(
+            "UPDATE wiki_pages SET status = 'draft' WHERE published = 0"
+        ))
+
+    if not _index_exists('ix_wiki_pages_status'):
+        op.create_index('ix_wiki_pages_status', 'wiki_pages', ['status'])
+
+
+def downgrade():
+    if _index_exists('ix_wiki_pages_status'):
+        op.drop_index('ix_wiki_pages_status', table_name='wiki_pages')
+    # status column intentionally left — SQLite cannot drop columns cleanly
+    # and restoring published semantics from status is straightforward if needed

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -159,7 +159,7 @@ def test_wiki_page_not_found():
 def test_wiki_page_published():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='test-page', title='Test', body_markdown='# Hello', published=True)
+        p = WikiPage(slug='test-page', title='Test', body_markdown='# Hello', status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -171,7 +171,7 @@ def test_wiki_page_published():
 def test_wiki_draft_hidden_from_public():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='draft-page', title='Draft', body_markdown='secret', published=False)
+        p = WikiPage(slug='draft-page', title='Draft', body_markdown='secret', status="draft")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -190,7 +190,7 @@ def test_wiki_search_finds_by_title():
     app = _app()
     with app.app_context():
         p = WikiPage(slug='nashville-overview', title='Nashville Overview',
-                     body_markdown='A city of music.', published=True)
+                     body_markdown='A city of music.', status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -204,7 +204,7 @@ def test_wiki_search_finds_by_body():
     with app.app_context():
         p = WikiPage(slug='elysium-page', title='The Elysium',
                      body_markdown='The kindred gather at the Elysium each full moon.',
-                     published=True)
+                     status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -217,7 +217,7 @@ def test_wiki_search_hides_drafts():
     app = _app()
     with app.app_context():
         p = WikiPage(slug='secret-page', title='Secret Draft',
-                     body_markdown='hidden content', published=False)
+                     body_markdown='hidden content', status="draft")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -237,7 +237,7 @@ def test_wiki_new_requires_staff():
 def test_wiki_delete_requires_staff():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='del-test', title='Delete Me', published=True)
+        p = WikiPage(slug='del-test', title='Delete Me', status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -265,7 +265,7 @@ def test_api_wiki_page_create():
 def test_api_wiki_page_update():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='existing', title='Old Title', published=True)
+        p = WikiPage(slug='existing', title='Old Title', status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -283,7 +283,7 @@ def test_api_wiki_page_update():
 def test_api_wiki_page_update_blocked_when_sync_locked():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='existing', title='Old Title', published=True, sync_locked=True)
+        p = WikiPage(slug='existing', title='Old Title', status="active", sync_locked=True)
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -319,7 +319,7 @@ def test_api_wiki_page_missing_fields():
 def test_api_wiki_page_delete():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='to-delete', title='Bye', published=True)
+        p = WikiPage(slug='to-delete', title='Bye', status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -336,7 +336,7 @@ def test_api_wiki_page_delete():
 def test_api_wiki_page_delete_blocked_when_sync_locked():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='to-delete', title='Bye', published=True, sync_locked=True)
+        p = WikiPage(slug='to-delete', title='Bye', status="active", sync_locked=True)
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -370,7 +370,7 @@ def test_api_wiki_page_delete_requires_auth():
 def test_wiki_staff_can_lock_and_unlock_page():
     app = _app()
     with app.app_context():
-        p = WikiPage(slug='lock-me', title='Lock Me', published=True)
+        p = WikiPage(slug='lock-me', title='Lock Me', status="active")
         db.session.add(p)
         db.session.commit()
     with app.test_client() as client:
@@ -403,7 +403,7 @@ def test_character_page_shows_xp_snapshot():
                            creation_xp=10, active=True)
         db.session.add(char)
         page = WikiPage(slug='char-evander-cole', title='Evander Cole',
-                        category='characters', published=True)
+                        category='characters', status="active")
         db.session.add(page)
         db.session.commit()
     with app.test_client() as client:
@@ -431,7 +431,7 @@ def test_character_page_xp_snapshot_reflects_spends():
         )
         db.session.add(spend)
         page = WikiPage(slug='char-evander-cole', title='Evander Cole',
-                        category='characters', published=True)
+                        category='characters', status="active")
         db.session.add(page)
         db.session.commit()
     with app.test_client() as client:
@@ -446,7 +446,7 @@ def test_non_character_page_no_xp_snapshot():
     app = _app()
     with app.app_context():
         page = WikiPage(slug='loc-elysium', title='The Elysium',
-                        category='locations', published=True,
+                        category='locations', status="active",
                         body_markdown='A place.')
         db.session.add(page)
         db.session.commit()
@@ -461,7 +461,7 @@ def test_character_page_no_xp_when_unmatched():
     app = _app()
     with app.app_context():
         page = WikiPage(slug='char-ghost', title='Ghost Character',
-                        category='characters', published=True,
+                        category='characters', status="active",
                         body_markdown='No DB record.')
         db.session.add(page)
         db.session.commit()


### PR DESCRIPTION
## Summary

Replaces the binary `published` boolean on wiki pages with a four-state `status` field, adding a proper admin panel for managing page visibility.

### Statuses

| Status | Visible to players | Notes |
|--------|-------------------|-------|
| **Draft** | No | Staff-only; work in progress |
| **Active** | Yes | Fully live |
| **Upcoming** | Yes | Shown with "Coming Soon" banner — good for teasing new locations/characters |
| **Archived** | No | Hidden but preserved for history |

### What changed

- **Schema** (`db.py` + migration `b5c8d2e1a9f6`): `status String(20)` replaces `published Boolean`; existing data migrated (`published=0 → draft`, `published=1 → active`)
- **Staff sidebar** (`page.html`): inline status dropdown with a checkmark button — change status without going to the edit form
- **Edit form** (`edit.html`): status dropdown with descriptive help text replaces the published checkbox
- **Category page** (`category.html`): staff see all pages including drafts/archived; hero shows "N hidden / N upcoming" counts; cards get appropriate badges
- **Search** (`search.html`): draft/upcoming/archived badges on results visible to staff
- **API** (`api.py`): bot sync sending `published: bool` is translated → status, but only overrides `draft`/`active` — pages you've set to `upcoming` or `archived` are not overwritten by the sync
- **`wiki.py`**: `set_status` POST route; all queries updated to use status; `WIKI_PUBLIC_STATUSES = ('active', 'upcoming')`

## Test plan

- [ ] Existing active pages still visible to players
- [ ] Setting a page to Draft hides it from players; staff can still see it
- [ ] Setting a page to Upcoming shows it to players with "Coming Soon" banner
- [ ] Setting a page to Archived hides it from players; shows in staff category view with Archived badge
- [ ] Edit form status dropdown saves correctly on new and existing pages
- [ ] Bot sync upsert still works (published bool translated to status)
- [ ] Bot sync does not override Upcoming/Archived pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)