### PR TITLE
Add cubby sync: auto-retire characters when cubbies disappear, backfill channel IDs

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -143,6 +143,19 @@ WIKI_SYNC_TIMEZONE=America/Chicago
 # How often to check whether the scheduled time has arrived (default 5 min)
 WIKI_SYNC_INTERVAL_MS=300000
 
+# Cubby sync: scans Character Cubby channels, backfills ticket_channel_id by name match,
+# and auto-retires characters whose cubby is deleted or moved to the Retired Characters category.
+# Set CUBBY_SYNC_ENABLED=true to activate; requires DISCORD_GUILD_ID (or CUBBY_SYNC_GUILD_ID).
+CUBBY_SYNC_ENABLED=false
+# How often to scan (default 1 hour)
+CUBBY_SYNC_INTERVAL_MS=3600000
+# Guild to scan (defaults to DISCORD_GUILD_ID)
+CUBBY_SYNC_GUILD_ID=
+# Optional staff channel to post a summary when characters are retired or backfilled
+CUBBY_SYNC_STAFF_CHANNEL_ID=
+# Discord category ID for the "Retired Characters" category (default: 1225070632799043685)
+CUBBY_RETIRED_CATEGORY_ID=1225070632799043685
+
 # ---------------------------------------------------------------------------
 # discord-wiki-sync (one-time script — not used by the running bot)
 # Run: npm run wiki-sync:dry-run  /  npm run wiki-sync

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -16,6 +16,7 @@ import type { CommandContext } from '../discord';
 import { config } from '../config';
 import { liveConfig } from '../liveConfig';
 import { buildCubbyChannelMap, getChannelsInCubbyCategories, normalizeChannelName } from '../services/cubbyChannels';
+import { CubbySyncWorker } from '../services/cubbySyncWorker';
 import { errorToMessage, logEvent } from '../logger';
 import { startApproveWizard, findPlayerInChannel, findLatestPdf } from '../approveWizard';
 import { startEditWizard } from '../editWizard';
@@ -79,6 +80,11 @@ export const data = new SlashCommandBuilder()
           .setRequired(false)
           .setAutocomplete(true),
       ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('sync-cubbies')
+      .setDescription('Scan cubby channels, backfill channel IDs, and retire characters whose cubby is gone (staff only)'),
   )
   .addSubcommand((s) =>
     s
@@ -189,6 +195,43 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
     });
     const replyMsg = await interaction.fetchReply();
     pendingDeletes.set(replyMsg.id, characterName);
+    return;
+  }
+
+  if (sub === 'sync-cubbies') {
+    if (!config.testerDiscordIds.has(interaction.user.id)) {
+      await interaction.reply({ content: 'This command is restricted to staff.', ephemeral: true });
+      return;
+    }
+    await interaction.deferReply({ ephemeral: true });
+    try {
+      const worker = new CubbySyncWorker(ctx.adapter, ctx.client, {
+        enabled: true,
+        intervalMs: config.cubbySyncIntervalMs,
+        guildId: config.cubbySyncGuildId,
+        staffChannelId: config.cubbySyncStaffChannelId,
+        retiredCategoryId: config.cubbyRetiredCategoryId,
+      });
+      const report = await worker.runSync();
+      const lines: string[] = [
+        `**Cubby Sync Complete** — scanned ${report.scannedCharacters} character(s)`,
+      ];
+      if (report.backfilled.length > 0) {
+        lines.push(`\nChannel ID backfilled (${report.backfilled.length}): ${report.backfilled.map((b) => b.name).join(', ')}`);
+      }
+      if (report.retired.length > 0) {
+        lines.push(`\nRetired (${report.retired.length}): ${report.retired.map((r) => `${r.name} (${r.reason})`).join(', ')}`);
+      }
+      if (report.errors.length > 0) {
+        lines.push(`\nErrors (${report.errors.length}): ${report.errors.map((e) => `${e.name}: ${e.error}`).join(', ')}`);
+      }
+      if (report.backfilled.length === 0 && report.retired.length === 0 && report.errors.length === 0) {
+        lines.push('\nNo changes — all cubbies are in order.');
+      }
+      await interaction.editReply({ content: lines.join('\n').slice(0, 2000) });
+    } catch (err) {
+      await interaction.editReply({ content: `Sync failed: ${errorToMessage(err)}` });
+    }
     return;
   }
 

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -155,6 +155,11 @@ const envSchema = z.object({
   CC_SUBMISSION_NOTIFIER_ENABLED: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_INTERVAL_MS: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_LOOKBACK_SECONDS: z.string().optional(),
+  CUBBY_SYNC_ENABLED: z.string().optional(),
+  CUBBY_SYNC_INTERVAL_MS: z.string().optional(),
+  CUBBY_SYNC_GUILD_ID: z.string().optional(),
+  CUBBY_SYNC_STAFF_CHANNEL_ID: z.string().optional(),
+  CUBBY_RETIRED_CATEGORY_ID: z.string().optional(),
 });
 
 // Strip empty strings so optional fields behave as if absent.
