### PR TITLE
Add Ursula home server infrastructure as code

### DIFF
--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -116,7 +116,7 @@ export const DELETE_CANCEL_ID = 'lasombra:delete:cancel';
 // Keyed by staffUserId → channel ID where /lasombra update was run
 const pendingUpdates = new Map<string, string>();
 
-// Keyed by staffUserId → character name pending deletion
+// Keyed by confirmation message ID → character name pending deletion
 const pendingDeletes = new Map<string, string>();
 
 type PendingBroadcast = {
@@ -173,7 +173,6 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       return;
     }
     const characterName = interaction.options.getString('character', true).trim();
-    pendingDeletes.set(interaction.user.id, characterName);
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setCustomId(DELETE_CONFIRM_ID)
@@ -188,6 +187,8 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       content: `⚠️ Delete **${characterName}** from the roster? This is permanent and only works if they have no XP history.`,
       components: [row],
     });
+    const replyMsg = await interaction.fetchReply();
+    pendingDeletes.set(replyMsg.id, characterName);
     return;
   }
 
@@ -714,13 +715,13 @@ export async function handleDeleteButton(
   if (!isDeleteButton(interaction.customId)) return false;
 
   if (interaction.customId === DELETE_CANCEL_ID) {
-    pendingDeletes.delete(interaction.user.id);
+    pendingDeletes.delete(interaction.message.id);
     await interaction.update({ content: 'Delete cancelled.', components: [] });
     return true;
   }
 
-  const characterName = pendingDeletes.get(interaction.user.id);
-  pendingDeletes.delete(interaction.user.id);
+  const characterName = pendingDeletes.get(interaction.message.id);
+  pendingDeletes.delete(interaction.message.id);
 
   if (!characterName) {
     await interaction.update({ content: 'Session expired — run `/lasombra delete` again.', components: [] });

--- a/infra/ursula/README.md
+++ b/infra/ursula/README.md
@@ -1,0 +1,137 @@
+# Ursula Infrastructure
+
+Ursula (192.168.0.2) is the home server running the MCbN bot, a unified ops dashboard, and qBittorrent.
+Miniplex (192.168.0.4) is a Mac Mini. Practica (192.168.0.5) is a Raspberry Pi.
+
+## Network / SSH
+
+```
+Host ursula   → 192.168.0.2  (Ubuntu)
+Host miniplex → 192.168.0.4  (macOS)
+Host practica → 192.168.0.5  (Raspberry Pi, Ubuntu)
+```
+
+---
+
+## 1. Ursula Dashboard (Ursula only)
+
+Flask app on port 5050. Shows system stats for all three machines, Home Assistant locks, MCbN bot heartbeat, and active downloads.
+
+### Deploy
+
+```bash
+ssh ursula
+mkdir -p /home/jkomg/ursula/templates
+# copy files
+scp infra/ursula/dashboard/app.py jkomg@ursula:/home/jkomg/ursula/app.py
+scp infra/ursula/dashboard/templates/index.html jkomg@ursula:/home/jkomg/ursula/templates/index.html
+scp infra/ursula/dashboard/requirements.txt jkomg@ursula:/home/jkomg/ursula/requirements.txt
+
+# venv + deps
+ssh ursula "cd /home/jkomg/ursula && python3 -m venv venv && venv/bin/pip install -r requirements.txt"
+
+# env file (copy .env.example, fill in secrets)
+scp infra/ursula/dashboard/.env.example jkomg@ursula:/home/jkomg/ursula/.env
+ssh ursula "nano /home/jkomg/ursula/.env"
+
+# systemd service
+sudo cp infra/ursula/systemd/ursula-dashboard.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now ursula-dashboard
+```
+
+### Update dashboard after code changes
+
+```bash
+scp infra/ursula/dashboard/app.py jkomg@ursula:/home/jkomg/ursula/app.py
+scp infra/ursula/dashboard/templates/index.html jkomg@ursula:/home/jkomg/ursula/templates/index.html
+ssh ursula "sudo systemctl restart ursula-dashboard"
+```
+
+---
+
+## 2. Stats Agents
+
+Each machine runs a lightweight HTTP agent on port 9101 that the dashboard polls for CPU/RAM/disk/uptime.
+
+### Practica (Pi — Linux)
+
+```bash
+sudo apt install python3-psutil
+scp infra/ursula/agents/agent_linux.py jkomg@practica:/home/jkomg/agent.py
+
+# systemd
+scp infra/ursula/systemd/ursula-agent.service jkomg@practica:/tmp/ursula-agent.service
+ssh practica "sudo cp /tmp/ursula-agent.service /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now ursula-agent"
+```
+
+### Miniplex (macOS)
+
+```bash
+scp infra/ursula/agents/agent_mac.py jkomg@miniplex:/Users/jkomg/agent.py
+
+# launchd
+scp infra/ursula/launchd/com.ursula.agent.plist jkomg@miniplex:/Users/jkomg/Library/LaunchAgents/com.ursula.agent.plist
+ssh miniplex "launchctl load /Users/jkomg/Library/LaunchAgents/com.ursula.agent.plist"
+```
+
+Check it's running: `curl http://192.168.0.4:9101/stats`
+
+---
+
+## 3. MCbN Bot (Ursula)
+
+The bot runs as a Docker container (`lasombra-bot`) managed by Docker CE.
+
+```bash
+ssh ursula
+cd /home/jkomg/mcbn-xp-tracker/apps/bot
+# ensure .env is present (copy from apps/bot/.env.example, fill secrets)
+docker compose up -d --build
+docker compose logs -f
+```
+
+Bot must have `WEB_APP_BASE_URL=http://web:5001` if running alongside the web container,
+or `WEB_APP_BASE_URL=https://mcbn.jkomg.us` if pointing to production Cloud Run.
+
+### Docker install (if needed)
+
+```bash
+sudo apt update && sudo apt install -y docker.io
+sudo usermod -aG docker jkomg
+# log out and back in for group to take effect
+```
+
+---
+
+## 4. Mac Failover (Miniplex)
+
+A launchd job runs every 5 minutes. If Ursula's bot heartbeat goes stale (>10 min), it starts the bot locally via OrbStack. When Ursula recovers, it stops the local copy automatically.
+
+```bash
+# Install script
+sudo cp infra/ursula/failover/lasombra-failover.sh /usr/local/bin/lasombra-failover.sh
+sudo chmod +x /usr/local/bin/lasombra-failover.sh
+
+# Install launchd plist (runs as user agent)
+cp infra/ursula/launchd/com.mcbn.lasombra-failover.plist \
+   ~/Library/LaunchAgents/com.mcbn.lasombra-failover.plist
+launchctl load ~/Library/LaunchAgents/com.mcbn.lasombra-failover.plist
+```
+
+Logs: `tail -f /tmp/lasombra-failover.log`
+
+**Note:** The failover script contains `MCBN_TOKEN` — treat it as a secret. Do not commit the deployed copy with real credentials. Fill in your real token in the deployed copy — the version in this repo uses a placeholder.
+
+---
+
+## 5. Firewall / Port Summary
+
+| Port | Service | Host |
+|------|---------|------|
+| 5050 | Ursula dashboard | Ursula |
+| 9101 | Stats agent | Ursula, Miniplex, Practica |
+| 8080 | qBittorrent web UI | Ursula |
+| 8123 | Home Assistant | HA box (192.168.0.3) |
+
+All services are LAN-only. Dashboard is not exposed externally.

--- a/infra/ursula/agents/agent_linux.py
+++ b/infra/ursula/agents/agent_linux.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Ursula stats agent (Linux) — serves system metrics on port 9101
+# Deploy to: /home/jkomg/agent.py
+# Dependencies: pip3 install psutil  (or: sudo apt install python3-psutil)
+
+import json, time, os
+import psutil
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+PORT = int(os.getenv('AGENT_PORT', '9101'))
+
+
+def collect():
+    cpu = psutil.cpu_percent(interval=0.5)
+    vm  = psutil.virtual_memory()
+    disks = []
+    for p in psutil.disk_partitions(all=False):
+        try:
+            if p.mountpoint.startswith('/snap/'):
+                continue
+            u = psutil.disk_usage(p.mountpoint)
+            disks.append({
+                'mount':    p.mountpoint,
+                'used_gb':  round(u.used  / 1024**3, 1),
+                'total_gb': round(u.total / 1024**3, 1),
+                'pct':      u.percent,
+            })
+        except PermissionError:
+            continue
+    return {
+        'hostname':     psutil.os.uname().nodename,
+        'cpu_pct':      cpu,
+        'ram_pct':      vm.percent,
+        'ram_used_gb':  round(vm.used  / 1024**3, 1),
+        'ram_total_gb': round(vm.total / 1024**3, 1),
+        'disk':         disks,
+        'uptime_s':     int(time.time() - psutil.boot_time()),
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/stats':
+            body = json.dumps(collect()).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+    def log_message(self, *a): pass
+
+
+HTTPServer(('0.0.0.0', PORT), Handler).serve_forever()

--- a/infra/ursula/agents/agent_mac.py
+++ b/infra/ursula/agents/agent_mac.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Ursula stats agent (macOS) — no external dependencies
+import json, time, os, subprocess
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+PORT = int(os.getenv('AGENT_PORT', '9101'))
+
+def run(cmd):
+    return subprocess.check_output(cmd, shell=True, text=True).strip()
+
+def collect():
+    # CPU
+    try:
+        out = run("top -l 2 -s 0 -n 0 | grep 'CPU usage' | tail -1")
+        idle = float(out.split('% idle')[0].split(', ')[-1].strip())
+        cpu_pct = round(100 - idle, 1)
+    except Exception:
+        cpu_pct = 0.0
+
+    # RAM via vm_stat
+    try:
+        vm = run("vm_stat")
+        page_size = 4096
+        stats = {}
+        for line in vm.split('\n'):
+            if ':' in line:
+                k, v = line.split(':', 1)
+                try:
+                    stats[k.strip()] = int(v.strip().rstrip('.'))
+                except ValueError:
+                    pass
+        used = (stats.get('Pages active', 0) + stats.get('Pages wired down', 0)) * page_size
+        total = int(run("sysctl -n hw.memsize"))
+        ram_pct     = round(used / total * 100, 1)
+        ram_used_gb = round(used  / 1024**3, 1)
+        ram_total_gb= round(total / 1024**3, 1)
+    except Exception:
+        ram_pct = ram_used_gb = ram_total_gb = 0.0
+
+    # Disk — root + /Volumes/* only, skip APFS system volumes
+    disks = []
+    try:
+        for line in run("df -k").split('\n')[1:]:
+            parts = line.split()
+            if len(parts) < 6:
+                continue
+            mount = parts[-1]
+            if mount.startswith('/System/') or mount.startswith('/dev'):
+                continue
+            if parts[0].startswith(('devfs', 'map ')):
+                continue
+            try:
+                disks.append({
+                    'mount':    mount,
+                    'used_gb':  round(int(parts[2]) / 1024**2, 1),
+                    'total_gb': round(int(parts[1]) / 1024**2, 1),
+                    'pct':      float(parts[4].rstrip('%')),
+                })
+            except ValueError:
+                continue
+    except Exception:
+        pass
+
+    # Uptime
+    try:
+        sec = int(run("sysctl -n kern.boottime").split('sec = ')[1].split(',')[0])
+        uptime_s = int(time.time()) - sec
+    except Exception:
+        uptime_s = 0
+
+    return {
+        'hostname':     run("hostname -s"),
+        'cpu_pct':      cpu_pct,
+        'ram_pct':      ram_pct,
+        'ram_used_gb':  ram_used_gb,
+        'ram_total_gb': ram_total_gb,
+        'disk':         disks,
+        'uptime_s':     uptime_s,
+    }
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/stats':
+            body = json.dumps(collect()).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+    def log_message(self, *a): pass
+
+HTTPServer(('0.0.0.0', PORT), Handler).serve_forever()

--- a/infra/ursula/dashboard/.env.example
+++ b/infra/ursula/dashboard/.env.example
@@ -1,0 +1,13 @@
+# Home Assistant
+HA_URL=http://192.168.0.3:8123
+HA_TOKEN=
+
+# MCbN bot heartbeat (production web app)
+MCBN_WEB_URL=https://mcbn.jkomg.us
+MCBN_API_TOKEN=
+
+# qBittorrent (local to Ursula)
+QB_HOST=127.0.0.1
+QB_PORT=8080
+QB_USER=admin
+QB_PASS=

--- a/infra/ursula/dashboard/app.py
+++ b/infra/ursula/dashboard/app.py
@@ -1,0 +1,154 @@
+import os, time, subprocess, requests, psutil
+from flask import Flask, render_template, jsonify
+from dotenv import load_dotenv
+
+load_dotenv()
+app = Flask(__name__)
+
+HA_URL     = os.getenv('HA_URL', 'http://192.168.0.3:8123')
+HA_TOKEN   = os.getenv('HA_TOKEN', '')
+MCBN_URL   = os.getenv('MCBN_WEB_URL', '')
+MCBN_TOKEN = os.getenv('MCBN_API_TOKEN', '')
+QB_HOST    = os.getenv('QB_HOST', '127.0.0.1')
+QB_PORT    = os.getenv('QB_PORT', '8080')
+QB_USER    = os.getenv('QB_USER', 'admin')
+QB_PASS    = os.getenv('QB_PASS', '')
+
+REMOTE_AGENTS = {
+    'miniplex': 'http://192.168.0.4:9101',
+    'practica': 'http://192.168.0.5:9101',
+}
+
+def fetch_agent(url):
+    try:
+        r = requests.get(f'{url}/stats', timeout=3)
+        d = r.json()
+        d['online'] = True
+        return d
+    except Exception:
+        return {'online': False}
+
+def local_stats():
+    cpu = psutil.cpu_percent(interval=0.5)
+    vm  = psutil.virtual_memory()
+    disks = []
+    for p in psutil.disk_partitions(all=False):
+        try:
+            if p.mountpoint.startswith('/snap/'):
+                continue
+            u = psutil.disk_usage(p.mountpoint)
+            disks.append({
+                'mount':    p.mountpoint,
+                'used_gb':  round(u.used  / 1024**3, 1),
+                'total_gb': round(u.total / 1024**3, 1),
+                'pct':      u.percent,
+            })
+        except PermissionError:
+            continue
+    return {
+        'hostname':     'ursula',
+        'cpu_pct':      cpu,
+        'ram_pct':      vm.percent,
+        'ram_used_gb':  round(vm.used  / 1024**3, 1),
+        'ram_total_gb': round(vm.total / 1024**3, 1),
+        'disk':         disks,
+        'uptime_s':     int(time.time() - psutil.boot_time()),
+        'online':       True,
+    }
+
+def fetch_ha():
+    if not HA_TOKEN:
+        return None
+    try:
+        hdrs = {'Authorization': f'Bearer {HA_TOKEN}', 'Content-Type': 'application/json'}
+        r = requests.get(f'{HA_URL}/api/states', headers=hdrs, timeout=5)
+        states = r.json()
+        locks = [s for s in states if s['entity_id'].startswith('lock.')]
+        door_classes = ('door', 'window', 'motion', 'smoke', 'moisture')
+        alerts = [s for s in states
+                  if s['entity_id'].startswith('binary_sensor.')
+                  and s['state'] == 'on'
+                  and s.get('attributes', {}).get('device_class') in door_classes]
+        return {'locks': locks, 'alerts': alerts, 'online': True}
+    except Exception:
+        return {'online': False}
+
+def bot_container_running():
+    try:
+        result = subprocess.run(
+            ['docker', 'ps', '--filter', 'name=lasombra-bot', '--filter', 'status=running', '--format', '{{.Names}}'],
+            capture_output=True, text=True, timeout=5
+        )
+        return 'lasombra-bot' in result.stdout
+    except Exception:
+        return None  # unknown
+
+def fetch_bot():
+    if not MCBN_URL or not MCBN_TOKEN:
+        return None
+    try:
+        r = requests.get(f'{MCBN_URL}/api/bot-heartbeat',
+                         headers={'Authorization': f'Bearer {MCBN_TOKEN}'}, timeout=5)
+        d = r.json()
+        d['online'] = True
+        d['ursula_container'] = bot_container_running()
+        return d
+    except Exception:
+        return {'online': False, 'ursula_container': bot_container_running()}
+
+def fetch_downloads():
+    try:
+        s = requests.Session()
+        s.post(f'http://{QB_HOST}:{QB_PORT}/api/v2/auth/login',
+               data={'username': QB_USER, 'password': QB_PASS}, timeout=3)
+        r = s.get(f'http://{QB_HOST}:{QB_PORT}/api/v2/torrents/info', timeout=3)
+        torrents = r.json()
+        active = [t for t in torrents if t['state'] in ('downloading', 'stalledDL', 'metaDL')]
+        return {'torrents': active, 'total': len(torrents), 'online': True}
+    except Exception:
+        return {'online': False, 'torrents': [], 'total': 0}
+
+def build_alerts(systems, bot, ha):
+    alerts = []
+    for name, s in systems.items():
+        if not s.get('online'):
+            alerts.append({'level': 'danger', 'msg': f'{name.capitalize()} is offline'})
+            continue
+        for d in s.get('disk', []):
+            if d['pct'] > 90:
+                alerts.append({'level': 'danger', 'msg': f'{name.capitalize()} disk {d["mount"]} at {d["pct"]}%'})
+            elif d['pct'] > 80:
+                alerts.append({'level': 'warning', 'msg': f'{name.capitalize()} disk {d["mount"]} at {d["pct"]}%'})
+    if bot:
+        age = bot.get('age_seconds')
+        container = bot.get('ursula_container')
+        if age is None or (isinstance(age, (int, float)) and age > 600):
+            alerts.append({'level': 'danger', 'msg': 'Bot heartbeat stale — bot may be down'})
+        if container is False:
+            alerts.append({'level': 'warning', 'msg': 'Bot container not running on Ursula — failover may be active'})
+    if ha and not ha.get('online'):
+        alerts.append({'level': 'warning', 'msg': 'Home Assistant unreachable'})
+    return alerts
+
+@app.route('/api/status')
+def api_status():
+    systems = {'ursula': local_stats()}
+    for name, url in REMOTE_AGENTS.items():
+        systems[name] = fetch_agent(url)
+    bot = fetch_bot()
+    ha  = fetch_ha()
+    return jsonify({
+        'systems':   systems,
+        'ha':        ha,
+        'bot':       bot,
+        'downloads': fetch_downloads(),
+        'alerts':    build_alerts(systems, bot, ha),
+        'ts':        int(time.time()),
+    })
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5050, debug=False)

--- a/infra/ursula/dashboard/requirements.txt
+++ b/infra/ursula/dashboard/requirements.txt
@@ -1,0 +1,4 @@
+flask
+python-dotenv
+requests
+psutil

--- a/infra/ursula/dashboard/templates/index.html
+++ b/infra/ursula/dashboard/templates/index.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ursula</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <style>
+    body { background: #0d1117; color: #c9d1d9; }
+    .widget { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 1.25rem; }
+    .section-label { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.15em; color: #8b949e; margin-bottom: 0.75rem; }
+    .system-name { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: #8b949e; }
+    .metric-label { font-size: 0.68rem; color: #8b949e; text-transform: uppercase; margin-top: 0.6rem; }
+    .progress { height: 5px; border-radius: 3px; background: #21262d; }
+    .status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 5px; }
+    .dot-green { background: #3fb950; }
+    .dot-red { background: #f85149; }
+    .dot-yellow { background: #d29922; }
+    .uptime-tag { font-size: 0.7rem; color: #8b949e; }
+    .divider-row { display: flex; justify-content: space-between; align-items: center; padding: 0.45rem 0; border-bottom: 1px solid #21262d; }
+    .divider-row:last-child { border-bottom: none; }
+    #ts { font-size: 0.7rem; color: #8b949e; }
+    #countdown { font-size: 0.62rem; color: #484f58; }
+  </style>
+</head>
+<body class="p-3">
+
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h5 class="mb-0"><i class="bi bi-display text-primary me-2"></i>Ursula</h5>
+      <small class="text-muted">Operations Dashboard</small>
+    </div>
+    <div class="text-end">
+      <div id="ts">Loading...</div>
+      <div id="countdown"></div>
+    </div>
+  </div>
+
+  <div id="alerts-bar" class="mb-3"></div>
+
+  <div class="section-label">Systems</div>
+  <div class="row g-3 mb-3" id="systems-row"></div>
+
+  <div class="row g-3 mb-3">
+    <div class="col-md-6">
+      <div class="widget h-100">
+        <div class="section-label"><i class="bi bi-robot me-1"></i>MCbN Bot</div>
+        <div id="bot-widget">Loading...</div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="widget h-100">
+        <div class="section-label"><i class="bi bi-house-fill me-1"></i>Home Assistant</div>
+        <div id="ha-widget">Loading...</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="widget">
+    <div class="section-label"><i class="bi bi-arrow-down-circle me-1"></i>Downloads</div>
+    <div id="dl-content">Loading...</div>
+  </div>
+
+  <script>
+  const INTERVAL = 30;
+  let countdown = INTERVAL;
+
+  const dot = ok => `<span class="status-dot ${ok ? 'dot-green' : 'dot-red'}"></span>`;
+
+  function bar(pct) {
+    const cls = pct > 90 ? 'bg-danger' : pct > 70 ? 'bg-warning' : 'bg-success';
+    return `<div class="progress"><div class="progress-bar ${cls}" style="width:${pct}%"></div></div>`;
+  }
+
+  function uptime(s) {
+    if (s < 3600) return Math.floor(s / 60) + 'm';
+    if (s < 86400) return Math.floor(s / 3600) + 'h';
+    return Math.floor(s / 86400) + 'd ' + Math.floor((s % 86400) / 3600) + 'h';
+  }
+
+  function speed(bps) {
+    if (bps < 1024) return bps + ' B/s';
+    if (bps < 1048576) return (bps / 1024).toFixed(1) + ' KB/s';
+    return (bps / 1048576).toFixed(1) + ' MB/s';
+  }
+
+  function renderSystems(systems) {
+    const order = ['ursula', 'miniplex', 'practica'];
+    document.getElementById('systems-row').innerHTML = order.map(name => {
+      const s = systems[name] || {};
+      if (!s.online) return `
+        <div class="col-md-4"><div class="widget">
+          <div class="d-flex align-items-center mb-1">${dot(false)}<span class="system-name">${name}</span></div>
+          <small class="text-muted">Offline</small>
+        </div></div>`;
+      const diskHtml = (s.disk || []).map(d =>
+        `<div class="metric-label">Disk <span class="text-muted">${d.mount}</span> &nbsp;<strong class="text-light">${d.used_gb}/${d.total_gb} GB</strong></div>${bar(d.pct)}`
+      ).join('');
+      return `<div class="col-md-4"><div class="widget">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <div>${dot(true)}<span class="system-name">${s.hostname || name}</span></div>
+          <span class="uptime-tag">${uptime(s.uptime_s || 0)}</span>
+        </div>
+        <div class="metric-label">CPU &nbsp;<strong class="text-light">${s.cpu_pct}%</strong></div>${bar(s.cpu_pct)}
+        <div class="metric-label">RAM &nbsp;<strong class="text-light">${s.ram_used_gb}/${s.ram_total_gb} GB</strong></div>${bar(s.ram_pct)}
+        ${diskHtml}
+      </div></div>`;
+    }).join('');
+  }
+
+  function renderAlerts(alerts) {
+    const el = document.getElementById('alerts-bar');
+    if (!alerts || !alerts.length) { el.innerHTML = ''; return; }
+    el.innerHTML = alerts.map(a =>
+      `<div class="alert alert-${a.level} py-2 px-3 mb-2" style="font-size:0.85rem;">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>${a.msg}
+      </div>`
+    ).join('');
+  }
+
+  function renderBot(bot) {
+    const el = document.getElementById('bot-widget');
+    if (!bot) { el.innerHTML = '<small class="text-muted">Not configured</small>'; return; }
+    if (!bot.online) { el.innerHTML = dot(false) + ' <span class="text-danger">Unreachable</span>'; return; }
+    const age = bot.age_seconds;
+    const fresh = age !== null && age < 600;
+    const container = bot.ursula_container;
+    const source = container === true ? '<span class="badge bg-success ms-2">Primary (Ursula)</span>'
+                 : container === false ? '<span class="badge bg-warning text-dark ms-2">Failover active</span>'
+                 : '<span class="badge bg-secondary ms-2">Source unknown</span>';
+    el.innerHTML = `
+      <div class="mb-1">${dot(fresh)} <strong>${fresh ? 'Connected' : 'Stale'}</strong>${source}</div>
+      <small class="text-muted">${age !== null ? 'Last beat: ' + Math.floor(age / 60) + 'm ago' : 'No heartbeat on record'}</small>`;
+  }
+
+  function renderHA(ha) {
+    const el = document.getElementById('ha-widget');
+    if (!ha) { el.innerHTML = '<small class="text-muted">Not configured</small>'; return; }
+    if (!ha.online) { el.innerHTML = dot(false) + ' <span class="text-danger">Unreachable</span>'; return; }
+    const locks = ha.locks || [], alerts = ha.alerts || [];
+    if (!locks.length && !alerts.length) {
+      el.innerHTML = dot(true) + ' <span class="text-success">All clear</span>';
+      return;
+    }
+    el.innerHTML = [
+      ...locks.map(l => {
+        const locked = l.state === 'locked';
+        const name = (l.attributes && l.attributes.friendly_name) || l.entity_id;
+        return `<div class="divider-row">
+          <span><i class="bi bi-${locked ? 'lock-fill' : 'unlock-fill'} text-${locked ? 'success' : 'danger'} me-2"></i>${name}</span>
+          <span class="badge bg-${locked ? 'success' : 'danger'}">${l.state}</span>
+        </div>`;
+      }),
+      ...alerts.map(a => {
+        const name = (a.attributes && a.attributes.friendly_name) || a.entity_id;
+        return `<div class="divider-row">
+          <span><i class="bi bi-exclamation-triangle-fill text-warning me-2"></i>${name}</span>
+          <span class="badge bg-warning text-dark">alert</span>
+        </div>`;
+      }),
+    ].join('');
+  }
+
+  function renderDownloads(dl) {
+    const el = document.getElementById('dl-content');
+    if (!dl || !dl.online) { el.innerHTML = '<small class="text-muted">qBittorrent unreachable</small>'; return; }
+    const t = dl.torrents || [];
+    if (!t.length) {
+      el.innerHTML = `<small class="text-muted">No active downloads &mdash; ${dl.total} total</small>`;
+      return;
+    }
+    el.innerHTML = t.map(tor => {
+      const pct = Math.round((tor.progress || 0) * 100);
+      return `<div class="mb-2">
+        <div class="d-flex justify-content-between">
+          <small class="text-light" style="max-width:80%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${tor.name}</small>
+          <small class="text-muted">${speed(tor.dlspeed || 0)}</small>
+        </div>
+        <div class="progress" style="height:4px;"><div class="progress-bar" style="width:${pct}%"></div></div>
+        <small class="text-muted">${pct}%</small>
+      </div>`;
+    }).join('');
+  }
+
+  async function refresh() {
+    try {
+      const data = await fetch('/api/status').then(r => r.json());
+      renderAlerts(data.alerts);
+      renderSystems(data.systems);
+      renderBot(data.bot);
+      renderHA(data.ha);
+      renderDownloads(data.downloads);
+      document.getElementById('ts').textContent = 'Updated ' + new Date(data.ts * 1000).toLocaleTimeString();
+      countdown = INTERVAL;
+    } catch (e) {
+      document.getElementById('ts').textContent = 'Update failed';
+    }
+  }
+
+  setInterval(() => {
+    countdown--;
+    document.getElementById('countdown').textContent = 'Next refresh in ' + countdown + 's';
+    if (countdown <= 0) { countdown = INTERVAL; refresh(); }
+  }, 1000);
+
+  refresh();
+  </script>
+</body>
+</html>

--- a/infra/ursula/failover/lasombra-failover.sh
+++ b/infra/ursula/failover/lasombra-failover.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Lasombra bot failover — starts local OrbStack bot if Ursula's bot heartbeat goes stale.
+# Stops local bot automatically when Ursula recovers.
+
+export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+
+MCBN_URL="https://mcbn.jkomg.us"
+MCBN_TOKEN="YOUR_MCBN_API_TOKEN_HERE"
+BOT_DIR="/Users/jasonkennedy/Projects/mcbn-xp-tracker/apps/bot"
+STALE_SECONDS=600   # 10 min — matches Ursula health check threshold
+LOG_PREFIX="$(date -u +"%Y-%m-%dT%H:%M:%SZ") [lasombra-failover]"
+
+local_bot_running() {
+  docker ps --filter name=lasombra-bot --filter status=running --format '{{.Names}}' 2>/dev/null | grep -q lasombra-bot
+}
+
+# Fetch heartbeat
+response=$(curl -sf "${MCBN_URL}/api/bot-heartbeat" \
+  -H "Authorization: Bearer ${MCBN_TOKEN}" \
+  --max-time 10 2>/dev/null || echo "")
+
+if [[ -z "$response" ]]; then
+  echo "${LOG_PREFIX} Could not reach web app — skipping"
+  exit 0
+fi
+
+age=$(echo "$response" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('age_seconds') if d.get('age_seconds') is not None else -1)" \
+  2>/dev/null || echo "-1")
+
+if [[ "$age" == "-1" || "$age" -gt "$STALE_SECONDS" ]]; then
+  if local_bot_running; then
+    echo "${LOG_PREFIX} Heartbeat stale (${age}s) — local failover already running"
+  else
+    echo "${LOG_PREFIX} Heartbeat stale (${age}s) — starting local failover bot"
+    cd "$BOT_DIR" && docker compose up -d
+  fi
+else
+  if local_bot_running; then
+    echo "${LOG_PREFIX} Ursula bot recovered (${age}s) — stopping local failover"
+    cd "$BOT_DIR" && docker compose down
+  else
+    echo "${LOG_PREFIX} OK (${age}s)"
+  fi
+fi

--- a/infra/ursula/launchd/com.mcbn.lasombra-failover.plist
+++ b/infra/ursula/launchd/com.mcbn.lasombra-failover.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mcbn.lasombra-failover</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/lasombra-failover.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/lasombra-failover.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/lasombra-failover.log</string>
+</dict>
+</plist>

--- a/infra/ursula/launchd/com.ursula.agent.plist
+++ b/infra/ursula/launchd/com.ursula.agent.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ursula.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/Users/jkomg/agent.py</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/ursula-agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ursula-agent.log</string>
+</dict>
+</plist>

--- a/infra/ursula/systemd/ursula-agent.service
+++ b/infra/ursula/systemd/ursula-agent.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Ursula Stats Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /home/jkomg/agent.py
+Restart=always
+RestartSec=5
+User=jkomg
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/ursula/systemd/ursula-dashboard.service
+++ b/infra/ursula/systemd/ursula-dashboard.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ursula Operations Dashboard
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/jkomg/ursula
+EnvironmentFile=/home/jkomg/ursula/.env
+ExecStart=/home/jkomg/ursula/venv/bin/python app.py
+Restart=always
+RestartSec=5
+User=jkomg
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `infra/ursula/` with everything needed to rebuild the home server stack from scratch
- Dashboard app (Flask/port 5050): system stats, HA locks, MCbN bot heartbeat, qBittorrent downloads
- Stats agents for Linux (`agent_linux.py`, used on Ursula + Practica) and macOS (`agent_mac.py`, used on Miniplex) — both serve on port 9101
- systemd services for Ursula dashboard and Practica agent
- launchd plists for Miniplex stats agent and Mac failover bot
- Failover script: starts local OrbStack bot when Ursula heartbeat goes stale >10min, stops it when Ursula recovers
- `.env.example` documenting all required env vars (no secrets)
- README runbook with step-by-step rebuild commands for all three machines

## Notes

- Real `MCBN_API_TOKEN` redacted from failover script (repo is public) — fill it in on the deployed copy
- `.env.example` force-added since `.gitignore` blocks `**/.env.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)