### PR TITLE
Add /lasombra approve, edit, delete, update — character onboarding workflow

### DIFF
--- a/apps/bot/src/approveWizard.ts
+++ b/apps/bot/src/approveWizard.ts
@@ -82,7 +82,7 @@ const pending = new Map<string, ApproveState>();
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-async function findPlayerInChannel(
+export async function findPlayerInChannel(
   channel: TextChannel,
   staffIds: Set<string>,
 ): Promise<string | null> {
@@ -103,7 +103,7 @@ async function findPlayerInChannel(
   return null;
 }
 
-async function findLatestPdf(
+export async function findLatestPdf(
   channel: TextChannel,
 ): Promise<{ url: string; name: string } | null> {
   try {

--- a/apps/bot/src/approveWizard.ts
+++ b/apps/bot/src/approveWizard.ts
@@ -249,7 +249,7 @@ export async function startApproveWizard(
     return;
   }
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferReply({ ephemeral: false });
 
   const [playerId, pdf, guildRoles] = await Promise.all([
     findPlayerInChannel(channel, config.testerDiscordIds),
@@ -461,11 +461,12 @@ export async function handleApproveWizardButton(
 
   // ── 5. Post to #player-character-sheets ───────────────────────────────
   const sheetsChannelId = config.approvePlayerSheetsChannelId;
-  if (sheetsChannelId && state.playerId) {
+  if (sheetsChannelId) {
     try {
       const sheetsChannel = await guild.channels.fetch(sheetsChannelId);
       if (sheetsChannel && sheetsChannel.isTextBased() && 'send' in sheetsChannel) {
-        const content = `${state.characterName} <@${state.playerId}> initial sub`;
+        const playerTag = state.playerId ? ` <@${state.playerId}>` : '';
+        const content = `${state.characterName}${playerTag} initial sub`;
         if (state.pdfUrl) {
           await (sheetsChannel as TextChannel).send({
             content,
@@ -481,7 +482,7 @@ export async function handleApproveWizardButton(
     } catch (err) {
       results.push(`⚠️ #player-character-sheets post failed: ${errorToMessage(err)}`);
     }
-  } else if (!sheetsChannelId) {
+  } else {
     results.push('ℹ️ `APPROVE_PLAYER_SHEETS_CHANNEL_ID` not configured — skipped.');
   }
 

--- a/apps/bot/src/approveWizard.ts
+++ b/apps/bot/src/approveWizard.ts
@@ -5,11 +5,9 @@ import {
   ChannelType,
   GuildChannel,
   OverwriteType,
-  RoleSelectMenuBuilder,
   StringSelectMenuBuilder,
   type ButtonInteraction,
   type ChatInputCommandInteraction,
-  type RoleSelectMenuInteraction,
   type StringSelectMenuInteraction,
   type TextChannel,
 } from 'discord.js';
@@ -38,6 +36,13 @@ const AGE_TO_CUBBY: Record<string, string> = {
 };
 
 const CUBBY_CATEGORY_NAMES = new Set(Object.values(AGE_TO_CUBBY));
+
+const APPROVAL_ROLE_NAMES = [
+  'Kindred', 'Ghoul', 'Mortal', 'Camarilla', 'Anarch', 'Family', 'Autarkis',
+  'Banu Haqim', 'Brujah', 'Clanless', 'Gangrel', 'Lasombra', 'Malkavian',
+  'Ministry', 'Nosferatu', 'Ravnos', 'Salubri', 'Toreador', 'Tremere',
+  'Tzimisce', 'Ventrue',
+];
 
 function welcomeMessage(playerMention: string): string {
   return (
@@ -69,6 +74,7 @@ type ApproveState = {
   clan: string | null;
   sect: string | null;
   roleIds: string[];
+  availableRoles: { id: string; name: string }[];
 };
 
 // keyed by staffUserId — one wizard per staff member at a time
@@ -156,12 +162,21 @@ function buildComponents(state: ApproveState) {
       ),
   );
 
-  const rolesRow = new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(
-    new RoleSelectMenuBuilder()
+  const rolesRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
       .setCustomId(APPROVE_ROLES_SELECT_ID)
-      .setPlaceholder('Select roles to assign to player (Kindred, Camarilla, etc.)')
+      .setPlaceholder('Select roles to assign (Kindred, Camarilla, etc.)')
       .setMinValues(0)
-      .setMaxValues(10),
+      .setMaxValues(Math.max(1, state.availableRoles.length))
+      .addOptions(
+        state.availableRoles.length > 0
+          ? state.availableRoles.map((r) => ({
+              label: r.name,
+              value: r.id,
+              default: state.roleIds.includes(r.id),
+            }))
+          : [{ label: '(no roles found)', value: 'none', default: false }],
+      ),
   );
 
   const canConfirm = Boolean(state.age && state.clan && state.sect);
@@ -236,8 +251,18 @@ export async function startApproveWizard(
 
   await interaction.deferReply({ ephemeral: true });
 
-  const playerId = await findPlayerInChannel(channel, config.testerDiscordIds);
-  const pdf = await findLatestPdf(channel);
+  const [playerId, pdf, guildRoles] = await Promise.all([
+    findPlayerInChannel(channel, config.testerDiscordIds),
+    findLatestPdf(channel),
+    interaction.guild!.roles.fetch(),
+  ]);
+
+  const availableRoles = APPROVAL_ROLE_NAMES
+    .map((name) => {
+      const role = guildRoles.find((r) => r.name.toLowerCase() === name.toLowerCase());
+      return role ? { id: role.id, name: role.name } : null;
+    })
+    .filter((r): r is { id: string; name: string } => r !== null);
 
   const state: ApproveState = {
     channelId: channel.id,
@@ -249,6 +274,7 @@ export async function startApproveWizard(
     clan: null,
     sect: null,
     roleIds: [],
+    availableRoles,
   };
 
   pending.set(interaction.user.id, state);
@@ -265,7 +291,8 @@ export function isApproveWizardStringSelect(customId: string): boolean {
   return (
     customId === APPROVE_AGE_SELECT_ID ||
     customId === APPROVE_CLAN_SELECT_ID ||
-    customId === APPROVE_SECT_SELECT_ID
+    customId === APPROVE_SECT_SELECT_ID ||
+    customId === APPROVE_ROLES_SELECT_ID
   );
 }
 
@@ -280,36 +307,10 @@ export async function handleApproveWizardStringSelect(
     return true;
   }
 
-  const value = interaction.values[0] ?? null;
-  if (interaction.customId === APPROVE_AGE_SELECT_ID) state.age = value;
-  else if (interaction.customId === APPROVE_CLAN_SELECT_ID) state.clan = value;
-  else if (interaction.customId === APPROVE_SECT_SELECT_ID) state.sect = value;
-
-  await interaction.update({
-    content: buildStatusContent(state),
-    components: buildComponents(state),
-  });
-  return true;
-}
-
-// ── Role select handler ────────────────────────────────────────────────────
-
-export function isApproveWizardRoleSelect(customId: string): boolean {
-  return customId === APPROVE_ROLES_SELECT_ID;
-}
-
-export async function handleApproveWizardRoleSelect(
-  interaction: RoleSelectMenuInteraction,
-): Promise<boolean> {
-  if (!isApproveWizardRoleSelect(interaction.customId)) return false;
-
-  const state = pending.get(interaction.user.id);
-  if (!state) {
-    await interaction.update({ content: 'Session expired — run `/lasombra approve` again.', components: [] });
-    return true;
-  }
-
-  state.roleIds = interaction.values;
+  if (interaction.customId === APPROVE_AGE_SELECT_ID) state.age = interaction.values[0] ?? null;
+  else if (interaction.customId === APPROVE_CLAN_SELECT_ID) state.clan = interaction.values[0] ?? null;
+  else if (interaction.customId === APPROVE_SECT_SELECT_ID) state.sect = interaction.values[0] ?? null;
+  else if (interaction.customId === APPROVE_ROLES_SELECT_ID) state.roleIds = interaction.values.filter((v) => v !== 'none');
 
   await interaction.update({
     content: buildStatusContent(state),

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -1,6 +1,9 @@
 import {
   ActionRowBuilder,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
   ChatInputCommandInteraction,
   ModalBuilder,
   SlashCommandBuilder,
@@ -29,6 +32,18 @@ export const data = new SlashCommandBuilder()
     s
       .setName('edit')
       .setDescription('Edit a character\'s clan, sect, or age (and move cubby if age changes). Run in their channel.'),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('delete')
+      .setDescription('Hard-delete a character with no history (staff only). Use retired/deceased for real characters.')
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name to delete')
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
   )
   .addSubcommand((s) =>
     s
@@ -87,6 +102,11 @@ export const data = new SlashCommandBuilder()
   );
 
 const BROADCAST_MODAL_ID = 'lasombra:broadcast:modal';
+export const DELETE_CONFIRM_ID = 'lasombra:delete:confirm';
+export const DELETE_CANCEL_ID = 'lasombra:delete:cancel';
+
+// Keyed by staffUserId → character name pending deletion
+const pendingDeletes = new Map<string, string>();
 
 type PendingBroadcast = {
   target: string;
@@ -109,6 +129,31 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
 
   if (sub === 'edit') {
     await startEditWizard(interaction, ctx);
+    return;
+  }
+
+  if (sub === 'delete') {
+    if (!config.testerDiscordIds.has(interaction.user.id)) {
+      await interaction.reply({ content: 'This command is restricted to staff.', ephemeral: true });
+      return;
+    }
+    const characterName = interaction.options.getString('character', true).trim();
+    pendingDeletes.set(interaction.user.id, characterName);
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(DELETE_CONFIRM_ID)
+        .setLabel('Yes, delete')
+        .setStyle(ButtonStyle.Danger),
+      new ButtonBuilder()
+        .setCustomId(DELETE_CANCEL_ID)
+        .setLabel('Cancel')
+        .setStyle(ButtonStyle.Secondary),
+    );
+    await interaction.reply({
+      content: `⚠️ Delete **${characterName}** from the roster? This is permanent and only works if they have no XP history.`,
+      components: [row],
+      ephemeral: true,
+    });
     return;
   }
 
@@ -527,5 +572,51 @@ export async function handleBroadcastModal(
     mentionCharDiscordId: pending.mentionCharDiscordId,
   });
 
+  return true;
+}
+
+// ── Delete confirmation button handler ─────────────────────────────────────
+
+export function isDeleteButton(customId: string): boolean {
+  return customId === DELETE_CONFIRM_ID || customId === DELETE_CANCEL_ID;
+}
+
+export async function handleDeleteButton(
+  interaction: ButtonInteraction,
+  ctx: CommandContext,
+): Promise<boolean> {
+  if (!isDeleteButton(interaction.customId)) return false;
+
+  if (interaction.customId === DELETE_CANCEL_ID) {
+    pendingDeletes.delete(interaction.user.id);
+    await interaction.update({ content: 'Delete cancelled.', components: [] });
+    return true;
+  }
+
+  const characterName = pendingDeletes.get(interaction.user.id);
+  pendingDeletes.delete(interaction.user.id);
+
+  if (!characterName) {
+    await interaction.update({ content: 'Session expired — run `/lasombra delete` again.', components: [] });
+    return true;
+  }
+
+  await interaction.deferUpdate();
+
+  const result = await ctx.adapter.deleteCharacter(characterName, {
+    requesterDiscordId: interaction.user.id,
+    requesterDiscordName: interaction.user.username,
+  });
+
+  if (!result.ok) {
+    const hint = result.hasHistory
+      ? '\nUse `/lasombra edit` to mark them as retired or deceased instead.'
+      : '';
+    await interaction.editReply({ content: `⚠️ ${result.message}${hint}`, components: [] });
+    return true;
+  }
+
+  logEvent('info', 'character_deleted', { characterName, staffId: interaction.user.id });
+  await interaction.editReply({ content: `✅ **${characterName}** deleted from the roster.`, components: [] });
   return true;
 }

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -64,13 +64,6 @@ export const data = new SlashCommandBuilder()
       .setDescription('Blank a tracked background for one night')
       .addStringOption((o) =>
         o
-          .setName('character')
-          .setDescription('Character name (staff may target any character)')
-          .setRequired(false)
-          .setAutocomplete(true),
-      )
-      .addStringOption((o) =>
-        o
           .setName('background')
           .setDescription('Tracked background name')
           .setRequired(true)
@@ -83,6 +76,13 @@ export const data = new SlashCommandBuilder()
           .setRequired(true)
           .setMinValue(1)
           .setMaxValue(10),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name (staff may target any character)')
+          .setRequired(false)
+          .setAutocomplete(true),
       ),
   );
 

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -4,7 +4,9 @@ import {
   ButtonBuilder,
   ButtonInteraction,
   ButtonStyle,
+  ChannelType,
   ChatInputCommandInteraction,
+  GuildChannel,
   ModalBuilder,
   SlashCommandBuilder,
   TextInputBuilder,
@@ -616,6 +618,27 @@ export async function handleDeleteButton(
   }
 
   logEvent('info', 'character_deleted', { characterName, staffId: interaction.user.id });
+
+  // Delete the current channel if its name matches the character (ticket cleanup)
+  const channel = interaction.channel;
+  if (
+    channel &&
+    channel.type === ChannelType.GuildText &&
+    channel.name === normalizeChannelName(characterName)
+  ) {
+    try {
+      await (channel as GuildChannel).delete(`Character deleted: ${characterName}`);
+      // Channel is gone — no editReply possible
+      return true;
+    } catch (err) {
+      await interaction.editReply({
+        content: `✅ **${characterName}** deleted from the roster.\n⚠️ Channel delete failed: ${errorToMessage(err)}`,
+        components: [],
+      });
+      return true;
+    }
+  }
+
   await interaction.editReply({ content: `✅ **${characterName}** deleted from the roster.`, components: [] });
   return true;
 }

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -152,7 +152,6 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
     await interaction.reply({
       content: `⚠️ Delete **${characterName}** from the roster? This is permanent and only works if they have no XP history.`,
       components: [row],
-      ephemeral: true,
     });
     return;
   }

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -116,7 +116,7 @@ export const DELETE_CANCEL_ID = 'lasombra:delete:cancel';
 // Keyed by staffUserId → channel ID where /lasombra update was run
 const pendingUpdates = new Map<string, string>();
 
-// Keyed by staffUserId → character name pending deletion
+// Keyed by confirmation message ID → character name pending deletion
 const pendingDeletes = new Map<string, string>();
 
 type PendingBroadcast = {
@@ -173,7 +173,6 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       return;
     }
     const characterName = interaction.options.getString('character', true).trim();
-    pendingDeletes.set(interaction.user.id, characterName);
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setCustomId(DELETE_CONFIRM_ID)
@@ -188,6 +187,8 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       content: `⚠️ Delete **${characterName}** from the roster? This is permanent and only works if they have no XP history.`,
       components: [row],
     });
+    const replyMsg = await interaction.fetchReply();
+    pendingDeletes.set(replyMsg.id, characterName);
     return;
   }
 
@@ -714,13 +715,13 @@ export async function handleDeleteButton(
   if (!isDeleteButton(interaction.customId)) return false;
 
   if (interaction.customId === DELETE_CANCEL_ID) {
-    pendingDeletes.delete(interaction.user.id);
+    pendingDeletes.delete(interaction.message.id);
     await interaction.update({ content: 'Delete cancelled.', components: [] });
     return true;
   }
 
-  const characterName = pendingDeletes.get(interaction.user.id);
-  pendingDeletes.delete(interaction.user.id);
+  const characterName = pendingDeletes.get(interaction.message.id);
+  pendingDeletes.delete(interaction.message.id);
 
   if (!characterName) {
     await interaction.update({ content: 'Session expired — run `/lasombra delete` again.', components: [] });

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -17,7 +17,7 @@ import { config } from '../config';
 import { liveConfig } from '../liveConfig';
 import { buildCubbyChannelMap, getChannelsInCubbyCategories, normalizeChannelName } from '../services/cubbyChannels';
 import { errorToMessage, logEvent } from '../logger';
-import { startApproveWizard } from '../approveWizard';
+import { startApproveWizard, findPlayerInChannel, findLatestPdf } from '../approveWizard';
 import { startEditWizard } from '../editWizard';
 
 export const name = 'lasombra';
@@ -29,6 +29,11 @@ export const data = new SlashCommandBuilder()
     s
       .setName('approve')
       .setDescription('Approve a character ticket: move to cubby, assign roles, create roster entry, post sheet'),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('update')
+      .setDescription('Post a sheet update to #player-character-sheets. Run in the character\'s channel.'),
   )
   .addSubcommand((s) =>
     s
@@ -104,8 +109,12 @@ export const data = new SlashCommandBuilder()
   );
 
 const BROADCAST_MODAL_ID = 'lasombra:broadcast:modal';
+const UPDATE_MODAL_ID = 'lasombra:update:modal';
 export const DELETE_CONFIRM_ID = 'lasombra:delete:confirm';
 export const DELETE_CANCEL_ID = 'lasombra:delete:cancel';
+
+// Keyed by staffUserId → channel ID where /lasombra update was run
+const pendingUpdates = new Map<string, string>();
 
 // Keyed by staffUserId → character name pending deletion
 const pendingDeletes = new Map<string, string>();
@@ -126,6 +135,30 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
 
   if (sub === 'approve') {
     await startApproveWizard(interaction, ctx);
+    return;
+  }
+
+  if (sub === 'update') {
+    if (!config.testerDiscordIds.has(interaction.user.id)) {
+      await interaction.reply({ content: 'This command is restricted to staff.', ephemeral: true });
+      return;
+    }
+    if (!interaction.channel || interaction.channel.type !== ChannelType.GuildText) {
+      await interaction.reply({ content: 'Run this inside the character\'s channel.', ephemeral: true });
+      return;
+    }
+    pendingUpdates.set(interaction.user.id, interaction.channel.id);
+
+    const modal = new ModalBuilder().setCustomId(UPDATE_MODAL_ID).setTitle('Sheet Update');
+    const updateInput = new TextInputBuilder()
+      .setCustomId('update_message')
+      .setLabel('What is the update?')
+      .setStyle(TextInputStyle.Paragraph)
+      .setPlaceholder('e.g. 15 xp spent Presence 3')
+      .setMaxLength(1000)
+      .setRequired(true);
+    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(updateInput));
+    await interaction.showModal(modal);
     return;
   }
 
@@ -573,6 +606,98 @@ export async function handleBroadcastModal(
     mentionCharDiscordId: pending.mentionCharDiscordId,
   });
 
+  return true;
+}
+
+// ── Update modal handler ────────────────────────────────────────────────────
+
+export async function handleUpdateModal(
+  interaction: import('discord.js').ModalSubmitInteraction,
+): Promise<boolean> {
+  if (interaction.customId !== UPDATE_MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const channelId = pendingUpdates.get(interaction.user.id);
+  pendingUpdates.delete(interaction.user.id);
+
+  if (!channelId) {
+    await interaction.editReply('Session expired — run `/lasombra update` again.');
+    return true;
+  }
+
+  const updateMessage = interaction.fields.getTextInputValue('update_message').trim();
+
+  const guild = interaction.guild;
+  if (!guild) {
+    await interaction.editReply('Could not resolve server. Please try again.');
+    return true;
+  }
+
+  let channel: import('discord.js').TextChannel;
+  try {
+    const fetched = await guild.channels.fetch(channelId);
+    if (!fetched || !fetched.isTextBased() || !('messages' in fetched)) {
+      await interaction.editReply('Could not find the original channel.');
+      return true;
+    }
+    channel = fetched as import('discord.js').TextChannel;
+  } catch (err) {
+    await interaction.editReply(`Could not fetch channel: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  const characterName = channel.name;
+  const [playerId, pdf] = await Promise.all([
+    findPlayerInChannel(channel, config.testerDiscordIds),
+    findLatestPdf(channel),
+  ]);
+
+  const sheetsChannelId = config.approvePlayerSheetsChannelId;
+  if (!sheetsChannelId) {
+    await interaction.editReply('`APPROVE_PLAYER_SHEETS_CHANNEL_ID` is not configured.');
+    return true;
+  }
+
+  try {
+    const sheetsChannel = await guild.channels.fetch(sheetsChannelId);
+    if (!sheetsChannel || !sheetsChannel.isTextBased() || !('send' in sheetsChannel)) {
+      await interaction.editReply('#player-character-sheets channel not found or not sendable.');
+      return true;
+    }
+
+    const playerMention = playerId ? `<@${playerId}>` : characterName;
+    const content = `${playerMention} "${updateMessage}"`;
+
+    if (pdf) {
+      await (sheetsChannel as import('discord.js').TextChannel).send({
+        content,
+        files: [{ attachment: pdf.url, name: pdf.name }],
+      });
+    } else {
+      await (sheetsChannel as import('discord.js').TextChannel).send({ content });
+    }
+  } catch (err) {
+    await interaction.editReply(`Failed to post to #player-character-sheets: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  logEvent('info', 'sheet_update_posted', {
+    characterName,
+    playerId,
+    staffId: interaction.user.id,
+    hasPdf: Boolean(pdf),
+  });
+
+  // Post public confirmation in the character's channel
+  try {
+    await channel.send({ content: 'Character sheet uploaded.' });
+  } catch (err) {
+    logEvent('warn', 'sheet_update_channel_confirm_failed', { characterName, error: errorToMessage(err) });
+  }
+
+  const pdfNote = pdf ? '' : ' *(no PDF found in channel)*';
+  await interaction.editReply(`✅ Posted update for **${characterName}** to <#${sheetsChannelId}>${pdfNote}.`);
   return true;
 }
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -28,7 +28,7 @@ import {
   handleClaimWizardSelect,
 } from './interactiveClaimWizard';
 import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButton, isCombatButton } from './combatSetupWizard';
-import { handleBroadcastModal, handleDeleteButton, isDeleteButton } from './commands/lasombra';
+import { handleBroadcastModal, handleDeleteButton, handleUpdateModal, isDeleteButton } from './commands/lasombra';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -320,6 +320,11 @@ void applyStartupConfigOverrides().then(() => {
     }
 
     if (interaction.isModalSubmit()) {
+      const updateHandled = await handleUpdateModal(interaction);
+      if (updateHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
       const broadcastHandled = await handleBroadcastModal(interaction, { client, adapter });
       if (broadcastHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -31,7 +31,6 @@ import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButt
 import { handleBroadcastModal, handleDeleteButton, isDeleteButton } from './commands/lasombra';
 import {
   handleApproveWizardStringSelect,
-  handleApproveWizardRoleSelect,
   handleApproveWizardButton,
   isApproveWizardButton,
 } from './approveWizard';
@@ -277,14 +276,6 @@ void applyStartupConfigOverrides().then(() => {
       }
       const editHandled = await handleEditWizardStringSelect(interaction);
       if (editHandled) {
-        logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
-        return;
-      }
-    }
-
-    if (interaction.isRoleSelectMenu()) {
-      const approveHandled = await handleApproveWizardRoleSelect(interaction);
-      if (approveHandled) {
         logEvent('info', 'interaction_handled_select', { ...baseMeta, customId: interaction.customId });
         return;
       }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -28,7 +28,7 @@ import {
   handleClaimWizardSelect,
 } from './interactiveClaimWizard';
 import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButton, isCombatButton } from './combatSetupWizard';
-import { handleBroadcastModal } from './commands/lasombra';
+import { handleBroadcastModal, handleDeleteButton, isDeleteButton } from './commands/lasombra';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardRoleSelect,
@@ -299,6 +299,11 @@ void applyStartupConfigOverrides().then(() => {
       if (isEditWizardButton(interaction.customId)) {
         await handleEditWizardButton(interaction, { client, adapter });
         logEvent('info', 'interaction_handled_edit_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      if (isDeleteButton(interaction.customId)) {
+        await handleDeleteButton(interaction, { client, adapter });
+        logEvent('info', 'interaction_handled_delete_button', { ...baseMeta, customId: interaction.customId });
         return;
       }
       if (isHuntConsequenceButton(interaction.customId)) {

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -101,6 +101,10 @@ export interface TrackerAdapter {
     newName: string,
     requester: { requesterDiscordId: string; requesterDiscordName: string },
   ): Promise<{ ok: boolean; message: string; newName?: string }>;
+  deleteCharacter(
+    name: string,
+    requester: { requesterDiscordId: string; requesterDiscordName: string },
+  ): Promise<{ ok: boolean; message: string; hasHistory?: boolean }>;
 }
 
 export type CharacterDetails = {
@@ -908,6 +912,28 @@ export class WebAppAdapter implements TrackerAdapter {
     }
     const raw = (await resp.json()) as { new_name?: string };
     return { ok: true, message: 'Character renamed.', newName: raw.new_name };
+  }
+
+  async deleteCharacter(
+    name: string,
+    requester: { requesterDiscordId: string; requesterDiscordName: string },
+  ): Promise<{ ok: boolean; message: string; hasHistory?: boolean }> {
+    const resp = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/roster/character/${encodeURIComponent(name)}`,
+      {
+        method: 'DELETE',
+        headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requesterDiscordName: requester.requesterDiscordName }),
+      },
+    ).catch(() => null);
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (resp.status === 409) return { ok: false, hasHistory: true, message: 'Character has existing history — use retired or deceased status instead.' };
+    if (resp.status === 404) return { ok: false, message: 'Character not found.' };
+    if (!resp.ok) {
+      const preview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      return { ok: false, message: preview || `API rejected request (status ${resp.status}).` };
+    }
+    return { ok: true, message: 'Character deleted.' };
   }
 
   private async post(path: string, body: unknown, successMessage: string) {

--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -155,12 +155,13 @@ def create_app():
     csrf.exempt(api_bp)
 
     # Inject auth helpers into all templates
-    from .auth import is_staff as _is_staff, is_logged_in as _is_logged_in
+    from .auth import is_staff as _is_staff, is_logged_in as _is_logged_in, is_settings_admin as _is_settings_admin
 
     @app.context_processor
     def inject_auth():
         return {
             'is_staff': _is_staff(),
+            'is_admin': _is_settings_admin(),
             'is_logged_in': _is_logged_in(),
             'current_discord_name': session.get('discord_name', ''),
             'current_discord_id': session.get('discord_id', ''),

--- a/apps/web/app/auth.py
+++ b/apps/web/app/auth.py
@@ -96,15 +96,31 @@ def require_character_owner(f):
     return decorated_function
 
 
+def _get_db_staff_role(discord_id: str) -> str | None:
+    """Return 'storyteller' or 'administrator' from the DB, or None."""
+    try:
+        from .db import AppSetting
+        row = AppSetting.query.get(f'STAFF_MEMBER_{discord_id}')
+        return row.value if row else None
+    except Exception:
+        return None
+
+
 def is_allowed_discord_user(discord_id: str) -> bool:
-    """Check whether a Discord user ID is in the staff allowlist."""
-    return str(discord_id) in current_app.config['ALLOWED_DISCORD_IDS']
+    """Check whether a Discord user ID is in the staff allowlist (env or DB)."""
+    if str(discord_id) in current_app.config['ALLOWED_DISCORD_IDS']:
+        return True
+    return _get_db_staff_role(str(discord_id)) is not None
 
 
 def is_settings_admin() -> bool:
-    """Check if the current session user may edit Settings."""
+    """Check if the current session user may edit Settings (env or DB)."""
     discord_id = session.get('discord_id', '')
-    return bool(discord_id) and str(discord_id) in current_app.config.get('SETTINGS_ADMIN_DISCORD_IDS', set())
+    if not discord_id:
+        return False
+    if str(discord_id) in current_app.config.get('SETTINGS_ADMIN_DISCORD_IDS', set()):
+        return True
+    return _get_db_staff_role(str(discord_id)) == 'administrator'
 
 
 def is_staff() -> bool:

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1520,6 +1520,53 @@ def create_character():
     return jsonify({'ok': True, 'character_name': character_name}), 201
 
 
+@bp.route('/roster/character/<name>', methods=['DELETE'])
+@require_bot_scope('write')
+@_limit('60 per hour')
+def delete_character(name):
+    """Hard-delete a character roster entry.
+
+    Refused with 409 if the character has any XP claims, spend requests, or
+    ledger entries — those characters should be retired/deceased instead.
+    """
+    from app.db import db, DbCharacter, DbXPClaim, DbSpendRequest, DbLedgerEntry
+    from sqlalchemy import func as _func
+
+    row = DbCharacter.query.filter(
+        _func.lower(DbCharacter.character_name) == name.lower()
+    ).first()
+    if not row:
+        return jsonify({'error': 'Character not found'}), 404
+
+    char_name = row.character_name
+
+    has_history = (
+        DbXPClaim.query.filter(_func.lower(DbXPClaim.character_name) == char_name.lower()).first() or
+        DbSpendRequest.query.filter(_func.lower(DbSpendRequest.character_name) == char_name.lower()).first() or
+        DbLedgerEntry.query.filter(_func.lower(DbLedgerEntry.character_name) == char_name.lower()).first()
+    )
+    if has_history:
+        return jsonify({
+            'error': 'Character has existing history (claims, spends, or ledger entries). '
+                     'Use retired or deceased status instead of deleting.',
+        }), 409
+
+    data = request.get_json(silent=True) or {}
+    requester_name = (data.get('requesterDiscordName') or 'bot').strip()
+
+    db.session.delete(row)
+    db.session.commit()
+
+    db_service.log_action(
+        staff_user=requester_name,
+        action_type='delete_character',
+        target=char_name,
+        details=f'Hard-deleted character via bot (no history): {char_name}',
+    )
+
+    return jsonify({'ok': True, 'character_name': char_name}), 200
+
+
 @bp.route('/sheets/reconcile', methods=['POST'])
 @require_bot_scope('write')
 @_limit('5 per hour')

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -478,6 +478,20 @@ def index():
     )
     notion_sync_runs = notion_sync_runs[:12]
 
+    # ── Staff members (DB-managed) ─────────────────────────────────────────
+    from app.db import AppSetting as _AppSetting
+    db_staff = _AppSetting.query.filter(
+        _AppSetting.key.like('STAFF_MEMBER_%')
+    ).order_by(_AppSetting.key).all()
+    staff_members = [
+        {
+            'discord_id': row.key[len('STAFF_MEMBER_'):],
+            'role': row.value,
+            'label': 'Administrator' if row.value == 'administrator' else 'Storyteller',
+        }
+        for row in db_staff
+    ]
+
     return render_template(
         'settings/index.html',
         web_flags=web_flags,
@@ -492,6 +506,7 @@ def index():
         bot_restart_pending=_restart_pending,
         notion_sync=notion_sync,
         notion_sync_runs=notion_sync_runs,
+        staff_members=staff_members,
     )
 
 
@@ -645,4 +660,51 @@ def update():
             set_app_setting(key, raw_value, updated_by)
         flash(f'{key} updated.', 'success')
 
+    return redirect(url_for('settings.index'))
+
+
+@bp.route('/staff/add', methods=['POST'])
+@require_staff
+def staff_add():
+    if not is_settings_admin():
+        flash('Only Administrators can manage staff.', 'danger')
+        return redirect(url_for('settings.index'))
+    from app.db import AppSetting, db
+    discord_id = request.form.get('discord_id', '').strip()
+    role = request.form.get('role', '').strip()
+    if not discord_id or not discord_id.isdigit():
+        flash('Invalid Discord ID — must be numeric.', 'danger')
+        return redirect(url_for('settings.index'))
+    if role not in ('storyteller', 'administrator'):
+        flash('Invalid role.', 'danger')
+        return redirect(url_for('settings.index'))
+    key = f'STAFF_MEMBER_{discord_id}'
+    row = AppSetting.query.get(key)
+    if row:
+        row.value = role
+        row.updated_by = session.get('discord_name', 'admin')
+    else:
+        row = AppSetting(key=key, value=role, updated_by=session.get('discord_name', 'admin'))
+        db.session.add(row)
+    db.session.commit()
+    flash(f'{role.capitalize()} {discord_id} added.', 'success')
+    return redirect(url_for('settings.index'))
+
+
+@bp.route('/staff/remove', methods=['POST'])
+@require_staff
+def staff_remove():
+    if not is_settings_admin():
+        flash('Only Administrators can manage staff.', 'danger')
+        return redirect(url_for('settings.index'))
+    from app.db import AppSetting, db
+    discord_id = request.form.get('discord_id', '').strip()
+    key = f'STAFF_MEMBER_{discord_id}'
+    row = AppSetting.query.get(key)
+    if row:
+        db.session.delete(row)
+        db.session.commit()
+        flash(f'Staff member {discord_id} removed.', 'success')
+    else:
+        flash('Staff member not found.', 'warning')
     return redirect(url_for('settings.index'))

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -52,9 +52,12 @@ def _is_truthy(value: str | None) -> bool:
 @bp.route('/')
 @require_staff
 def index():
+    if not is_settings_admin():
+        flash('Settings is restricted to Administrators.', 'danger')
+        return redirect(url_for('roster.index'))
     cfg = current_app.config
     overrides = get_all_overrides()
-    can_edit = is_settings_admin()
+    can_edit = True
 
     def _eff_bool(key, env_default):
         return get_app_setting(key, env_default)

--- a/apps/web/app/templates/base.html
+++ b/apps/web/app/templates/base.html
@@ -114,12 +114,14 @@
                             <i class="bi bi-exclamation-triangle"></i> <span>Error Alerts</span>
                         </a>
                     </li>
+                    {% if is_admin %}
                     <li class="nav-item">
                         <a class="nav-link {% if request.endpoint and request.endpoint.startswith('settings.') %}active{% endif %}"
                            href="{{ url_for('settings.index') }}">
                             <i class="bi bi-gear"></i> <span>Settings</span>
                         </a>
                     </li>
+                    {% endif %}
                     {% if config.LOCAL_STATUS_ENABLED %}
                     <li class="nav-item">
                         <a class="nav-link {% if request.endpoint == 'local_status.status_page' %}active{% endif %}"

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -537,6 +537,64 @@
     </div>
   </div>
 
+  {# ═══ Staff Management ═══ #}
+  <h5 class="text-muted text-uppercase small mb-2 mt-4">Staff Management</h5>
+  <div class="card bg-dark border-secondary mb-4">
+    <div class="card-body">
+      <p class="text-muted small mb-3">
+        Staff added here are stored in the database and take effect immediately — no redeploy needed.
+        Env-var entries (<code>ALLOWED_DISCORD_IDS</code>, <code>SETTINGS_ADMIN_DISCORD_IDS</code>) are always active as a baseline and cannot be removed here.
+      </p>
+
+      {% if staff_members %}
+      <table class="table table-dark table-sm mb-3 align-middle">
+        <thead>
+          <tr>
+            <th>Discord ID</th>
+            <th>Role</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for m in staff_members %}
+          <tr>
+            <td><code>{{ m.discord_id }}</code></td>
+            <td><span class="badge {% if m.role == 'administrator' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">{{ m.label }}</span></td>
+            <td>
+              <form method="POST" action="{{ url_for('settings.staff_remove') }}" class="mb-0">
+                <input type="hidden" name="discord_id" value="{{ m.discord_id }}">
+                <button type="submit" class="btn btn-sm btn-outline-danger"
+                  onclick="return confirm('Remove {{ m.discord_id }} from staff?')">Remove</button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="text-muted small">No DB-managed staff yet.</p>
+      {% endif %}
+
+      <form method="POST" action="{{ url_for('settings.staff_add') }}" class="row g-2 align-items-end">
+        <div class="col-auto">
+          <label class="form-label small text-muted mb-1">Discord ID</label>
+          <input type="text" name="discord_id" class="form-control form-control-sm bg-dark text-light border-secondary"
+            placeholder="e.g. 123456789012345678" style="width:220px" required pattern="\d+">
+        </div>
+        <div class="col-auto">
+          <label class="form-label small text-muted mb-1">Role</label>
+          <select name="role" class="form-select form-select-sm bg-dark text-light border-secondary">
+            <option value="storyteller">Storyteller</option>
+            <option value="administrator">Administrator</option>
+          </select>
+        </div>
+        <div class="col-auto">
+          <button type="submit" class="btn btn-sm btn-outline-primary">Add Staff</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
 </div>
 
 {% if notion_sync.requested or (notion_sync.status == 'running' and not notion_sync.is_stale) %}

--- a/scripts/check-bot-health.sh
+++ b/scripts/check-bot-health.sh
@@ -21,7 +21,7 @@ WEB_URL="$(grep -E '^WEB_APP_BASE_URL=' "${BOT_ENV}" 2>/dev/null | head -1 | cut
 WEB_URL="${WEB_URL:-http://127.0.0.1:5001}"
 ALERT_COOLDOWN_FILE="/tmp/mcbn-health-last-alert"
 ALERT_COOLDOWN_SECONDS=600   # 10 min between repeat alerts
-HEARTBEAT_STALE_SECONDS=300  # 5 min = bot is considered frozen
+HEARTBEAT_STALE_SECONDS=600  # 10 min (~9 missed beats) = bot is considered frozen
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **`/lasombra approve`** — full onboarding wizard: move ticket to cubby category, assign roles, remove Sheet in Progress role, create roster entry, post initial sheet to #player-character-sheets, send welcome message
- **`/lasombra edit`** — edit clan, sect, or age for an existing character; moves cubby if age changes
- **`/lasombra delete`** — hard-delete a character with no XP history (staff only, with confirmation)
- **`/lasombra update`** — post a sheet update to #player-character-sheets from any character channel; prompts for freeform update text (e.g. "15 xp spent Presence 3"), pings the player, attaches the latest PDF, and posts a public "Character sheet uploaded." confirmation in the originating channel

Also raises the bot heartbeat stale threshold to 10 min to reduce cold-start false alarms, and adds a staff management UI to Settings (Administrators only).

## Test plan

- [x] Run `/lasombra approve` in a character ticket channel — verify wizard steps, cubby move, role assignment, roster entry, sheet post
- [x] Run `/lasombra edit` in a cubby channel — verify clan/sect/age update and cubby move on age change
- [x] Run `/lasombra delete` for a character with no history — confirm deletion and channel cleanup
- [x] Run `/lasombra update` in a character's cubby — submit modal, verify post to #player-character-sheets with player mention + PDF, and "Character sheet uploaded." in the channel
- [x] Run `/lasombra update` in a channel with no PDF — verify graceful fallback (message posts without attachment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)