@@ -368,6 +373,11 @@ export const config = {
     86_400,
     'CC_SUBMISSION_NOTIFIER_LOOKBACK_SECONDS',
   ),
+  cubbySyncEnabled: (env.CUBBY_SYNC_ENABLED ?? 'false').toLowerCase() === 'true',
+  cubbySyncIntervalMs: parsePositiveInt(env.CUBBY_SYNC_INTERVAL_MS, 3_600_000, 'CUBBY_SYNC_INTERVAL_MS'),
+  cubbySyncGuildId: env.CUBBY_SYNC_GUILD_ID ?? env.DISCORD_GUILD_ID ?? env.TEST_GUILD_ID ?? '',
+  cubbySyncStaffChannelId: env.CUBBY_SYNC_STAFF_CHANNEL_ID ?? '',
+  cubbyRetiredCategoryId: env.CUBBY_RETIRED_CATEGORY_ID ?? '1225070632799043685',
 };
 
 if (config.testRequesterDiscordId) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -52,6 +52,7 @@ import {
 } from './services/huntConsequenceMonitor';
 import { ConfigSyncWorker } from './services/configSyncWorker';
 import { BotHeartbeatService } from './services/botHeartbeatService';
+import { CubbySyncWorker } from './services/cubbySyncWorker';
 import { liveConfig } from './liveConfig';
 import { BackgroundBlankReleaseService } from './services/backgroundBlankReleaseService';
 
@@ -200,6 +201,14 @@ void applyStartupConfigOverrides().then(() => {
     intervalMs: config.wikiSyncIntervalMs,
   });
 
