### PR TITLE
Add Backgrounds, SPCs, and Plotlines wiki categories; fix Discord sync formatting

### DIFF
--- a/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
+++ b/apps/bot/src/__tests__/runNotionSyncTargets.test.ts
@@ -272,8 +272,8 @@ describe('runNotionSync target orchestration', () => {
         title: 'Broadway',
       }),
       expect.objectContaining({
-        slug: 'characters-SPC Name',
-        category: 'characters',
+        slug: 'spcs-SPC Name',
+        category: 'spcs',
         title: 'SPC Name',
         body_markdown: 'SPC Name\nSPC profile body',
       }),

--- a/apps/bot/src/scripts/discord-notion-sync.ts
+++ b/apps/bot/src/scripts/discord-notion-sync.ts
@@ -554,14 +554,16 @@ async function main(opts: NotionSyncOptions) {
           await appendBodyBlocks(notion!, page.id, messagesToBlocks(messages));
         }
         if (WIKI_ENABLED) {
+          // Upsert under the new spcs category and delete any old char- slug.
           await wikiClient.upsertPage({
-            slug: wikiSlug('characters', name),
+            slug: wikiSlug('spcs', name),
             title: name,
-            category: 'characters',
+            category: 'spcs',
             body_markdown: messagesToMarkdown(messages),
             cover_image_url: cover ?? undefined,
             published: true,
           });
+          await wikiClient.deletePage(wikiSlug('characters', name));
         }
       }
       count++;
@@ -593,13 +595,15 @@ async function main(opts: NotionSyncOptions) {
           await appendBodyBlocks(notion!, page.id, textToBlocks(msg.content));
         }
         if (WIKI_ENABLED) {
+          // Upsert under the new spcs category and delete any old char- slug.
           await wikiClient.upsertPage({
-            slug: wikiSlug('characters', name),
+            slug: wikiSlug('spcs', name),
             title: name,
-            category: 'characters',
+            category: 'spcs',
             body_markdown: msg.content.trim(),
             published: true,
           });
+          await wikiClient.deletePage(wikiSlug('characters', name));
         }
       }
       count++;
@@ -844,11 +848,14 @@ async function main(opts: NotionSyncOptions) {
           }
           // children-of-the-night threads are PC profiles — merged into character
           // pages in step 6, not duplicated as lore wiki pages.
