### PR TITLE
Move CC tools out of Settings; expand Char. Creator nav

### DIFF
--- a/apps/web/app/templates/base.html
+++ b/apps/web/app/templates/base.html
@@ -116,9 +116,18 @@
                     </li>
                     {% if is_staff %}
                     <li class="nav-item">
-                        <a class="nav-link {% if request.endpoint and request.endpoint.startswith('cc_admin.') %}active{% endif %}"
+                        <span class="nav-link text-muted small text-uppercase ps-3" style="font-size:0.7rem;letter-spacing:.05em;pointer-events:none;">Char. Creator</span>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4 {% if request.endpoint == 'cc_admin.draft_list' or request.endpoint == 'cc_admin.draft_review' %}active{% endif %}"
+                           href="{{ url_for('cc_admin.draft_list') }}">
+                            <i class="bi bi-person-check"></i> <span>Drafts</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link ps-4 {% if request.endpoint == 'cc_admin.loresheet_list' %}active{% endif %}"
                            href="{{ url_for('cc_admin.loresheet_list') }}">
-                            <i class="bi bi-person-badge"></i> <span>Char. Creator</span>
+                            <i class="bi bi-slash-circle"></i> <span>Loresheet Restrictions</span>
                         </a>
                     </li>
                     {% endif %}

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -12,25 +12,6 @@
     {% endif %}
   </div>
 
-  {# ═══ Character Creator ═══ #}
-  <h5 class="text-muted text-uppercase small mb-2 mt-4">Character Creator</h5>
-  <div class="card mb-4">
-    <div class="card-body d-flex align-items-center justify-content-between flex-wrap gap-3">
-      <div>
-        <div class="fw-semibold mb-1"><i class="bi bi-person-badge me-2 text-danger"></i>Loresheet Restrictions</div>
-        <small class="text-muted">Ban or allow specific loresheets in the character creator. Banned loresheets are hidden from players immediately.</small>
-      </div>
-      <div class="d-flex gap-2 flex-wrap">
-        <a href="{{ url_for('cc_admin.draft_list') }}" class="btn btn-sm btn-outline-warning text-nowrap">
-          <i class="bi bi-person-check me-1"></i> Review Drafts
-        </a>
-        <a href="{{ url_for('cc_admin.loresheet_list') }}" class="btn btn-sm btn-outline-danger text-nowrap">
-          <i class="bi bi-slash-circle me-1"></i> Manage Loresheets
-        </a>
-      </div>
-    </div>
-  </div>
-
   {# ═══ Web App — Feature Flags ═══ #}
   <h5 class="text-muted text-uppercase small mb-2 mt-4">Web App — Feature Flags</h5>
   <div class="card mb-4">

--- a/apps/web/tests/test_settings_wiki_sync_reset.py
+++ b/apps/web/tests/test_settings_wiki_sync_reset.py
@@ -37,7 +37,7 @@ def _app():
     app.register_blueprint(_stub_bp('audit', '/audit', {'/': 'log', '/errors': 'errors'}))
     app.register_blueprint(_stub_bp('player', '/player', {'/': 'my_characters'}))
     app.register_blueprint(_stub_bp('wiki', '/wiki', {'/': 'index'}))
-    app.register_blueprint(_stub_bp('cc_admin', '/cc-admin', {'/loresheets': 'loresheet_list', '/drafts': 'draft_list'}))
+    app.register_blueprint(_stub_bp('cc_admin', '/cc-admin', {'/loresheets': 'loresheet_list'}))
     app.register_blueprint(settings_bp, url_prefix='/settings')
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
- **Nav**: replace single "Char. Creator" link with a labelled section containing "Drafts" and "Loresheet Restrictions" as separate indented links
- **Settings**: remove the Character Creator card — operational tools belong in the nav, not settings
- **Test**: remove `draft_list` stub from settings test (no longer referenced by settings template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)