### PR TITLE
Remove Recently Updated section from wiki index

### DIFF
--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -201,11 +201,6 @@ def _get_featured_page(slug: str) -> Markup | None:
 
 @bp.route('/')
 def index():
-    recent = (WikiPage.query
-              .filter(WikiPage.status.in_(WIKI_PUBLIC_STATUSES))
-              .order_by(WikiPage.updated_at.desc())
-              .limit(6)
-              .all())
     counts = {s: WikiPage.query.filter_by(category=s).filter(
                   WikiPage.status.in_(WIKI_PUBLIC_STATUSES)).count()
               for s, _, _ in CATEGORIES}
@@ -213,7 +208,6 @@ def index():
     state_of_domain = _get_featured_page('state-of-the-domain')
     return render_template(
         'wiki/index.html',
-        recent=recent,
         counts=counts,
         chronicle_background=chronicle_background,
         state_of_domain=state_of_domain,

--- a/apps/web/app/templates/wiki/index.html
+++ b/apps/web/app/templates/wiki/index.html
@@ -71,37 +71,5 @@
 <hr class="wiki-sep">
 {% endif %}
 
-<!-- Recently Updated -->
-{% if recent %}
-<section class="mb-4">
-    <h2 class="wiki-section-heading mb-4">Recently Updated</h2>
-    <div class="row g-3">
-        {% for p in recent %}
-        <div class="col-md-6 col-lg-4">
-            <a href="{{ url_for('wiki.page', slug=p.slug) }}" class="wiki-page-card text-decoration-none">
-                {% if p.cover_image_url %}
-                <div class="wiki-card-cover" style="background-image: url('{{ p.cover_image_url }}');"></div>
-                {% endif %}
-                <div class="wiki-card-body">
-                    {% if p.category %}
-                    <span class="wiki-cat-badge">{{ wiki_category_display.get(p.category, p.category) }}</span>
-                    {% endif %}
-                    <h5>{{ p.title }}</h5>
-                    <div class="meta">
-                        <i class="bi bi-clock me-1"></i>
-                        {{ p.updated_at.strftime('%b %d, %Y') if p.updated_at else '' }}
-                    </div>
-                </div>
-            </a>
-        </div>
-        {% endfor %}
-    </div>
-</section>
-{% else %}
-<div class="empty-state">
-    <i class="bi bi-journal-richtext"></i>
-    <p>The chronicle has yet to be written. {% if is_staff %}<a href="{{ url_for('wiki.new_page') }}">Create the first page.</a>{% endif %}</p>
-</div>
-{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- Removes the Recently Updated card grid from the wiki homepage
- Removes the `recent` query from the index route (small perf win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)