### PR TITLE
Add /lasombra approve and /lasombra edit for character onboarding

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -104,6 +104,12 @@ COMBAT_SYSTEM_HELPER_ROLE_ID=
 # Optional channel ID for /staff broadcast announcements target
 ANNOUNCEMENTS_CHANNEL_ID=
 
+# Character approval (/lasombra approve)
+# Channel ID for #player-character-sheets where approved sheets are posted
+APPROVE_PLAYER_SHEETS_CHANNEL_ID=
+# Role ID for "Sheet in Progress" — removed from player on approval
+APPROVE_SHEET_IN_PROGRESS_ROLE_ID=
+
 # Optional nightly Google Sheets reconciliation (syncs DB → Sheets once per day)
 # Set SHEETS_RECONCILE_ENABLED=true to activate; requires SHEETS integration on the web side.
 SHEETS_RECONCILE_ENABLED=false

--- a/apps/bot/src/approveWizard.ts
+++ b/apps/bot/src/approveWizard.ts
@@ -1,0 +1,516 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChannelType,
+  GuildChannel,
+  OverwriteType,
+  RoleSelectMenuBuilder,
+  StringSelectMenuBuilder,
+  type ButtonInteraction,
+  type ChatInputCommandInteraction,
+  type RoleSelectMenuInteraction,
+  type StringSelectMenuInteraction,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from './discord';
+import { config } from './config';
+import { errorToMessage, logEvent } from './logger';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const CLANS = [
+  'Brujah', 'Gangrel', 'Hecata', 'Lasombra', 'Malkavian',
+  'Nosferatu', 'Ravnos', 'Salubri', 'Toreador', 'Tremere',
+  'Tzimisce', 'Ventrue', 'Banu Haqim', 'The Ministry',
+  'Thin-Blood', 'Caitiff', 'Mortal', 'Ghoul',
+];
+
+const AGE_OPTIONS = ['Mortal', 'Fledgling', 'Neonate', 'Ancilla'];
+
+const SECT_OPTIONS = ['Camarilla', 'Anarch', 'Hecata', 'Autarkis', 'NA'];
+
+const AGE_TO_CUBBY: Record<string, string> = {
+  mortal: 'mortal character cubbies',
+  fledgling: 'fledgeling character cubbies',
+  neonate: 'neonate character cubbies',
+  ancilla: 'ancilla character cubbies',
+};
+
+const CUBBY_CATEGORY_NAMES = new Set(Object.values(AGE_TO_CUBBY));
+
+function welcomeMessage(playerMention: string): string {
+  return (
+    `This is approved and processed. Welcome to Music City, ${playerMention}! ` +
+    `Don't sleep on <#1170107198748237885> or <#1225527235574759454> — they're there for you. ` +
+    `You can bring questions to <#1170106212453453834> or <#1168654464308228217> and your feedback is welcome in <#1194292553864990770>. ` +
+    `Ping staff with questions!`
+  );
+}
+
+// ── Custom IDs ─────────────────────────────────────────────────────────────
+
+export const APPROVE_AGE_SELECT_ID = 'approve:age:select';
+export const APPROVE_CLAN_SELECT_ID = 'approve:clan:select';
+export const APPROVE_SECT_SELECT_ID = 'approve:sect:select';
+export const APPROVE_ROLES_SELECT_ID = 'approve:roles:select';
+export const APPROVE_CONFIRM_ID = 'approve:confirm';
+export const APPROVE_CANCEL_ID = 'approve:cancel';
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+type ApproveState = {
+  channelId: string;
+  characterName: string;
+  playerId: string | null;
+  pdfUrl: string | null;
+  pdfFilename: string | null;
+  age: string | null;
+  clan: string | null;
+  sect: string | null;
+  roleIds: string[];
+};
+
+// keyed by staffUserId — one wizard per staff member at a time
+const pending = new Map<string, ApproveState>();
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function findPlayerInChannel(
+  channel: TextChannel,
+  staffIds: Set<string>,
+): Promise<string | null> {
+  const memberOverwriteIds = channel.permissionOverwrites.cache
+    .filter((o) => o.type === OverwriteType.Member && !staffIds.has(o.id))
+    .map((o) => o.id);
+
+  for (const id of memberOverwriteIds) {
+    try {
+      const member = await channel.guild.members.fetch(id);
+      if (!member.user.bot) {
+        return id;
+      }
+    } catch {
+      // member may have left; skip
+    }
+  }
+  return null;
+}
+
+async function findLatestPdf(
+  channel: TextChannel,
+): Promise<{ url: string; name: string } | null> {
+  try {
+    const messages = await channel.messages.fetch({ limit: 50 });
+    // Collection is newest-first by default
+    for (const msg of messages.values()) {
+      for (const att of msg.attachments.values()) {
+        if (att.name?.toLowerCase().endsWith('.pdf')) {
+          return { url: att.url, name: att.name };
+        }
+      }
+    }
+  } catch {
+    // ignore fetch errors
+  }
+  return null;
+}
+
+function buildComponents(state: ApproveState) {
+  const ageRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(APPROVE_AGE_SELECT_ID)
+      .setPlaceholder('Select age category')
+      .addOptions(
+        AGE_OPTIONS.map((a) => ({
+          label: a,
+          value: a.toLowerCase(),
+          default: state.age === a.toLowerCase(),
+        })),
+      ),
+  );
+
+  const clanRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(APPROVE_CLAN_SELECT_ID)
+      .setPlaceholder('Select clan')
+      .addOptions(
+        CLANS.map((c) => ({
+          label: c,
+          value: c,
+          default: state.clan === c,
+        })),
+      ),
+  );
+
+  const sectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(APPROVE_SECT_SELECT_ID)
+      .setPlaceholder('Select sect')
+      .addOptions(
+        SECT_OPTIONS.map((s) => ({
+          label: s,
+          value: s,
+          default: state.sect === s,
+        })),
+      ),
+  );
+
+  const rolesRow = new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(
+    new RoleSelectMenuBuilder()
+      .setCustomId(APPROVE_ROLES_SELECT_ID)
+      .setPlaceholder('Select roles to assign to player (Kindred, Camarilla, etc.)')
+      .setMinValues(0)
+      .setMaxValues(10),
+  );
+
+  const canConfirm = Boolean(state.age && state.clan && state.sect);
+  const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(APPROVE_CONFIRM_ID)
+      .setLabel('Confirm & Onboard')
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(!canConfirm),
+    new ButtonBuilder()
+      .setCustomId(APPROVE_CANCEL_ID)
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return [ageRow, clanRow, sectRow, rolesRow, buttonRow];
+}
+
+function buildStatusContent(state: ApproveState): string {
+  const roleList =
+    state.roleIds.length > 0
+      ? state.roleIds.map((id) => `<@&${id}>`).join(' ')
+      : '*(none selected)*';
+
+  return [
+    `**Approve character: ${state.characterName}**`,
+    `Player: ${state.playerId ? `<@${state.playerId}>` : '⚠️ could not detect — confirm manually'}`,
+    `Sheet: ${state.pdfUrl ? `✅ found (\`${state.pdfFilename}\`)` : '⚠️ no PDF found in channel'}`,
+    `Age: **${state.age ?? '—'}**  |  Clan: **${state.clan ?? '—'}**  |  Sect: **${state.sect ?? '—'}**`,
+    `Roles to add: ${roleList}`,
+    '',
+    canConfirmStatus(state),
+  ].join('\n');
+}
+
+function canConfirmStatus(state: ApproveState): string {
+  if (state.age && state.clan && state.sect) {
+    return '*All required fields set — hit **Confirm & Onboard** to execute.*';
+  }
+  return '*Select Age, Clan, and Sect to enable confirm.*';
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────
+
+export async function startApproveWizard(
+  interaction: ChatInputCommandInteraction,
+  _ctx: CommandContext,
+): Promise<void> {
+  if (!config.testerDiscordIds.has(interaction.user.id)) {
+    await interaction.reply({ content: 'This command is restricted to staff.', ephemeral: true });
+    return;
+  }
+
+  const channel = interaction.channel;
+  if (!channel || channel.type !== ChannelType.GuildText) {
+    await interaction.reply({
+      content: 'Run this inside a ticket channel.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // Guard: don't run if already inside a cubby category
+  const parentName = channel.parent?.name.toLowerCase().trim() ?? '';
+  if (CUBBY_CATEGORY_NAMES.has(parentName)) {
+    await interaction.reply({
+      content: `⚠️ This channel is already in **${channel.parent?.name}**. Run \`/lasombra approve\` from a Character Tickets channel.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const playerId = await findPlayerInChannel(channel, config.testerDiscordIds);
+  const pdf = await findLatestPdf(channel);
+
+  const state: ApproveState = {
+    channelId: channel.id,
+    characterName: channel.name,
+    playerId,
+    pdfUrl: pdf?.url ?? null,
+    pdfFilename: pdf?.name ?? null,
+    age: null,
+    clan: null,
+    sect: null,
+    roleIds: [],
+  };
+
+  pending.set(interaction.user.id, state);
+
+  await interaction.editReply({
+    content: buildStatusContent(state),
+    components: buildComponents(state),
+  });
+}
+
+// ── String select handler (age / clan / sect) ──────────────────────────────
+
+export function isApproveWizardStringSelect(customId: string): boolean {
+  return (
+    customId === APPROVE_AGE_SELECT_ID ||
+    customId === APPROVE_CLAN_SELECT_ID ||
+    customId === APPROVE_SECT_SELECT_ID
+  );
+}
+
+export async function handleApproveWizardStringSelect(
+  interaction: StringSelectMenuInteraction,
+): Promise<boolean> {
+  if (!isApproveWizardStringSelect(interaction.customId)) return false;
+
+  const state = pending.get(interaction.user.id);
+  if (!state) {
+    await interaction.update({ content: 'Session expired — run `/lasombra approve` again.', components: [] });
+    return true;
+  }
+
+  const value = interaction.values[0] ?? null;
+  if (interaction.customId === APPROVE_AGE_SELECT_ID) state.age = value;
+  else if (interaction.customId === APPROVE_CLAN_SELECT_ID) state.clan = value;
+  else if (interaction.customId === APPROVE_SECT_SELECT_ID) state.sect = value;
+
+  await interaction.update({
+    content: buildStatusContent(state),
+    components: buildComponents(state),
+  });
+  return true;
+}
+
+// ── Role select handler ────────────────────────────────────────────────────
+
+export function isApproveWizardRoleSelect(customId: string): boolean {
+  return customId === APPROVE_ROLES_SELECT_ID;
+}
+
+export async function handleApproveWizardRoleSelect(
+  interaction: RoleSelectMenuInteraction,
+): Promise<boolean> {
+  if (!isApproveWizardRoleSelect(interaction.customId)) return false;
+
+  const state = pending.get(interaction.user.id);
+  if (!state) {
+    await interaction.update({ content: 'Session expired — run `/lasombra approve` again.', components: [] });
+    return true;
+  }
+
+  state.roleIds = interaction.values;
+
+  await interaction.update({
+    content: buildStatusContent(state),
+    components: buildComponents(state),
+  });
+  return true;
+}
+
+// ── Button handler (confirm / cancel) ─────────────────────────────────────
+
+export function isApproveWizardButton(customId: string): boolean {
+  return customId === APPROVE_CONFIRM_ID || customId === APPROVE_CANCEL_ID;
+}
+
+export async function handleApproveWizardButton(
+  interaction: ButtonInteraction,
+  ctx: CommandContext,
+): Promise<boolean> {
+  if (!isApproveWizardButton(interaction.customId)) return false;
+
+  if (interaction.customId === APPROVE_CANCEL_ID) {
+    pending.delete(interaction.user.id);
+    await interaction.update({ content: 'Approval cancelled.', components: [] });
+    return true;
+  }
+
+  // Confirm
+  const state = pending.get(interaction.user.id);
+  pending.delete(interaction.user.id);
+
+  if (!state) {
+    await interaction.update({ content: 'Session expired — run `/lasombra approve` again.', components: [] });
+    return true;
+  }
+
+  if (!state.age || !state.clan || !state.sect) {
+    await interaction.update({
+      content: '⚠️ Age, Clan, and Sect are all required.',
+      components: buildComponents(state),
+    });
+    return true;
+  }
+
+  await interaction.deferUpdate();
+
+  const guild = interaction.guild;
+  if (!guild) {
+    await interaction.editReply({ content: '⚠️ Could not resolve server.', components: [] });
+    return true;
+  }
+
+  const results: string[] = [`**Onboarding: ${state.characterName}**`, ''];
+
+  // ── 1. Move channel to cubbie ──────────────────────────────────────────
+  const targetCubbyName = AGE_TO_CUBBY[state.age];
+  let channelMoved = false;
+  try {
+    const allChannels = await guild.channels.fetch();
+    const targetCategory = allChannels.find(
+      (ch) =>
+        ch?.type === ChannelType.GuildCategory &&
+        ch.name.toLowerCase().trim() === targetCubbyName,
+    );
+    if (!targetCategory) {
+      results.push(`⚠️ Category **${targetCubbyName}** not found — channel not moved.`);
+    } else {
+      const ticketChannel = await guild.channels.fetch(state.channelId);
+      if (ticketChannel instanceof GuildChannel) {
+        await ticketChannel.setParent(targetCategory.id, {
+          lockPermissions: false,
+          reason: `Character approved: ${state.characterName}`,
+        });
+        results.push(`✅ Channel moved to **${targetCubbyName}**.`);
+        channelMoved = true;
+      }
+    }
+  } catch (err) {
+    results.push(`⚠️ Channel move failed: ${errorToMessage(err)}`);
+  }
+
+  // ── 2. Assign roles ────────────────────────────────────────────────────
+  let playerMember: import('discord.js').GuildMember | null = null;
+  if (state.playerId) {
+    try {
+      playerMember = await guild.members.fetch(state.playerId);
+    } catch {
+      results.push(`⚠️ Could not fetch player <@${state.playerId}> — roles not assigned.`);
+    }
+  } else {
+    results.push('⚠️ No player detected — roles not assigned.');
+  }
+
+  if (playerMember) {
+    if (state.roleIds.length > 0) {
+      try {
+        for (const roleId of state.roleIds) {
+          await playerMember.roles.add(roleId, `Character approved: ${state.characterName}`);
+        }
+        results.push(`✅ Added ${state.roleIds.length} role(s) to <@${state.playerId}>.`);
+      } catch (err) {
+        results.push(`⚠️ Role assignment failed: ${errorToMessage(err)}`);
+      }
+    } else {
+      results.push('ℹ️ No roles selected — none added.');
+    }
+
+    // ── 3. Remove Sheet in Progress role ────────────────────────────────
+    const sipRoleId = config.approveSheetInProgressRoleId;
+    if (sipRoleId) {
+      try {
+        if (playerMember.roles.cache.has(sipRoleId)) {
+          await playerMember.roles.remove(sipRoleId, `Character approved: ${state.characterName}`);
+          results.push('✅ Removed Sheet in Progress role.');
+        } else {
+          results.push('ℹ️ Sheet in Progress role not present on player — skipped.');
+        }
+      } catch (err) {
+        results.push(`⚠️ Could not remove Sheet in Progress role: ${errorToMessage(err)}`);
+      }
+    } else {
+      results.push('ℹ️ `APPROVE_SHEET_IN_PROGRESS_ROLE_ID` not set — skipped.');
+    }
+  }
+
+  // ── 4. Create roster entry ─────────────────────────────────────────────
+  let rosterCreated = false;
+  const ageForRoster = state.age.charAt(0).toUpperCase() + state.age.slice(1);
+  try {
+    const result = await ctx.adapter.createCharacter({
+      characterName: state.characterName,
+      playerDiscord: state.playerId ?? '',
+      playerDiscordName: playerMember?.user.username ?? '',
+      clan: state.clan,
+      ageCategory: ageForRoster,
+      sect: state.sect,
+      requesterDiscordId: interaction.user.id,
+      requesterDiscordName: interaction.user.username,
+    });
+    if (result.ok) {
+      results.push(`✅ Roster entry created for **${state.characterName}**.`);
+      rosterCreated = true;
+    } else {
+      results.push(`⚠️ Roster creation failed: ${result.message}`);
+    }
+  } catch (err) {
+    results.push(`⚠️ Roster creation error: ${errorToMessage(err)}`);
+  }
+
+  // ── 5. Post to #player-character-sheets ───────────────────────────────
+  const sheetsChannelId = config.approvePlayerSheetsChannelId;
+  if (sheetsChannelId && state.playerId) {
+    try {
+      const sheetsChannel = await guild.channels.fetch(sheetsChannelId);
+      if (sheetsChannel && sheetsChannel.isTextBased() && 'send' in sheetsChannel) {
+        const content = `${state.characterName} <@${state.playerId}> initial sub`;
+        if (state.pdfUrl) {
+          await (sheetsChannel as TextChannel).send({
+            content,
+            files: [{ attachment: state.pdfUrl, name: state.pdfFilename ?? 'character-sheet.pdf' }],
+          });
+        } else {
+          await (sheetsChannel as TextChannel).send({ content: `${content} *(no PDF found in ticket)*` });
+        }
+        results.push(`✅ Posted to <#${sheetsChannelId}>.`);
+      } else {
+        results.push('⚠️ #player-character-sheets channel not found or not sendable.');
+      }
+    } catch (err) {
+      results.push(`⚠️ #player-character-sheets post failed: ${errorToMessage(err)}`);
+    }
+  } else if (!sheetsChannelId) {
+    results.push('ℹ️ `APPROVE_PLAYER_SHEETS_CHANNEL_ID` not configured — skipped.');
+  }
+
+  // ── 6. Post welcome message in cubby ──────────────────────────────────
+  if (state.playerId) {
+    try {
+      const cubbyChannel = await guild.channels.fetch(state.channelId);
+      if (cubbyChannel && cubbyChannel.isTextBased() && 'send' in cubbyChannel) {
+        await (cubbyChannel as TextChannel).send({
+          content: welcomeMessage(`<@${state.playerId}>`),
+        });
+        results.push('✅ Welcome message posted.');
+      }
+    } catch (err) {
+      results.push(`⚠️ Welcome message failed: ${errorToMessage(err)}`);
+    }
+  }
+
+  logEvent('info', 'character_approved', {
+    characterName: state.characterName,
+    playerId: state.playerId,
+    age: state.age,
+    clan: state.clan,
+    sect: state.sect,
+    roleIds: state.roleIds,
+    staffId: interaction.user.id,
+    rosterCreated,
+    channelMoved,
+  });
+
+  await interaction.editReply({ content: results.join('\n'), components: [] });
+  return true;
+}

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -12,12 +12,24 @@ import { config } from '../config';
 import { liveConfig } from '../liveConfig';
 import { buildCubbyChannelMap, getChannelsInCubbyCategories, normalizeChannelName } from '../services/cubbyChannels';
 import { errorToMessage, logEvent } from '../logger';
