### PR TITLE
Add pending character drafts to dashboard

### DIFF
--- a/apps/web/app/blueprints/dashboard.py
+++ b/apps/web/app/blueprints/dashboard.py
@@ -21,15 +21,18 @@ DISCORD_USER_URL = 'https://discord.com/api/v10/users/@me'
 @require_staff
 def index():
     """Main dashboard showing XP summary for all characters."""
+    from app.db import CharacterDraft
     dashboard_data = db_service.get_dashboard_data()
     pending_claims = len(db_service.get_pending_claims())
     pending_spends = len(db_service.get_pending_spends())
+    pending_drafts = CharacterDraft.query.filter_by(status='submitted').count()
 
     return render_template(
         'dashboard.html',
         characters=dashboard_data,
         pending_claims=pending_claims,
         pending_spends=pending_spends,
+        pending_drafts=pending_drafts,
     )
 
 

--- a/apps/web/app/templates/dashboard.html
+++ b/apps/web/app/templates/dashboard.html
@@ -4,7 +4,7 @@
 <h2 class="mb-4">Dashboard</h2>
 
 <!-- Action strip -->
-{% if pending_claims > 0 or pending_spends > 0 %}
+{% if pending_claims > 0 or pending_spends > 0 or pending_drafts > 0 %}
 <div class="action-strip d-flex align-items-center gap-3 flex-wrap mb-4 p-3">
     <span><i class="bi bi-bell-fill text-warning me-1"></i> <strong>Needs attention:</strong></span>
     {% if pending_claims > 0 %}
@@ -15,6 +15,11 @@
     {% if pending_spends > 0 %}
     <a href="{{ url_for('spends.pending') }}" class="btn btn-sm btn-outline-danger">
         <i class="bi bi-cart-check"></i> {{ pending_spends }} Spend{{ 's' if pending_spends != 1 }}
+    </a>
+    {% endif %}
+    {% if pending_drafts > 0 %}
+    <a href="{{ url_for('cc_admin.draft_list') }}" class="btn btn-sm btn-outline-info">
+        <i class="bi bi-person-check"></i> {{ pending_drafts }} Draft{{ 's' if pending_drafts != 1 }}
     </a>
     {% endif %}
 </div>
@@ -53,6 +58,18 @@
           <h6 class="card-title text-muted mb-1" style="font-family: inherit; font-size: 0.8rem; letter-spacing: 0.05em; text-transform: uppercase;">Pending Spends</h6>
           <p class="card-text display-6 mb-2 lh-1">{{ pending_spends }}</p>
           <a href="/spends/" class="btn btn-sm btn-outline-danger">View Spends</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4 mb-3">
+    <div class="card stat-card h-100">
+      <div class="card-body d-flex align-items-center gap-3">
+        <i class="bi bi-person-check stat-icon text-info"></i>
+        <div>
+          <h6 class="card-title text-muted mb-1" style="font-family: inherit; font-size: 0.8rem; letter-spacing: 0.05em; text-transform: uppercase;">Pending Drafts</h6>
+          <p class="card-text display-6 mb-2 lh-1">{{ pending_drafts }}</p>
+          <a href="{{ url_for('cc_admin.draft_list') }}" class="btn btn-sm btn-outline-info">Review Drafts</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Surfaces pending character draft reviews on the main dashboard:

- **Action strip**: shows a "N Draft(s)" button when there are submitted drafts awaiting review, alongside existing claims/spends alerts
- **Stat card**: new "Pending Drafts" card with a "Review Drafts" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)