### PR TITLE
Fix bot deploy: remove existing container before recreating

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Rebuild and restart bot
         run: |
           cd ${{ secrets.URSULA_BOT_DIR }}/apps/bot
+          docker rm -f lasombra-bot 2>/dev/null || true
           npm run ops:docker:up
 
       - name: Notify Discord

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Rebuild and restart bot
         run: |
           cd ${{ secrets.URSULA_BOT_DIR }}/apps/bot
+          docker compose -f docker-compose.yml build
           docker rm -f lasombra-bot 2>/dev/null || true
           npm run ops:docker:up
 


### PR DESCRIPTION
The \`lasombra-bot\` container already exists from a previous run, causing a name conflict when compose tries to create it. Force-remove it before bringing it back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)