+import { startApproveWizard } from '../approveWizard';
+import { startEditWizard } from '../editWizard';
 
 export const name = 'lasombra';
 
 export const data = new SlashCommandBuilder()
   .setName('lasombra')
   .setDescription('Lasombra utility commands')
+  .addSubcommand((s) =>
+    s
+      .setName('approve')
+      .setDescription('Approve a character ticket: move to cubby, assign roles, create roster entry, post sheet'),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('edit')
+      .setDescription('Edit a character\'s clan, sect, or age (and move cubby if age changes). Run in their channel.'),
+  )
   .addSubcommand((s) =>
     s
       .setName('broadcast')
@@ -89,6 +101,16 @@ const pendingBroadcasts = new Map<string, PendingBroadcast>();
 
 export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
   const sub = interaction.options.getSubcommand();
+
+  if (sub === 'approve') {
+    await startApproveWizard(interaction, ctx);
+    return;
+  }
+
+  if (sub === 'edit') {
+    await startEditWizard(interaction, ctx);
+    return;
+  }
 
   if (sub === 'broadcast') {
     if (!config.testerDiscordIds.has(interaction.user.id)) {

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -149,6 +149,8 @@ const envSchema = z.object({
   NOTION_TOKEN: z.string().optional(),
   NOTION_SYNC_MSG_LIMIT: z.string().optional(),
   DISCORD_GUILD_ID: z.string().optional(),
+  APPROVE_PLAYER_SHEETS_CHANNEL_ID: z.string().optional(),
+  APPROVE_SHEET_IN_PROGRESS_ROLE_ID: z.string().optional(),
 });
 
 const env = envSchema.parse(process.env);
@@ -345,6 +347,8 @@ export const config = {
   notionToken: env.NOTION_TOKEN ?? '',
   notionSyncMsgLimit: parsePositiveInt(env.NOTION_SYNC_MSG_LIMIT, 200, 'NOTION_SYNC_MSG_LIMIT'),
   discordGuildId: env.DISCORD_GUILD_ID ?? env.TEST_GUILD_ID ?? '',
+  approvePlayerSheetsChannelId: env.APPROVE_PLAYER_SHEETS_CHANNEL_ID ?? '',
+  approveSheetInProgressRoleId: env.APPROVE_SHEET_IN_PROGRESS_ROLE_ID ?? '',
 };
 
 if (config.testRequesterDiscordId) {

--- a/apps/bot/src/editWizard.ts
+++ b/apps/bot/src/editWizard.ts
@@ -151,10 +151,31 @@ export async function startEditWizard(
 
   await interaction.deferReply({ ephemeral: true });
 
-  const charDetails = await ctx.adapter.getCharacterDetails(channel.name).catch(() => null);
+  // Channel names are normalized slugs (e.g. "astrid-von-holt") but roster
+  // names are human-readable (e.g. "Astrid von Holt"). Match by normalizing
+  // each roster entry rather than sending the slug directly to the API.
+  let resolvedName: string | null = null;
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const match = roster.characters.find(
+      (c) => normalizeChannelName(c.name) === channel.name,
+    );
+    resolvedName = match?.name ?? null;
+  } catch {
+    // fall through to the not-found message below
+  }
+
+  if (!resolvedName) {
+    await interaction.editReply(
+      `No roster entry found matching channel **${channel.name}**. Make sure the channel name matches the character name.`,
+    );
+    return;
+  }
+
+  const charDetails = await ctx.adapter.getCharacterDetails(resolvedName).catch(() => null);
   if (!charDetails) {
     await interaction.editReply(
-      `No roster entry found for **${channel.name}**. Check the channel name matches the character name exactly.`,
+      `Could not load details for **${resolvedName}** — try again shortly.`,
     );
     return;
   }
@@ -309,9 +330,11 @@ export async function handleEditWizardButton(
     results.push(`✅ Roster updated (${fieldList}).`);
   } else {
     results.push(`⚠️ Roster update failed: ${updateResult.message}`);
+    await interaction.editReply({ content: results.join('\n'), components: [] });
+    return true;
   }
 
-  // ── Move cubby if age changed ──────────────────────────────────────────
+  // ── Move cubby if age changed (only runs if roster update succeeded) ───
   if (changed.ageCategory) {
     const targetCubbyName = AGE_TO_CUBBY[changed.ageCategory.toLowerCase()];
     if (targetCubbyName) {

--- a/apps/bot/src/editWizard.ts
+++ b/apps/bot/src/editWizard.ts
@@ -1,0 +1,426 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChannelType,
+  GuildChannel,
+  ModalBuilder,
+  StringSelectMenuBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type ButtonInteraction,
+  type ChatInputCommandInteraction,
+  type ModalSubmitInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+import type { CommandContext } from './discord';
+import { config } from './config';
+import { normalizeChannelName } from './services/cubbyChannels';
+import { errorToMessage, logEvent } from './logger';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const CLANS = [
+  'Brujah', 'Gangrel', 'Hecata', 'Lasombra', 'Malkavian',
+  'Nosferatu', 'Ravnos', 'Salubri', 'Toreador', 'Tremere',
+  'Tzimisce', 'Ventrue', 'Banu Haqim', 'The Ministry',
+  'Thin-Blood', 'Caitiff', 'Mortal', 'Ghoul',
+];
+
+const AGE_OPTIONS = ['Mortal', 'Fledgling', 'Neonate', 'Ancilla'];
+const SECT_OPTIONS = ['Camarilla', 'Anarch', 'Hecata', 'Autarkis', 'NA'];
+
+const AGE_TO_CUBBY: Record<string, string> = {
+  mortal: 'mortal character cubbies',
+  fledgling: 'fledgeling character cubbies',
+  neonate: 'neonate character cubbies',
+  ancilla: 'ancilla character cubbies',
+};
+
+// ── Custom IDs ─────────────────────────────────────────────────────────────
+
+export const EDIT_AGE_SELECT_ID = 'edit:age:select';
+export const EDIT_CLAN_SELECT_ID = 'edit:clan:select';
+export const EDIT_SECT_SELECT_ID = 'edit:sect:select';
+export const EDIT_SAVE_ID = 'edit:save';
+export const EDIT_RENAME_ID = 'edit:rename';
+export const EDIT_CANCEL_ID = 'edit:cancel';
+export const EDIT_RENAME_MODAL_ID = 'edit:rename:modal';
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+type EditState = {
+  channelId: string;
+  characterName: string;
+  originalAge: string;
+  age: string;
+  clan: string;
+  sect: string;
+};
+
+// keyed by staffUserId
+const pending = new Map<string, EditState>();
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function buildComponents(state: EditState) {
+  const ageRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(EDIT_AGE_SELECT_ID)
+      .setPlaceholder('Age category')
+      .addOptions(
+        AGE_OPTIONS.map((a) => ({
+          label: a,
+          value: a.toLowerCase(),
+          default: state.age === a.toLowerCase(),
+        })),
+      ),
+  );
+
+  const clanRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(EDIT_CLAN_SELECT_ID)
+      .setPlaceholder('Clan')
+      .addOptions(
+        CLANS.map((c) => ({
+          label: c,
+          value: c,
+          default: state.clan === c,
+        })),
+      ),
+  );
+
+  const sectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(EDIT_SECT_SELECT_ID)
+      .setPlaceholder('Sect')
+      .addOptions(
+        SECT_OPTIONS.map((s) => ({
+          label: s,
+          value: s,
+          default: state.sect === s,
+        })),
+      ),
+  );
+
+  const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(EDIT_SAVE_ID)
+      .setLabel('Save Changes')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(EDIT_RENAME_ID)
+      .setLabel('Rename Character')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(EDIT_CANCEL_ID)
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return [ageRow, clanRow, sectRow, buttonRow];
+}
+
+function buildStatusContent(state: EditState): string {
+  const ageDirty = state.age !== state.originalAge;
+  return [
+    `**Edit character: ${state.characterName}**`,
+    `Age: **${state.age || '—'}**${ageDirty ? ` *(was ${state.originalAge || '—'}, cubby will move)*` : ''}`,
+    `Clan: **${state.clan || '—'}**  |  Sect: **${state.sect || '—'}**`,
+    '',
+    '*Adjust fields above, then hit **Save Changes**. Use **Rename Character** to fix the name.*',
+  ].join('\n');
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────
+
+export async function startEditWizard(
+  interaction: ChatInputCommandInteraction,
+  ctx: CommandContext,
+): Promise<void> {
+  if (!config.testerDiscordIds.has(interaction.user.id)) {
+    await interaction.reply({ content: 'This command is restricted to staff.', ephemeral: true });
+    return;
+  }
+
+  const channel = interaction.channel;
+  if (!channel || channel.type !== ChannelType.GuildText) {
+    await interaction.reply({ content: 'Run this inside a character cubby channel.', ephemeral: true });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const charDetails = await ctx.adapter.getCharacterDetails(channel.name).catch(() => null);
+  if (!charDetails) {
+    await interaction.editReply(
+      `No roster entry found for **${channel.name}**. Check the channel name matches the character name exactly.`,
+    );
+    return;
+  }
+
+  const age = charDetails.age_category.toLowerCase();
+  const state: EditState = {
+    channelId: channel.id,
+    characterName: charDetails.character_name,
+    originalAge: age,
+    age,
+    clan: charDetails.clan,
+    sect: charDetails.sect,
+  };
+
+  pending.set(interaction.user.id, state);
+
+  await interaction.editReply({
+    content: buildStatusContent(state),
+    components: buildComponents(state),
+  });
+}
+
+// ── String select handler ──────────────────────────────────────────────────
+
+export function isEditWizardStringSelect(customId: string): boolean {
+  return (
+    customId === EDIT_AGE_SELECT_ID ||
+    customId === EDIT_CLAN_SELECT_ID ||
+    customId === EDIT_SECT_SELECT_ID
+  );
+}
+
+export async function handleEditWizardStringSelect(
+  interaction: StringSelectMenuInteraction,
+): Promise<boolean> {
+  if (!isEditWizardStringSelect(interaction.customId)) return false;
+
+  const state = pending.get(interaction.user.id);
+  if (!state) {
+    await interaction.update({ content: 'Session expired — run `/lasombra edit` again.', components: [] });
+    return true;
+  }
+
+  const value = interaction.values[0] ?? '';
+  if (interaction.customId === EDIT_AGE_SELECT_ID) state.age = value;
+  else if (interaction.customId === EDIT_CLAN_SELECT_ID) state.clan = value;
+  else if (interaction.customId === EDIT_SECT_SELECT_ID) state.sect = value;
+
+  await interaction.update({
+    content: buildStatusContent(state),
+    components: buildComponents(state),
+  });
+  return true;
+}
+
+// ── Button handler ─────────────────────────────────────────────────────────
+
+export function isEditWizardButton(customId: string): boolean {
+  return (
+    customId === EDIT_SAVE_ID ||
+    customId === EDIT_RENAME_ID ||
+    customId === EDIT_CANCEL_ID
+  );
+}
+
+export async function handleEditWizardButton(
+  interaction: ButtonInteraction,
+  ctx: CommandContext,
+): Promise<boolean> {
+  if (!isEditWizardButton(interaction.customId)) return false;
+
+  if (interaction.customId === EDIT_CANCEL_ID) {
+    pending.delete(interaction.user.id);
+    await interaction.update({ content: 'Edit cancelled.', components: [] });
+    return true;
+  }
+
+  if (interaction.customId === EDIT_RENAME_ID) {
+    const state = pending.get(interaction.user.id);
+    if (!state) {
+      await interaction.update({ content: 'Session expired — run `/lasombra edit` again.', components: [] });
+      return true;
+    }
+    const modal = new ModalBuilder()
+      .setCustomId(EDIT_RENAME_MODAL_ID)
+      .setTitle('Rename Character');
+    modal.addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('new_name')
+          .setLabel('New character name')
+          .setStyle(TextInputStyle.Short)
+          .setValue(state.characterName)
+          .setRequired(true)
+          .setMaxLength(100),
+      ),
+    );
+    await interaction.showModal(modal);
+    return true;
+  }
+
+  // Save Changes
+  const state = pending.get(interaction.user.id);
+  pending.delete(interaction.user.id);
+
+  if (!state) {
+    await interaction.update({ content: 'Session expired — run `/lasombra edit` again.', components: [] });
+    return true;
+  }
+
+  await interaction.deferUpdate();
+
+  const guild = interaction.guild;
+  if (!guild) {
+    await interaction.editReply({ content: '⚠️ Could not resolve server.', components: [] });
+    return true;
+  }
+
+  const updates: { clan?: string; ageCategory?: string; sect?: string } = {};
+  if (state.clan) updates.clan = state.clan;
+  if (state.sect) updates.sect = state.sect;
+  if (state.age) updates.ageCategory = state.age.charAt(0).toUpperCase() + state.age.slice(1);
+
+  // Detect what actually changed by re-fetching current character
+  const current = await ctx.adapter.getCharacterDetails(state.characterName).catch(() => null);
+  if (!current) {
+    await interaction.editReply({ content: `⚠️ Could not fetch current data for **${state.characterName}**.`, components: [] });
+    return true;
+  }
+
+  const changed: typeof updates = {};
+  if (updates.clan && updates.clan !== current.clan) changed.clan = updates.clan;
+  if (updates.sect && updates.sect !== current.sect) changed.sect = updates.sect;
+  if (updates.ageCategory && updates.ageCategory.toLowerCase() !== current.age_category.toLowerCase()) {
+    changed.ageCategory = updates.ageCategory;
+  }
+
+  if (Object.keys(changed).length === 0) {
+    await interaction.editReply({ content: 'No changes detected — nothing saved.', components: [] });
+    return true;
+  }
+
+  const results: string[] = [`**Edit: ${state.characterName}**`, ''];
+
+  // ── Update roster fields ───────────────────────────────────────────────
+  const updateResult = await ctx.adapter.updateCharacter(state.characterName, changed, {
+    requesterDiscordId: interaction.user.id,
+    requesterDiscordName: interaction.user.username,
+  });
+  if (updateResult.ok) {
+    const fieldList = Object.keys(changed).map((k) => k.replace('ageCategory', 'age')).join(', ');
+    results.push(`✅ Roster updated (${fieldList}).`);
+  } else {
+    results.push(`⚠️ Roster update failed: ${updateResult.message}`);
+  }
+
+  // ── Move cubby if age changed ──────────────────────────────────────────
+  if (changed.ageCategory) {
+    const targetCubbyName = AGE_TO_CUBBY[changed.ageCategory.toLowerCase()];
+    if (targetCubbyName) {
+      try {
+        const allChannels = await guild.channels.fetch();
+        const targetCategory = allChannels.find(
+          (ch) =>
+            ch?.type === ChannelType.GuildCategory &&
+            ch.name.toLowerCase().trim() === targetCubbyName,
+        );
+        if (!targetCategory) {
+          results.push(`⚠️ Category **${targetCubbyName}** not found — channel not moved.`);
+        } else {
+          const ch = await guild.channels.fetch(state.channelId);
+          if (ch instanceof GuildChannel) {
+            await ch.setParent(targetCategory.id, {
+              lockPermissions: false,
+              reason: `Age updated to ${changed.ageCategory}: ${state.characterName}`,
+            });
+            results.push(`✅ Channel moved to **${targetCubbyName}**.`);
+          }
+        }
+      } catch (err) {
+        results.push(`⚠️ Channel move failed: ${errorToMessage(err)}`);
+      }
+    }
+  }
+
+  logEvent('info', 'character_edited', {
+    characterName: state.characterName,
+    changed,
+    staffId: interaction.user.id,
+  });
+
+  await interaction.editReply({ content: results.join('\n'), components: [] });
+  return true;
+}
+
+// ── Rename modal handler ───────────────────────────────────────────────────
+
+export function isEditRenameModal(customId: string): boolean {
+  return customId === EDIT_RENAME_MODAL_ID;
+}
+
+export async function handleEditRenameModal(
+  interaction: ModalSubmitInteraction,
+  ctx: CommandContext,
+): Promise<boolean> {
+  if (!isEditRenameModal(interaction.customId)) return false;
+
+  const state = pending.get(interaction.user.id);
+  pending.delete(interaction.user.id);
+
+  if (!state) {
+    await interaction.reply({ content: 'Session expired — run `/lasombra edit` again.', ephemeral: true });
+    return true;
+  }
+
+  const newName = interaction.fields.getTextInputValue('new_name').trim();
+  if (!newName) {
+    await interaction.reply({ content: '⚠️ New name cannot be empty.', ephemeral: true });
+    return true;
+  }
+
+  if (newName.toLowerCase() === state.characterName.toLowerCase()) {
+    await interaction.reply({ content: 'Name unchanged — nothing saved.', ephemeral: true });
+    return true;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const guild = interaction.guild;
+  if (!guild) {
+    await interaction.editReply('⚠️ Could not resolve server.');
+    return true;
+  }
+
+  const results: string[] = [`**Rename: ${state.characterName} → ${newName}**`, ''];
+
+  // ── Rename in roster ───────────────────────────────────────────────────
+  const renameResult = await ctx.adapter.renameCharacter(state.characterName, newName, {
+    requesterDiscordId: interaction.user.id,
+    requesterDiscordName: interaction.user.username,
+  });
+  if (renameResult.ok) {
+    results.push(`✅ Roster entry renamed to **${newName}**.`);
+  } else {
+    results.push(`⚠️ Roster rename failed: ${renameResult.message}`);
+    await interaction.editReply(results.join('\n'));
+    return true;
+  }
+
+  // ── Rename Discord channel ─────────────────────────────────────────────
+  try {
+    const ch = await guild.channels.fetch(state.channelId);
+    if (ch instanceof GuildChannel) {
+      await ch.setName(normalizeChannelName(newName), `Renamed from ${state.characterName}: ${interaction.user.username}`);
+      results.push(`✅ Channel renamed to **${normalizeChannelName(newName)}**.`);
+    }
+  } catch (err) {
+    results.push(`⚠️ Channel rename failed: ${errorToMessage(err)}`);
+  }
+
+  logEvent('info', 'character_renamed', {
+    oldName: state.characterName,
+    newName,
+    staffId: interaction.user.id,
+  });
+
+  await interaction.editReply(results.join('\n'));
+  return true;
+}

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -29,6 +29,18 @@ import {
 } from './interactiveClaimWizard';
 import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButton, isCombatButton } from './combatSetupWizard';
 import { handleBroadcastModal } from './commands/lasombra';
+import {
+  handleApproveWizardStringSelect,
+  handleApproveWizardRoleSelect,
+  handleApproveWizardButton,
+  isApproveWizardButton,
+} from './approveWizard';
+import {
+  handleEditWizardStringSelect,
+  handleEditWizardButton,
+  isEditWizardButton,
+  handleEditRenameModal,
+} from './editWizard';
 import { startCubbyChannelMonitor } from './services/cubbyChannelMonitor';
 import { SubmissionNotifier } from './services/submissionNotifier';
 import {
@@ -253,14 +265,42 @@ void applyStartupConfigOverrides().then(() => {
         logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
         return;
       }
-      const handled = await handleClaimWizardSelect(interaction);
-      if (handled) {
+      const claimHandled = await handleClaimWizardSelect(interaction);
+      if (claimHandled) {
+        logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const approveHandled = await handleApproveWizardStringSelect(interaction);
+      if (approveHandled) {
+        logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const editHandled = await handleEditWizardStringSelect(interaction);
+      if (editHandled) {
+        logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+    }
+
+    if (interaction.isRoleSelectMenu()) {
+      const approveHandled = await handleApproveWizardRoleSelect(interaction);
+      if (approveHandled) {
         logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
         return;
       }
     }
 
     if (interaction.isButton()) {
+      if (isApproveWizardButton(interaction.customId)) {
+        await handleApproveWizardButton(interaction, { client, adapter });
+        logEvent('info', 'interaction_handled_approve_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      if (isEditWizardButton(interaction.customId)) {
+        await handleEditWizardButton(interaction, { client, adapter });
+        logEvent('info', 'interaction_handled_edit_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
       if (isHuntConsequenceButton(interaction.customId)) {
         await handleHuntConsequenceButton(interaction, huntConsequenceCfg);
         logEvent('info', 'interaction_handled_hunt_consequence', { ...baseMeta, customId: interaction.customId });
@@ -286,6 +326,11 @@ void applyStartupConfigOverrides().then(() => {
     if (interaction.isModalSubmit()) {
       const broadcastHandled = await handleBroadcastModal(interaction, { client, adapter });
       if (broadcastHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const editRenameHandled = await handleEditRenameModal(interaction, { client, adapter });
+      if (editRenameHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;
       }

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -80,7 +80,38 @@ export interface TrackerAdapter {
   getAllReminderPrefs(): Promise<Record<string, { optOut: boolean; snoozeUntilEpoch: number }>>;
   setReminderPref(discordId: string, prefs: { optOut: boolean; snoozeUntilEpoch: number }): Promise<void>;
   triggerSheetsReconcile(): Promise<SheetsReconcileSummary>;
+  createCharacter(payload: {
+    characterName: string;
+    playerDiscord: string;
+    playerDiscordName: string;
+    clan: string;
+    ageCategory: string;
+    sect: string;
+    requesterDiscordId: string;
+    requesterDiscordName: string;
+  }): Promise<{ ok: boolean; message: string; characterName?: string }>;
+  getCharacterDetails(name: string): Promise<CharacterDetails | null>;
+  updateCharacter(
+    name: string,
+    updates: { clan?: string; ageCategory?: string; sect?: string },
+    requester: { requesterDiscordId: string; requesterDiscordName: string },
+  ): Promise<{ ok: boolean; message: string }>;
+  renameCharacter(
+    name: string,
+    newName: string,
+    requester: { requesterDiscordId: string; requesterDiscordName: string },
+  ): Promise<{ ok: boolean; message: string; newName?: string }>;
 }
+
+export type CharacterDetails = {
+  character_name: string;
+  player_discord: string;
+  player_discord_name: string;
+  clan: string;
+  age_category: string;
+  sect: string;
+  active: boolean;
+};
 
 export interface SheetsReconcileSummary {
   started_at: string;
@@ -772,6 +803,111 @@ export class WebAppAdapter implements TrackerAdapter {
     });
     if (!res.ok) throw new Error(`sheets/reconcile POST failed: ${res.status}`);
     return res.json() as Promise<SheetsReconcileSummary>;
+  }
+
+  async createCharacter(payload: {
+    characterName: string;
+    playerDiscord: string;
+    playerDiscordName: string;
+    clan: string;
+    ageCategory: string;
+    sect: string;
+    requesterDiscordId: string;
+    requesterDiscordName: string;
+  }): Promise<{ ok: boolean; message: string; characterName?: string }> {
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/roster/character`, {
+      method: 'POST',
+      headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        character_name: payload.characterName,
+        player_discord: payload.playerDiscord,
+        player_discord_name: payload.playerDiscordName,
+        clan: payload.clan,
+        age_category: payload.ageCategory,
+        sect: payload.sect,
+        requesterDiscordId: payload.requesterDiscordId,
+        requesterDiscordName: payload.requesterDiscordName,
+      }),
+    }).catch(() => null);
+
+    if (!resp) {
+      return { ok: false, message: 'Unable to reach web app API.' };
+    }
+    if (resp.status === 409) {
+      return { ok: false, message: `Character "${payload.characterName}" already exists on the roster.` };
+    }
+    if (!resp.ok) {
+      const bodyPreview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      return { ok: false, message: bodyPreview || `API rejected request (status ${resp.status}).` };
+    }
+    const raw = (await resp.json()) as { character_name?: string };
+    return { ok: true, message: 'Character created.', characterName: raw.character_name };
+  }
+
+  async getCharacterDetails(name: string): Promise<CharacterDetails | null> {
+    const resp = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/roster/character/${encodeURIComponent(name)}`,
+      { headers: this.readAuthHeaders() },
+    ).catch(() => null);
+    if (!resp || resp.status === 404) return null;
+    if (!resp.ok) throw new Error(`get character details failed (${resp.status})`);
+    return resp.json() as Promise<CharacterDetails>;
+  }
+
+  async updateCharacter(
+    name: string,
+    updates: { clan?: string; ageCategory?: string; sect?: string },
+    requester: { requesterDiscordId: string; requesterDiscordName: string },
+  ): Promise<{ ok: boolean; message: string }> {
+    const body: Record<string, string> = {
+      requesterDiscordId: requester.requesterDiscordId,
+      requesterDiscordName: requester.requesterDiscordName,
+    };
+    if (updates.clan !== undefined) body.clan = updates.clan;
+    if (updates.ageCategory !== undefined) body.age_category = updates.ageCategory;
+    if (updates.sect !== undefined) body.sect = updates.sect;
+
+    const resp = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/roster/character/${encodeURIComponent(name)}`,
+      {
+        method: 'PATCH',
+        headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    ).catch(() => null);
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (!resp.ok) {
+      const preview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      return { ok: false, message: preview || `API rejected request (status ${resp.status}).` };
+    }
+    return { ok: true, message: 'Character updated.' };
+  }
+
+  async renameCharacter(
+    name: string,
+    newName: string,
+    requester: { requesterDiscordId: string; requesterDiscordName: string },
+  ): Promise<{ ok: boolean; message: string; newName?: string }> {
+    const resp = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/roster/character/${encodeURIComponent(name)}/rename`,
+      {
+        method: 'POST',
+        headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          new_name: newName,
+          requesterDiscordId: requester.requesterDiscordId,
+          requesterDiscordName: requester.requesterDiscordName,
+        }),
+      },
+    ).catch(() => null);
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (resp.status === 409) return { ok: false, message: `Character "${newName}" already exists.` };
+    if (!resp.ok) {
+      const preview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      return { ok: false, message: preview || `API rejected request (status ${resp.status}).` };
+    }
+    const raw = (await resp.json()) as { new_name?: string };
+    return { ok: true, message: 'Character renamed.', newName: raw.new_name };
   }
 
   private async post(path: string, body: unknown, successMessage: string) {

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1367,6 +1367,159 @@ def delete_wiki_page(slug):
     return jsonify({'status': 'deleted', 'slug': slug})
 
 
+@bp.route('/roster/character/<name>', methods=['GET'])
+@require_bot_scope('read')
+@_limit('120 per hour')
+def get_character_api(name):
+    """Return current details for a character by name."""
+    char = db_service.get_character(name)
+    if not char:
+        return jsonify({'error': 'Character not found'}), 404
+    return jsonify({
+        'character_name': char.character_name,
+        'player_discord': char.player_discord or '',
+        'player_discord_name': char.player_discord_name or '',
+        'clan': char.clan or '',
+        'age_category': char.age_category or '',
+        'sect': char.sect or '',
+        'active': char.active,
+    }), 200
+
+
+@bp.route('/roster/character/<name>', methods=['PATCH'])
+@require_bot_scope('write')
+@_limit('60 per hour')
+def update_character_api(name):
+    """Update clan, age_category, and/or sect for an existing character."""
+    from app.models import CLANS, AGE_CATEGORIES, SECTS
+
+    char = db_service.get_character(name)
+    if not char:
+        return jsonify({'error': 'Character not found'}), 404
+
+    data = request.get_json(silent=True) or {}
+    updates = {}
+    for field in ('clan', 'age_category', 'sect'):
+        if field in data:
+            updates[field] = (data[field] or '').strip()
+
+    if not updates:
+        return jsonify({'error': 'No updatable fields provided'}), 400
+
+    if 'clan' in updates and updates['clan'] and updates['clan'] not in CLANS:
+        return jsonify({'error': f'Invalid clan: {updates["clan"]}'}), 400
+    if 'age_category' in updates and updates['age_category'] and updates['age_category'] not in AGE_CATEGORIES:
+        return jsonify({'error': f'Invalid age_category: {updates["age_category"]}'}), 400
+    if 'sect' in updates and updates['sect'] and updates['sect'] not in SECTS:
+        return jsonify({'error': f'Invalid sect: {updates["sect"]}'}), 400
+
+    db_service.update_character(name, updates)
+    requester_name = (data.get('requesterDiscordName') or 'bot').strip()
+    db_service.log_action(
+        staff_user=requester_name,
+        action_type='edit_character',
+        target=name,
+        details=f'Updated via bot: {", ".join(updates.keys())}',
+    )
+    return jsonify({'ok': True, 'character_name': name}), 200
+
+
+@bp.route('/roster/character/<name>/rename', methods=['POST'])
+@require_bot_scope('write')
+@_limit('30 per hour')
+def rename_character_api(name):
+    """Rename a character and migrate all related records."""
+    char = db_service.get_character(name)
+    if not char:
+        return jsonify({'error': 'Character not found'}), 404
+
+    data = request.get_json(silent=True) or {}
+    new_name = (data.get('new_name') or '').strip()
+    if not new_name:
+        return jsonify({'error': 'new_name is required'}), 400
+    if new_name.lower() == name.lower():
+        return jsonify({'error': 'New name is the same as the current name'}), 400
+
+    try:
+        db_service.rename_character(name, new_name)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 409
+
+    requester_name = (data.get('requesterDiscordName') or 'bot').strip()
+    db_service.log_action(
+        staff_user=requester_name,
+        action_type='rename_character',
+        target=new_name,
+        details=f'Renamed via bot: "{name}" → "{new_name}"',
+    )
+    return jsonify({'ok': True, 'old_name': name, 'new_name': new_name}), 200
+
+
+@bp.route('/roster/character', methods=['POST'])
+@require_bot_scope('write')
+@_limit('60 per hour')
+def create_character():
+    """Create a new character roster entry via the bot (e.g. /lasombra approve).
+
+    Body fields:
+      character_name       string, required
+      player_discord       string (Discord snowflake), optional
+      player_discord_name  string (Discord username), optional
+      clan                 string, must match CLANS list
+      age_category         string, must match AGE_CATEGORIES list
+      sect                 string, must match SECTS list
+      requesterDiscordId   string, for audit log
+      requesterDiscordName string, for audit log
+    """
+    from app.models import Character, CLANS, AGE_CATEGORIES, SECTS
+
+    data = request.get_json(silent=True) or {}
+    character_name = (data.get('character_name') or '').strip()
+    if not character_name:
+        return jsonify({'error': 'character_name is required'}), 400
+
+    clan = (data.get('clan') or '').strip()
+    age_category = (data.get('age_category') or '').strip()
+    sect = (data.get('sect') or '').strip()
+    player_discord = (data.get('player_discord') or '').strip()
+    player_discord_name = (data.get('player_discord_name') or '').strip()
+    requester_name = (data.get('requesterDiscordName') or 'bot').strip()
+
+    if clan and clan not in CLANS:
+        return jsonify({'error': f'Invalid clan: {clan}'}), 400
+    if age_category and age_category not in AGE_CATEGORIES:
+        return jsonify({'error': f'Invalid age_category: {age_category}'}), 400
+    if sect and sect not in SECTS:
+        return jsonify({'error': f'Invalid sect: {sect}'}), 400
+
+    existing = db_service.get_character(character_name)
+    if existing:
+        return jsonify({'error': f'Character "{character_name}" already exists'}), 409
+
+    char = Character(
+        character_name=character_name,
+        player_discord=player_discord,
+        player_discord_name=player_discord_name,
+        clan=clan,
+        age_category=age_category,
+        sect=sect,
+        active=True,
+        creation_xp=0,
+    )
+    db_service.add_character(char)
+    if sheets_sync:
+        sheets_sync.sync_add_character(char)
+
+    db_service.log_action(
+        staff_user=requester_name,
+        action_type='add_character',
+        target=character_name,
+        details=f'Added character via bot: {character_name} ({clan}, {sect})',
+    )
+
+    return jsonify({'ok': True, 'character_name': character_name}), 201
+
+
 @bp.route('/sheets/reconcile', methods=['POST'])
 @require_bot_scope('write')
 @_limit('5 per hour')

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -823,6 +823,115 @@ Also keeps `active` boolean aligned with status.
 
 ---
 
+## GET /api/roster/character/{name}
+
+**Scope:** read | **Rate limit:** 120/hour
+
+Returns current details for a character. Used by `/lasombra edit` to pre-fill the form.
+
+**Response 200:**
+```json
+{
+  "character_name": "Astrid",
+  "player_discord": "166346048049119233",
+  "player_discord_name": "itsneeon",
+  "clan": "Gangrel",
+  "age_category": "Neonate",
+  "sect": "Camarilla",
+  "active": true
+}
+```
+
+**Response 404:** Character not found.
+
+---
+
+## PATCH /api/roster/character/{name}
+
+**Scope:** write | **Rate limit:** 60/hour
+
+Updates clan, age_category, and/or sect for an existing character.
+
+**Body:**
+```json
+{
+  "clan": "Toreador",
+  "age_category": "Ancilla",
+  "sect": "Camarilla",
+  "requesterDiscordId": "111111111111111111",
+  "requesterDiscordName": "StaffMember"
+}
+```
+
+All fields are optional. At least one of `clan`, `age_category`, `sect` is required.
+
+**Response 200:** `{ "ok": true, "character_name": "Astrid" }`
+**Response 400:** No updatable fields or invalid value.
+**Response 404:** Character not found.
+
+---
+
+## POST /api/roster/character/{name}/rename
+
+**Scope:** write | **Rate limit:** 30/hour
+
+Renames a character and migrates all claims, spends, ledger, and audit entries.
+
+**Body:**
+```json
+{
+  "new_name": "Astrid von Holt",
+  "requesterDiscordId": "111111111111111111",
+  "requesterDiscordName": "StaffMember"
+}
+```
+
+**Response 200:** `{ "ok": true, "old_name": "Astrid", "new_name": "Astrid von Holt" }`
+**Response 400:** `new_name` missing or same as current.
+**Response 404:** Character not found.
+**Response 409:** `new_name` already exists on the roster.
+
+---
+
+## POST /api/roster/character
+
+**Scope:** write | **Rate limit:** 60/hour
+
+Creates a new character roster entry. Called by the bot during `/lasombra approve`.
+
+**Body:**
+```json
+{
+  "character_name": "Astrid",
+  "player_discord": "166346048049119233",
+  "player_discord_name": "itsneeon",
+  "clan": "Gangrel",
+  "age_category": "Neonate",
+  "sect": "Camarilla",
+  "requesterDiscordId": "111111111111111111",
+  "requesterDiscordName": "StaffMember"
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `character_name` | Yes | Must be unique (case-insensitive) |
+| `clan` | No | Must match CLANS list if provided |
+| `age_category` | No | Fledgling / Neonate / Ancilla / Elder / Mortal |
+| `sect` | No | Camarilla / Anarch / Hecata / Autarkis / NA |
+| `player_discord` | No | Discord snowflake |
+| `player_discord_name` | No | Discord username |
+
+**Response 201:**
+```json
+{ "ok": true, "character_name": "Astrid" }
+```
+
+**Response 400:** Missing or invalid fields.
+**Response 409:** Character name already exists.
+
+---
+
 ## POST /api/sheets/reconcile
 
 **Scope:** write | **Rate limit:** 5/hour


### PR DESCRIPTION
## Summary

- **`/lasombra approve`** — run in a renamed ticket channel (staff does `$rename` first). Bot auto-detects the player via permission overwrites, finds the latest PDF, and shows a 5-row Discord form (age/clan/sect selects + role multi-select + Confirm & Onboard button). On confirm:
  1. Moves channel to the correct cubby category (Mortal/Fledgling/Neonate/Ancilla)
  2. Adds selected Discord roles to player (additive — won't touch existing roles)
  3. Removes Sheet in Progress role
  4. Creates roster entry via new `POST /api/roster/character` endpoint
  5. Posts sheet + player mention to `#player-character-sheets` with PDF
  6. Posts welcome message in the cubby with channel links

- **`/lasombra edit`** — run in a character's cubby channel. Fetches current roster data and pre-fills age/clan/sect selects. **Save Changes** updates roster fields and moves the channel to a new cubby if age changed. **Rename Character** opens a modal, renames in the roster (migrating all XP history/claims/spends), and renames the Discord channel.

## New API endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/roster/character` | Create character (approve flow) |
| `GET` | `/api/roster/character/{name}` | Fetch character details (edit pre-fill) |
| `PATCH` | `/api/roster/character/{name}` | Update clan/age/sect |
| `POST` | `/api/roster/character/{name}/rename` | Rename + migrate all records |

## New bot env vars

```
APPROVE_PLAYER_SHEETS_CHANNEL_ID=1199460096535695470
APPROVE_SHEET_IN_PROGRESS_ROLE_ID=1374158816740118528
```

Already set in `.env` on the host. `.env.example` updated.

## Test plan

- [ ] CI passes
- [ ] `/lasombra approve` in a ticket channel shows form with player detected and PDF found
- [ ] Confirm executes all 6 steps and reports per-step status
- [ ] `/lasombra edit` in a cubby shows pre-filled form matching current roster values
- [ ] Changing age + Save moves channel to correct cubby
- [ ] Rename Character modal renames both roster entry and Discord channel
- [ ] No existing commands or tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)