### PR TITLE
Use guild command registration by default; configurable lasombra command name

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -156,6 +156,10 @@ CUBBY_SYNC_STAFF_CHANNEL_ID=
 # Discord category ID for the "Retired Characters" category (default: 1225070632799043685)
 CUBBY_RETIRED_CATEGORY_ID=1225070632799043685
 
+# Override the slash command name for the Lasombra command (default: lasombra).
+# Set to "dev-lasombra" on dev bots to avoid collisions with the prod bot in the same guild.
+LASOMBRA_COMMAND_NAME=lasombra
+
 # ---------------------------------------------------------------------------
 # discord-wiki-sync (one-time script — not used by the running bot)
 # Run: npm run wiki-sync:dry-run  /  npm run wiki-sync

--- a/apps/bot/src/approveWizard.ts
+++ b/apps/bot/src/approveWizard.ts
@@ -374,7 +374,7 @@ export async function handleApproveWizardStringSelect(
 
   const state = pending.get(interaction.user.id);
   if (!state) {
-    await interaction.update({ content: 'Session expired — run `/lasombra approve` again.', components: [] });
+    await interaction.update({ content: 'Session expired — run `/${config.lasombraCommandName} approve` again.', components: [] });
     return true;
   }
 
@@ -413,7 +413,7 @@ export async function handleApproveWizardButton(
   pending.delete(interaction.user.id);
 
   if (!state) {
-    await interaction.update({ content: 'Session expired — run `/lasombra approve` again.', components: [] });
+    await interaction.update({ content: 'Session expired — run `/${config.lasombraCommandName} approve` again.', components: [] });
     return true;
   }
 

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -21,10 +21,10 @@ import { errorToMessage, logEvent } from '../logger';
 import { startApproveWizard, findPlayerInChannel, findLatestPdf } from '../approveWizard';
 import { startEditWizard } from '../editWizard';
 
-export const name = 'lasombra';
+export const name = config.lasombraCommandName;
 
 export const data = new SlashCommandBuilder()
-  .setName('lasombra')
+  .setName(config.lasombraCommandName)
   .setDescription('Lasombra utility commands')
   .addSubcommand((s) =>
     s

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -666,7 +666,7 @@ export async function handleUpdateModal(
   pendingUpdates.delete(interaction.user.id);
 
   if (!channelId) {
-    await interaction.editReply('Session expired — run `/lasombra update` again.');
+    await interaction.editReply(`Session expired — run \`/${config.lasombraCommandName} update\` again.`);
     return true;
   }
 
@@ -767,7 +767,7 @@ export async function handleDeleteButton(
   pendingDeletes.delete(interaction.message.id);
 
   if (!characterName) {
-    await interaction.update({ content: 'Session expired — run `/lasombra delete` again.', components: [] });
+    await interaction.update({ content: `Session expired — run \`/${config.lasombraCommandName} delete\` again.`, components: [] });
     return true;
   }
 
@@ -780,7 +780,7 @@ export async function handleDeleteButton(
 
   if (!result.ok) {
     const hint = result.hasHistory
-      ? '\nUse `/lasombra edit` to mark them as retired or deceased instead.'
+      ? `\nUse \`/${config.lasombraCommandName} edit\` to mark them as retired or deceased instead.`
       : '';
     await interaction.editReply({ content: `⚠️ ${result.message}${hint}`, components: [] });
     return true;

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -160,7 +160,7 @@ const envSchema = z.object({
   CUBBY_SYNC_GUILD_ID: z.string().optional(),
   CUBBY_SYNC_STAFF_CHANNEL_ID: z.string().optional(),
   CUBBY_RETIRED_CATEGORY_ID: z.string().optional(),
-  LASOMBRA_COMMAND_NAME: z.string().optional(),
+  LASOMBRA_COMMAND_NAME: z.string().regex(/^[-_a-z0-9]{1,32}$/, 'LASOMBRA_COMMAND_NAME must be 1-32 chars, lowercase letters/numbers/hyphens/underscores only').optional(),
 });
 
 // Strip empty strings so optional fields behave as if absent.

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -160,6 +160,7 @@ const envSchema = z.object({
   CUBBY_SYNC_GUILD_ID: z.string().optional(),
   CUBBY_SYNC_STAFF_CHANNEL_ID: z.string().optional(),
   CUBBY_RETIRED_CATEGORY_ID: z.string().optional(),
+  LASOMBRA_COMMAND_NAME: z.string().optional(),
 });
 
 // Strip empty strings so optional fields behave as if absent.
@@ -378,6 +379,7 @@ export const config = {
   cubbySyncGuildId: env.CUBBY_SYNC_GUILD_ID ?? env.DISCORD_GUILD_ID ?? env.TEST_GUILD_ID ?? '',
   cubbySyncStaffChannelId: env.CUBBY_SYNC_STAFF_CHANNEL_ID ?? '',
   cubbyRetiredCategoryId: env.CUBBY_RETIRED_CATEGORY_ID ?? '1225070632799043685',
+  lasombraCommandName: env.LASOMBRA_COMMAND_NAME ?? 'lasombra',
 };
 
 if (config.testRequesterDiscordId) {

--- a/apps/bot/src/editWizard.ts
+++ b/apps/bot/src/editWizard.ts
@@ -215,7 +215,7 @@ export async function handleEditWizardStringSelect(
 
   const state = pending.get(interaction.user.id);
   if (!state) {
-    await interaction.update({ content: 'Session expired — run `/lasombra edit` again.', components: [] });
+    await interaction.update({ content: 'Session expired — run `/${config.lasombraCommandName} edit` again.', components: [] });
     return true;
   }
 
@@ -256,7 +256,7 @@ export async function handleEditWizardButton(
   if (interaction.customId === EDIT_RENAME_ID) {
     const state = pending.get(interaction.user.id);
     if (!state) {
-      await interaction.update({ content: 'Session expired — run `/lasombra edit` again.', components: [] });
+      await interaction.update({ content: 'Session expired — run `/${config.lasombraCommandName} edit` again.', components: [] });
       return true;
     }
     const modal = new ModalBuilder()
@@ -282,7 +282,7 @@ export async function handleEditWizardButton(
   pending.delete(interaction.user.id);
 
   if (!state) {
-    await interaction.update({ content: 'Session expired — run `/lasombra edit` again.', components: [] });
+    await interaction.update({ content: 'Session expired — run `/${config.lasombraCommandName} edit` again.', components: [] });
     return true;
   }
 
@@ -389,7 +389,7 @@ export async function handleEditRenameModal(
   pending.delete(interaction.user.id);
 
   if (!state) {
-    await interaction.reply({ content: 'Session expired — run `/lasombra edit` again.', ephemeral: true });
+    await interaction.reply({ content: 'Session expired — run `/${config.lasombraCommandName} edit` again.', ephemeral: true });
     return true;
   }
 

--- a/apps/bot/src/registerCommands.ts
+++ b/apps/bot/src/registerCommands.ts
@@ -39,7 +39,7 @@ export async function registerCommands(client: BotClient) {
 
   const token = config.botToken;
   const clientId = config.clientId;
-  const guildId = config.testGuildId;
+  const guildId = config.testGuildId ?? config.discordGuildId;
 
   if (!token || !clientId) {
     logEvent('warn', 'command_registration_skipped_missing_env', {


### PR DESCRIPTION
## Summary

- **`registerCommands`**: falls back to `DISCORD_GUILD_ID` when `TEST_GUILD_ID` is unset, so prod bots register commands as guild commands (instant propagation) without any extra config
- **`LASOMBRA_COMMAND_NAME`**: new env var (default: `lasombra`) — set to `dev-lasombra` on dev bots to prevent command collisions when dev and prod bots share a guild

## Test plan

- [ ] Prod bot (no `TEST_GUILD_ID`, has `DISCORD_GUILD_ID`): restart → commands register to guild immediately, `/lasombra sync-cubbies` appears
- [ ] Dev bot: set `LASOMBRA_COMMAND_NAME=dev-lasombra` → `/dev-lasombra` appears, no longer doubles `/lasombra`

🤖 Generated with [Claude Code](https://claude.com/claude-code)