+  const cubbySyncWorker = new CubbySyncWorker(adapter, client, {
+    enabled: config.cubbySyncEnabled,
+    intervalMs: config.cubbySyncIntervalMs,
+    guildId: config.cubbySyncGuildId,
+    staffChannelId: config.cubbySyncStaffChannelId,
+    retiredCategoryId: config.cubbyRetiredCategoryId,
+  });
+
   const configSyncWorker = new ConfigSyncWorker(adapter, config.configSyncIntervalMs);
   const wikiSyncCapable = Boolean(config.discordGuildId);
   const botHeartbeatService = new BotHeartbeatService(
@@ -245,6 +254,7 @@ void applyStartupConfigOverrides().then(() => {
     passageOfTimeService.start();
     sheetsReconcileService.start();
     wikiSyncScheduler.start();
+    cubbySyncWorker.start();
     characterSubmissionNotifier.start();
     startCubbyChannelMonitor(client);
     startCharacterTicketMonitor(client, {

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -38,6 +38,9 @@ export interface TrackerAdapter {
   getClaimContext(requester: RequesterContext, opts?: { forceRefresh?: boolean }): Promise<ClaimContext>;
   getActiveRoster(): Promise<{ characters: string[] }>;
   getActiveRosterWithIds(): Promise<{ characters: Array<{ name: string; discordId: string | null }> }>;
+  getActiveRosterWithChannelIds(): Promise<{ characters: Array<{ name: string; ticketChannelId: string | null }> }>;
+  setCharacterStatus(name: string, status: string, requesterName: string): Promise<{ ok: boolean; message: string }>;
+  updateCharacterChannelId(name: string, ticketChannelId: string | null, requesterName: string): Promise<{ ok: boolean; message: string }>;
   getBackgroundStatus(characterName: string, requester: RequesterContext): Promise<BackgroundStatusResponse | null>;
   blankBackground(
     requester: RequesterContext,
@@ -214,6 +217,10 @@ const activeRosterSchema = z.object({
 
 const activeRosterWithIdsSchema = z.object({
   characters: z.array(z.object({ name: z.string(), discordId: z.string().nullable() })),
+});
+
+const activeRosterWithChannelIdsSchema = z.object({
+  characters: z.array(z.object({ name: z.string(), ticketChannelId: z.string().nullable() })),
 });
 
 const claimReminderTargetsSchema = z.object({
@@ -439,6 +446,51 @@ export class WebAppAdapter implements TrackerAdapter {
     }
     const raw = await resp.json();
     return activeRosterWithIdsSchema.parse(raw);
+  }
+
+  async getActiveRosterWithChannelIds(): Promise<{ characters: Array<{ name: string; ticketChannelId: string | null }> }> {
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/meta/active-roster?includeChannelIds=1`, {
+      headers: this.readAuthHeaders(),
+    }).catch(() => null);
+    if (!resp) throw new Error('Unable to reach web app active-roster API.');
+    if (!resp.ok) throw new Error(`Web app active-roster API failed (${resp.status})`);
+    const raw = await resp.json();
+    return activeRosterWithChannelIdsSchema.parse(raw);
+  }
+
+  async setCharacterStatus(name: string, status: string, requesterName: string): Promise<{ ok: boolean; message: string }> {
+    const resp = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/character/${encodeURIComponent(name)}/status`,
+      {
+        method: 'PUT',
+        headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, requesterDiscordName: requesterName }),
+      },
+    ).catch(() => null);
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (resp.status === 404) return { ok: false, message: `Character "${name}" not found.` };
+    if (!resp.ok) {
+      const preview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      return { ok: false, message: preview || `API rejected request (status ${resp.status}).` };
+    }
+    return { ok: true, message: `Character "${name}" status set to "${status}".` };
+  }
+
+  async updateCharacterChannelId(name: string, ticketChannelId: string | null, requesterName: string): Promise<{ ok: boolean; message: string }> {
+    const resp = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/roster/character/${encodeURIComponent(name)}`,
+      {
+        method: 'PATCH',
+        headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticket_channel_id: ticketChannelId, requesterDiscordName: requesterName }),
+      },
+    ).catch(() => null);
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (!resp.ok) {
+      const preview = await resp.text().then((v) => v.slice(0, 160)).catch(() => '');
+      return { ok: false, message: preview || `API rejected request (status ${resp.status}).` };
+    }
+    return { ok: true, message: `Channel ID updated for "${name}".` };
   }
 
   async getBackgroundStatus(characterName: string, requester: RequesterContext): Promise<BackgroundStatusResponse | null> {

--- a/apps/bot/src/services/cubbySyncWorker.ts
+++ b/apps/bot/src/services/cubbySyncWorker.ts
@@ -1,0 +1,204 @@
+/**
+ * Cubby Sync Worker
+ *
+ * Periodically scans Character Cubby Discord channels, diffs against the
+ * active roster, and:
+ *   - Backfills `ticket_channel_id` on characters whose cubby is found by name
+ *   - Retires characters whose cubby channel no longer exists or has been moved
+ *     to the "Retired Characters" category
+ */
+
+import { ChannelType, type Client } from 'discord.js';
+import { errorToMessage, logEvent } from '../logger';
+import type { TrackerAdapter } from './adapter';
+import { CUBBY_CATEGORY_NAMES, normalizeChannelName } from './cubbyChannels';
+
+type CubbySyncConfig = {
+  enabled: boolean;
+  intervalMs: number;
+  guildId: string;
+  staffChannelId: string;
+  retiredCategoryId: string;
+};
+
+export type CubbySyncReport = {
+  scannedCharacters: number;
+  backfilled: Array<{ name: string; channelId: string }>;
+  retired: Array<{ name: string; reason: string }>;
+  errors: Array<{ name: string; error: string }>;
+};
+
+export class CubbySyncWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(
+    private readonly adapter: TrackerAdapter,
+    private readonly client: Client,
+    private readonly cfg: CubbySyncConfig,
+  ) {}
+
+  start() {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.cfg.intervalMs);
+    this.timer.unref();
+    logEvent('info', 'cubby_sync_worker_started', { intervalMs: this.cfg.intervalMs });
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async runSync(): Promise<CubbySyncReport> {
+    const report: CubbySyncReport = {
+      scannedCharacters: 0,
+      backfilled: [],
+      retired: [],
+      errors: [],
+    };
+
+    const guild = await this.client.guilds.fetch(this.cfg.guildId).catch(() => null);
+    if (!guild) {
+      throw new Error(`Cubby sync: could not fetch guild ${this.cfg.guildId}`);
+    }
+
+    // Fetch all channels once
+    const allChannels = await guild.channels.fetch();
+
+    // Build sets: parent category IDs for active cubbies
+    const activeCubbyParentIds = new Set<string>();
+    for (const channel of allChannels.values()) {
+      if (!channel || channel.type !== ChannelType.GuildCategory) continue;
+      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+        activeCubbyParentIds.add(channel.id);
+      }
+    }
+
+    // Build:
+    //  activeCubbyChannelIds: Set<channelId> — channels inside active cubby categories
+    //  activeCubbyNameMap:    Map<normalizedName, channelId> — for name-based backfill
+    //  retiredCubbyChannelIds: Set<channelId> — channels inside the retired category
+    const activeCubbyChannelIds = new Set<string>();
+    const activeCubbyNameMap = new Map<string, string>();
+    const retiredCubbyChannelIds = new Set<string>();
+
+    for (const channel of allChannels.values()) {
+      if (!channel || channel.type !== ChannelType.GuildText) continue;
+      const parentId = channel.parentId ?? '';
+      if (activeCubbyParentIds.has(parentId)) {
+        activeCubbyChannelIds.add(channel.id);
+        activeCubbyNameMap.set(normalizeChannelName(channel.name), channel.id);
+      } else if (parentId === this.cfg.retiredCategoryId) {
+        retiredCubbyChannelIds.add(channel.id);
+      }
+    }
+
+    // Fetch active roster with channel IDs
+    const roster = await this.adapter.getActiveRosterWithChannelIds();
+    report.scannedCharacters = roster.characters.length;
+
+    for (const { name, ticketChannelId } of roster.characters) {
+      try {
+        if (ticketChannelId) {
+          // Character has a known cubby channel ID — check its current location
+          if (activeCubbyChannelIds.has(ticketChannelId)) {
+            // Still in an active cubby category — nothing to do
+            continue;
+          }
+
+          // Channel moved to retired category or deleted entirely
+          const reason = retiredCubbyChannelIds.has(ticketChannelId)
+            ? 'cubby moved to Retired Characters category'
+            : 'cubby channel no longer exists';
+
+          const result = await this.adapter.setCharacterStatus(name, 'retired', 'cubby-sync');
+          if (result.ok) {
+            report.retired.push({ name, reason });
+            logEvent('info', 'cubby_sync_retired', { name, reason });
+          } else {
+            report.errors.push({ name, error: result.message });
+          }
+        } else {
+          // No channel ID recorded — attempt name-based backfill
+          const normalized = normalizeChannelName(name);
+          const matchedChannelId = activeCubbyNameMap.get(normalized);
+          if (matchedChannelId) {
+            const result = await this.adapter.updateCharacterChannelId(name, matchedChannelId, 'cubby-sync');
+            if (result.ok) {
+              report.backfilled.push({ name, channelId: matchedChannelId });
+              logEvent('info', 'cubby_sync_backfilled', { name, channelId: matchedChannelId });
+            } else {
+              report.errors.push({ name, error: result.message });
+            }
+          }
+          // No match by name and no existing ID — skip (can't confirm retirement)
+        }
+      } catch (err) {
+        report.errors.push({ name, error: errorToMessage(err) });
+      }
+    }
+
+    return report;
+  }
+
+  private async tick() {
+    if (!this.cfg.enabled) return;
+    if (this.running) return;
+    this.running = true;
+    try {
+      const report = await this.runSync();
+      logEvent('info', 'cubby_sync_complete', {
+        scanned: report.scannedCharacters,
+        backfilled: report.backfilled.length,
+        retired: report.retired.length,
+        errors: report.errors.length,
+      });
+
+      if (this.cfg.staffChannelId && (report.backfilled.length > 0 || report.retired.length > 0 || report.errors.length > 0)) {
+        await this._postSummary(report);
+      }
+    } catch (err) {
+      logEvent('warn', 'cubby_sync_error', { error: errorToMessage(err) });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async _postSummary(report: CubbySyncReport) {
+    try {
+      const guild = await this.client.guilds.fetch(this.cfg.guildId).catch(() => null);
+      if (!guild) return;
+      const channel = await guild.channels.fetch(this.cfg.staffChannelId).catch(() => null);
+      if (!channel || !('send' in channel)) return;
+
+      const lines: string[] = ['**Cubby Sync Report**'];
+      if (report.retired.length > 0) {
+        lines.push(`\n**Retired (${report.retired.length}):**`);
+        for (const { name, reason } of report.retired) {
+          lines.push(`• ${name} — ${reason}`);
+        }
+      }
+      if (report.backfilled.length > 0) {
+        lines.push(`\n**Channel ID backfilled (${report.backfilled.length}):**`);
+        for (const { name } of report.backfilled) {
+          lines.push(`• ${name}`);
+        }
+      }
+      if (report.errors.length > 0) {
+        lines.push(`\n**Errors (${report.errors.length}):**`);
+        for (const { name, error } of report.errors) {
+          lines.push(`• ${name}: ${error}`);
+        }
+      }
+
+      const content = lines.join('\n').slice(0, 2000);
+      await (channel as { send: (opts: { content: string }) => Promise<unknown> }).send({ content });
+    } catch (err) {
+      logEvent('warn', 'cubby_sync_summary_post_failed', { error: errorToMessage(err) });
+    }
+  }
+}

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -334,6 +334,16 @@ def active_roster():
         return backend
     characters = db_service.get_active_characters()
     characters.sort(key=lambda c: c.character_name.lower())
+    if request.args.get('includeChannelIds') == '1':
+        return jsonify({
+            'characters': [
+                {
+                    'name': c.character_name,
+                    'ticketChannelId': c.ticket_channel_id or None,
+                }
+                for c in characters
+            ]
+        })
     if request.args.get('includeDiscordIds') == '1':
         return jsonify({
             'characters': [
@@ -1392,7 +1402,7 @@ def get_character_api(name):
 @require_bot_scope('write')
 @_limit('60 per hour')
 def update_character_api(name):
-    """Update clan, age_category, and/or sect for an existing character."""
+    """Update clan, age_category, sect, and/or ticket_channel_id for an existing character."""
     from app.models import CLANS, AGE_CATEGORIES, SECTS
 
     char = db_service.get_character(name)
@@ -1404,6 +1414,8 @@ def update_character_api(name):
     for field in ('clan', 'age_category', 'sect'):
         if field in data:
             updates[field] = (data[field] or '').strip()
+    if 'ticket_channel_id' in data:
+        updates['ticket_channel_id'] = (data['ticket_channel_id'] or '').strip() or None
 
     if not updates:
         return jsonify({'error': 'No updatable fields provided'}), 400


### PR DESCRIPTION
## Summary

- **Web API**: `GET /meta/active-roster?includeChannelIds=1` returns `{name, ticketChannelId}` per active character; `PATCH /roster/character/<name>` now accepts `ticket_channel_id`
- **Bot adapter**: three new methods — `getActiveRosterWithChannelIds()`, `setCharacterStatus()`, `updateCharacterChannelId()`
- **`CubbySyncWorker`** (new service): periodic scan that:
  - Retires characters whose `ticket_channel_id` points to a deleted channel or one moved to the Retired Characters category (`1225070632799043685`)
  - Backfills `ticket_channel_id` for characters with no recorded channel ID by normalised name-match against active cubby categories
  - Optionally posts a summary to a configured staff channel when changes are made
- **`/lasombra sync-cubbies`**: manual on-demand scan with an ephemeral reply showing what was retired/backfilled/errored
- Worker starts automatically on bot ready, controlled by `CUBBY_SYNC_ENABLED`
- Documents `CUBBY_SYNC_ENABLED`, `CUBBY_SYNC_INTERVAL_MS`, `CUBBY_SYNC_GUILD_ID`, `CUBBY_SYNC_STAFF_CHANNEL_ID`, `CUBBY_RETIRED_CATEGORY_ID` in `.env.example`

## Test plan

- [ ] Set `CUBBY_SYNC_ENABLED=false` — worker starts but skips ticks
- [ ] Run `/lasombra sync-cubbies` in Discord — returns ephemeral report; characters with cubbies in active categories untouched, characters with cubbies in retired category or with deleted channels retired
- [ ] Run `/lasombra sync-cubbies` for a character with no `ticket_channel_id` but a matching channel name — channel ID backfilled, no status change
- [ ] Verify `GET /meta/active-roster?includeChannelIds=1` returns `ticketChannelId` field
- [ ] Verify `PATCH /roster/character/<name>` with `{"ticket_channel_id": "..."}` updates the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)