### PR TITLE
Add bot auto-deploy to Ursula; fix active-roster 500 on includeChannelIds

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -1,0 +1,95 @@
+name: Deploy Bot to Ursula
+
+on:
+  # Trigger after CI completes on main — only deploy when CI passes
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual deploy'
+        required: false
+        default: 'manual trigger'
+
+jobs:
+  deploy:
+    name: Deploy Bot
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      github.repository == 'jkomg/mcbn-xp-tracker' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
+
+    steps:
+      - name: Resolve deploy SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout (for commit message)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.sha.outputs.sha }}
+
+      - name: Deploy to Ursula via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.URSULA_SSH_HOST }}
+          username: ${{ secrets.URSULA_SSH_USER }}
+          key: ${{ secrets.URSULA_SSH_KEY }}
+          script: |
+            set -e
+            cd ${{ secrets.URSULA_BOT_DIR }}
+            git fetch origin main
+            git checkout main
+            git pull origin main
+            cd apps/bot
+            npm run ops:docker:up
+
+      - name: Notify Discord
+        if: always()
+        continue-on-error: true
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          STATUS: ${{ job.status }}
+          SHA: ${{ steps.sha.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TRIGGER: ${{ github.event_name }}
+        run: |
+          [ -z "$WEBHOOK" ] && exit 0
+
+          SHORT_SHA="${SHA:0:7}"
+          COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${SHA}"
+          COMMIT_MSG=$(git log -1 --format="%s" "$SHA")
+
+          if [ "$STATUS" = "success" ]; then
+            COLOR=3066993
+            ICON="✅"
+            TITLE="Bot deployed"
+            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) is live on Ursula.\n${COMMIT_MSG}"
+          else
+            COLOR=15158332
+            ICON="❌"
+            TITLE="Bot deploy failed"
+            BODY="[\`${SHORT_SHA}\`](${COMMIT_URL}) did not deploy. [View logs](${RUN_URL}).\n${COMMIT_MSG}"
+          fi
+
+          curl -s -X POST "$WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"${ICON} ${TITLE}\",
+                \"description\": \"${BODY}\",
+                \"color\": ${COLOR},
+                \"footer\": { \"text\": \"triggered by ${TRIGGER}\" }
+              }]
+            }"

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -335,13 +335,15 @@ def active_roster():
     characters = db_service.get_active_characters()
     characters.sort(key=lambda c: c.character_name.lower())
     if request.args.get('includeChannelIds') == '1':
+        from app.db import DbCharacter
+        rows = DbCharacter.query.filter_by(active=True).order_by(DbCharacter.character_name).all()
         return jsonify({
             'characters': [
                 {
-                    'name': c.character_name,
-                    'ticketChannelId': c.ticket_channel_id or None,
+                    'name': r.character_name,
+                    'ticketChannelId': r.ticket_channel_id or None,
                 }
-                for c in characters
+                for r in rows
             ]
         })
     if request.args.get('includeDiscordIds') == '1':


### PR DESCRIPTION
## Summary

- **`.github/workflows/deploy-bot.yml`**: after CI passes on main, SSHes into Ursula, pulls latest main, and runs `npm run ops:docker:up` to rebuild and restart the bot container. Posts a Discord embed on success/failure (same pattern as web deploy). Requires secrets: `URSULA_SSH_HOST`, `URSULA_SSH_USER`, `URSULA_SSH_KEY`, `URSULA_BOT_DIR`.
- **Fix 500 on `GET /meta/active-roster?includeChannelIds=1`**: `db_service.get_active_characters()` returns `Character` dataclass objects which don't have `ticket_channel_id`. Fixed by querying `DbCharacter` directly in this branch.

## Secrets to add in GitHub repo settings

| Secret | Value |
|--------|-------|
| `URSULA_SSH_HOST` | Ursula hostname/IP |
| `URSULA_SSH_USER` | SSH username |
| `URSULA_SSH_KEY` | Private deploy key (generate fresh — see PR) |
| `URSULA_BOT_DIR` | Absolute repo path on Ursula (e.g. `/home/jason/mcbn-xp-tracker`) |

## Test plan

- [ ] Add secrets, merge, push a bot change — confirm bot redeploys on Ursula
- [ ] `GET /meta/active-roster?includeChannelIds=1` returns 200 with `ticketChannelId` fields
- [ ] `/lasombra sync-cubbies` no longer 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)