+          // backgrounds forum gets its own wiki category; slug stays lore- prefix
+          // so existing pages are updated in-place rather than duplicated.
           if (WIKI_ENABLED && chanName !== 'children-of-the-night') {
+            const pageCategory = chanName === 'backgrounds' ? 'backgrounds' : 'lore';
             await wikiClient.upsertPage({
               slug: wikiSlug('lore', title),
               title,
-              category: 'lore',
+              category: pageCategory,
               body_markdown: messagesToMarkdown(messages),
               cover_image_url: cover ?? undefined,
               published: true,

--- a/apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts
+++ b/apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts
@@ -2,6 +2,7 @@ export type DiscordMessageForWiki = {
   content: string;
   author: { username: string; global_name?: string };
   timestamp: string;
+  attachments?: { url: string; content_type?: string; filename: string }[];
 };
 
 export function slugify(text: string): string {
@@ -20,6 +21,9 @@ export function wikiSlug(category: string, name: string): string {
     locations: 'loc',
     characters: 'char',
     lore: 'lore',
+    backgrounds: 'bg',
+    spcs: 'spc',
+    plotlines: 'plot',
   };
   const prefix = prefixes[category] ?? category;
   return `${prefix}-${slugify(name)}`;
@@ -35,6 +39,9 @@ export function wikiSlug(category: string, name: string): string {
  *  - User/role/channel mentions: <@id> <@!id> <#id> <@&id> → removed
  *  - Timestamp tags: <t:123:F> → removed
  *  - Unbalanced ** bold markers: if count is odd, close at end of block
+ *  - Single newlines → markdown line breaks (  \n) so Discord's line-per-field
+ *    format renders as separate lines rather than one collapsed paragraph.
+ *    Double newlines (paragraph breaks) are left unchanged.
  */
 export function sanitizeDiscordMarkdown(text: string): string {
   let s = text
@@ -43,19 +50,28 @@ export function sanitizeDiscordMarkdown(text: string): string {
     .replace(/<[@#!&]?!?\d+>/g, '') // mentions & channels
     .replace(/<t:\d+(?::[tTdDfFR])?>/g, ''); // timestamp tags
 
+  // Convert lone newlines to markdown line breaks; leave blank lines alone.
+  s = s.replace(/(?<!\n)\n(?!\n)/g, '  \n');
+
   if ((s.match(/\*\*/g) ?? []).length % 2 !== 0) s += '**';
   return s.trim();
 }
 
 export function messagesToMarkdown(messages: DiscordMessageForWiki[]): string {
-  return messages
-    .filter((m) => m.content.trim())
-    .map((m) => {
-      const author = m.author.global_name ?? m.author.username;
-      const date = m.timestamp.slice(0, 10);
-      return `### ${author} · ${date}\n\n${sanitizeDiscordMarkdown(m.content.trim())}`;
-    })
-    .join('\n\n---\n\n');
+  const parts: string[] = [];
+  for (const m of messages) {
+    const images = (m.attachments ?? []).filter(
+      (a) => a.content_type?.startsWith('image/') || /\.(png|jpe?g|gif|webp)$/i.test(a.filename),
+    );
+    if (!m.content.trim() && !images.length) continue;
+    const author = m.author.global_name ?? m.author.username;
+    const date = m.timestamp.slice(0, 10);
+    const textBody = m.content.trim() ? sanitizeDiscordMarkdown(m.content.trim()) : '';
+    const imageBody = images.map((img) => `![](${img.url})`).join('\n\n');
+    const body = [textBody, imageBody].filter(Boolean).join('\n\n');
+    parts.push(`### ${author} · ${date}\n\n${body}`);
+  }
+  return parts.join('\n\n---\n\n');
 }
 
 // Coterie membership: display name → member character names (lowercase for matching)

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -30,6 +30,9 @@ WIKI_PUBLIC_STATUSES = ('active', 'upcoming')
 CATEGORIES: list[tuple[str, str, str]] = [
     ('locations',   'Locations',   'bi-geo-alt-fill'),
     ('characters',  'Characters',  'bi-person-fill'),
+    ('backgrounds', 'Backgrounds', 'bi-journal-text'),
+    ('spcs',        'SPCs',        'bi-person-badge-fill'),
+    ('plotlines',   'Plotlines',   'bi-diagram-3-fill'),
     ('coteries',    'Coteries',    'bi-people-fill'),
     ('factions',    'Factions',    'bi-shield-fill'),
     ('lore',        'Lore',        'bi-book-fill'),


### PR DESCRIPTION
## Summary

- **New wiki categories**: Backgrounds, SPCs, and Plotlines added to the wiki nav (between Characters and Coteries)
- **SPC separation**: SPCs now live under the `spcs` category with `spc-` slug prefix instead of `characters`/`char-`; sync automatically deletes old `char-*` SPC pages on the next run
- **Backgrounds separation**: `#backgrounds` forum threads get `category: backgrounds` instead of `lore`; existing `lore-*` slugs are updated in-place (no duplicates)
- **Line break fix**: Single newlines in Discord content now convert to markdown line breaks (`  \n`) so field-per-line posts like `**Name**: Belladonna Jane` render on separate lines instead of collapsing into one paragraph
- **Images in body**: All images from Discord messages now render as `![]()` in the wiki body; image-only posts are no longer skipped

## Test plan

- [ ] CI passes (bot lint/tests, web tests)
- [ ] Deploy web app — verify Backgrounds, SPCs, Plotlines appear in wiki sidebar nav
- [ ] Re-run sync with `--wiki-only` — verify SPC pages move to `spc-*` slugs under SPCs category, old `char-*` SPC pages deleted
- [ ] Check a background page (e.g. Belladonna Jane) — bold fields on separate lines, cover image + any additional images in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)