### PR TITLE
Wiki Sign In goes directly to Discord OAuth

### DIFF
--- a/apps/web/app/blueprints/dashboard.py
+++ b/apps/web/app/blueprints/dashboard.py
@@ -105,10 +105,16 @@ def discord_callback():
 
     try:
         token_resp = requests.post(DISCORD_TOKEN_URL, data=token_data, headers=headers, timeout=10)
-        token_resp.raise_for_status()
+        if not token_resp.ok:
+            current_app.logger.error(
+                'Discord token exchange failed: HTTP %s — %s',
+                token_resp.status_code, token_resp.text,
+            )
+            flash('Failed to authenticate with Discord. Please try again.', 'danger')
+            return redirect(url_for('dashboard.login'))
         access_token = token_resp.json().get('access_token')
     except Exception as exc:
-        current_app.logger.error('Discord token exchange failed: %s', exc)
+        current_app.logger.error('Discord token exchange error: %s', exc)
         flash('Failed to authenticate with Discord. Please try again.', 'danger')
         return redirect(url_for('dashboard.login'))
 

--- a/apps/web/app/blueprints/dashboard.py
+++ b/apps/web/app/blueprints/dashboard.py
@@ -52,6 +52,10 @@ def login():
 @limiter.limit("10 per minute")
 def discord_redirect():
     """Redirect user to Discord's OAuth2 authorization page."""
+    # Stash a ?next= return path if provided (e.g. from wiki Sign In button)
+    next_path = request.args.get('next', '').strip()
+    if next_path and next_path.startswith('/') and not next_path.startswith('//'):
+        session['login_next'] = next_path
     # Generate a random state token to prevent CSRF
     state = secrets.token_urlsafe(32)
     session['oauth_state'] = state

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -75,7 +75,7 @@
                         <i class="bi bi-box-arrow-right"></i>
                     </a>
                     {% else %}
-                    <a href="{{ url_for('dashboard.login', next=request.path) }}" class="btn btn-sm wiki-btn-login">
+                    <a href="{{ url_for('dashboard.discord_redirect', next=request.path) }}" class="btn btn-sm wiki-btn-login">
                         <i class="bi bi-discord me-1"></i>Sign In
                     </a>
                     {% endif %}

--- a/apps/web/deploy.sh
+++ b/apps/web/deploy.sh
@@ -78,6 +78,7 @@ docker push "${IMAGE}"
 echo "==> Deploying to Cloud Run..."
 gcloud run deploy "${SERVICE_NAME}" \
   --image "${IMAGE}" \
+  --project "${PROJECT_ID}" \
   --region "${REGION}" \
   --platform managed \
   --allow-unauthenticated \
@@ -108,9 +109,10 @@ gcloud run deploy "${SERVICE_NAME}" \
 
 echo "==> Routing 100% traffic to latest revision..."
 gcloud run services update-traffic "${SERVICE_NAME}" \
+  --project "${PROJECT_ID}" \
   --region "${REGION}" \
   --to-latest
 
 echo ""
 echo "==> Deployed! Your app URL:"
-gcloud run services describe "${SERVICE_NAME}" --region "${REGION}" --format="value(status.url)"
+gcloud run services describe "${SERVICE_NAME}" --project "${PROJECT_ID}" --region "${REGION}" --format="value(status.url)"

--- a/apps/web/tests/test_wiki.py
+++ b/apps/web/tests/test_wiki.py
@@ -34,7 +34,7 @@ def _app():
     db.init_app(app)
     CSRFProtect(app)
     # Stub blueprints referenced by wiki templates
-    dash = _stub_bp('dashboard', '/', {'/': 'index', '/login': 'login', '/logout': 'logout'})
+    dash = _stub_bp('dashboard', '/', {'/': 'index', '/login': 'login', '/logout': 'logout', '/auth/discord': 'discord_redirect'})
     player = _stub_bp('player', '/player', {'/player/': 'my_characters'})
     app.register_blueprint(dash)
     app.register_blueprint(player)


### PR DESCRIPTION
## Summary

- Wiki Sign In button now goes directly to `/auth/discord?next=/wiki/...` — no intermediate login.html page
- `discord_redirect` stashes `?next=` into `login_next` before starting OAuth, so after authorization you land back on the wiki page you came from
- If you're already logged in as staff anywhere on the site and navigate to the wiki, your session carries over automatically and the admin controls appear immediately

## Note on where admin controls appear

The **editor sidebar** (Edit / Status / Lock / Delete) appears in the right column when you open a **specific wiki page** (e.g. `/wiki/sylvester-glass`). It does not appear on the wiki index or category listing pages — those have a **New Page** button and bulk-select checkboxes instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)