### PR TITLE
Fix prod crash-loop: add character_drafts migration to main

### DIFF
--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -1,6 +1,7 @@
 """SQLAlchemy models for MCbN XP Tracker."""
 
-from datetime import datetime
+import uuid
+from datetime import datetime, timezone
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import DateTime, Integer, String, Boolean, Text
@@ -196,6 +197,27 @@ class DbReminderPreference(db.Model):
     opt_out = db.Column(Boolean, default=False, nullable=False)
     snooze_until_epoch = db.Column(Integer, default=0, nullable=False)
     updated_at = db.Column(String(20), default='')
+
+
+class CharacterDraft(db.Model):
+    """In-progress and submitted character creation drafts."""
+    __tablename__ = 'character_drafts'
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    player_discord_id = db.Column(db.String(32), nullable=False, index=True)
+    character_name = db.Column(db.String(200), nullable=True)
+    # draft | submitted | revision_requested | approved
+    status = db.Column(db.String(32), nullable=False, default='draft', index=True)
+    is_spc = db.Column(db.Boolean, nullable=False, default=False)
+    ticket_channel_id = db.Column(db.String(32), nullable=True)
+    character_data = db.Column(db.Text, nullable=True)  # JSON blob
+    roster_character_id = db.Column(db.Integer, db.ForeignKey('characters.id'), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False,
+                           default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(db.DateTime, nullable=True,
+                           onupdate=lambda: datetime.now(timezone.utc))
+    submitted_at = db.Column(db.DateTime, nullable=True)
+    approved_at = db.Column(db.DateTime, nullable=True)
+    approved_by = db.Column(db.String(32), nullable=True)
 
 
 class DbCharacterBackground(db.Model):

--- a/apps/web/migrations/versions/cc1a2d4f8e9b_add_character_drafts_table.py
+++ b/apps/web/migrations/versions/cc1a2d4f8e9b_add_character_drafts_table.py
@@ -1,0 +1,55 @@
+"""add character drafts table
+
+Revision ID: cc1a2d4f8e9b
+Revises: b5c8d2e1a9f6
+Create Date: 2026-05-21
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cc1a2d4f8e9b'
+down_revision = 'b5c8d2e1a9f6'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
+def upgrade():
+    if _table_exists('character_drafts'):
+        return
+    op.create_table(
+        'character_drafts',
+        sa.Column('id', sa.String(length=36), nullable=False),
+        sa.Column('player_discord_id', sa.String(length=32), nullable=False),
+        sa.Column('character_name', sa.String(length=200), nullable=True),
+        sa.Column('status', sa.String(length=32), nullable=False, server_default='draft'),
+        sa.Column('is_spc', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('ticket_channel_id', sa.String(length=32), nullable=True),
+        sa.Column('character_data', sa.Text(), nullable=True),
+        sa.Column('roster_character_id', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('submitted_at', sa.DateTime(), nullable=True),
+        sa.Column('approved_at', sa.DateTime(), nullable=True),
+        sa.Column('approved_by', sa.String(length=32), nullable=True),
+        sa.ForeignKeyConstraint(['roster_character_id'], ['characters.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_character_drafts_player', 'character_drafts', ['player_discord_id'])
+    op.create_index('ix_character_drafts_status', 'character_drafts', ['status'])
+
+
+def downgrade():
+    op.drop_index('ix_character_drafts_status', table_name='character_drafts')
+    op.drop_index('ix_character_drafts_player', table_name='character_drafts')
+    op.drop_table('character_drafts')


### PR DESCRIPTION
## Summary
- **Site is down** — all Cloud Run workers crash-loop with `Error: Can't locate revision identified by 'cc1a2d4f8e9b'`
- Root cause: the `character_drafts` migration was applied to the production Turso DB from a local dev run of `feat/character-creator`, but the migration file and `CharacterDraft` model were never merged to `main`
- Fix: adds `cc1a2d4f8e9b_add_character_drafts_table.py` and the `CharacterDraft` SQLAlchemy model to main

## Test plan
- [ ] Deploy succeeds and workers start without migration errors
- [ ] Site becomes accessible again at mcbn.jkomg.us

🤖 Generated with [Claude Code](https://claude.com/claude-code)