### PR TITLE
Fix wiki Discord login flow and add logout button

### DIFF
--- a/apps/web/app/blueprints/dashboard.py
+++ b/apps/web/app/blueprints/dashboard.py
@@ -41,6 +41,10 @@ def login():
     if session.get('discord_id'):
         # Logged in as player, not staff — send to player portal
         return redirect(url_for('player.my_characters'))
+    # Stash a safe local ?next= path so OAuth callback returns to the right page
+    next_path = request.args.get('next', '').strip()
+    if next_path and next_path.startswith('/') and not next_path.startswith('//'):
+        session['login_next'] = next_path
     return render_template('login.html')
 
 
@@ -139,8 +143,10 @@ def discord_callback():
         session['authenticated'] = True
         session['staff_user'] = discord_name
         flash(f'Welcome, {discord_name}.', 'success')
+        # Prefer stashed next URL (e.g. wiki page); fall back to dashboard
+        default_next = url_for('dashboard.index')
         return redirect(next_url if next_url != url_for('player.my_characters')
-                        else url_for('dashboard.index'))
+                        else default_next)
     else:
         # Player user — redirect to player portal
         flash(f'Welcome, {discord_name}.', 'success')

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -61,13 +61,21 @@
                        title="Staff dashboard">
                         <i class="bi bi-speedometer2"></i>
                     </a>
+                    <a href="{{ url_for('dashboard.logout') }}" class="btn btn-sm btn-outline-secondary"
+                       title="Sign out">
+                        <i class="bi bi-box-arrow-right"></i>
+                    </a>
                     {% elif is_logged_in %}
                     <a href="{{ url_for('player.my_characters') }}" class="btn btn-sm btn-outline-secondary"
                        title="Player portal">
                         <i class="bi bi-person-circle"></i>
                     </a>
+                    <a href="{{ url_for('dashboard.logout') }}" class="btn btn-sm btn-outline-secondary"
+                       title="Sign out">
+                        <i class="bi bi-box-arrow-right"></i>
+                    </a>
                     {% else %}
-                    <a href="{{ url_for('dashboard.login') }}" class="btn btn-sm wiki-btn-login">
+                    <a href="{{ url_for('dashboard.login', next=request.path) }}" class="btn btn-sm wiki-btn-login">
                         <i class="bi bi-discord me-1"></i>Sign In
                     </a>
                     {% endif %}


### PR DESCRIPTION
## Summary

- **Return to wiki after sign-in**: Sign In button on wiki pages now passes `?next={{ request.path }}` to the login route, which stashes it as `login_next`. After Discord OAuth completes you land back on the page you came from instead of the dashboard.
- **Logout button**: Added a sign-out button (→ icon) to the wiki navbar for both staff and player sessions. Previously there was no way to log out from within the wiki.

## Test plan

- [ ] Click Sign In on a wiki page → complete Discord OAuth → land back on that wiki page
- [ ] Sign out button appears in wiki navbar when logged in as staff
- [ ] Sign out button appears in wiki navbar when logged in as player
- [ ] Sign out clears session and returns to login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)