### PR TITLE
CC nav cleanup + dev bot ticket monitor flag

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -118,6 +118,8 @@ CC_CREATION_RULES_URL=
 # If unset, any category whose name contains "character tickets" matches.
 # Set this in dev/staging to avoid firing on prod ticket categories.
 CC_TICKET_CATEGORY_IDS=
+# Set to false on dev bots to prevent posting welcome messages in prod ticket channels.
+CC_TICKET_MONITOR_ENABLED=true
 # Character submission notifier: posts an embed in the player's ticket channel when
 # they hit "Submit for Review" in the character creator.
 # Enabled by default — set to false to disable.

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -152,6 +152,7 @@ const envSchema = z.object({
   APPROVE_SHEET_IN_PROGRESS_ROLE_ID: z.string().optional(),
   CC_CREATION_RULES_URL: z.string().transform(v => v || undefined).pipe(z.string().url().optional()),
   CC_TICKET_CATEGORY_IDS: z.string().optional(),
+  CC_TICKET_MONITOR_ENABLED: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_ENABLED: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_INTERVAL_MS: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_LOOKBACK_SECONDS: z.string().optional(),
@@ -363,6 +364,7 @@ export const config = {
   approveSheetInProgressRoleId: env.APPROVE_SHEET_IN_PROGRESS_ROLE_ID ?? '',
   ccCreationRulesUrl: env.CC_CREATION_RULES_URL,
   ccTicketCategoryIds: parseCsvIds(env.CC_TICKET_CATEGORY_IDS),
+  ccTicketMonitorEnabled: (env.CC_TICKET_MONITOR_ENABLED ?? 'true').toLowerCase() === 'true',
   ccSubmissionNotifierEnabled: (env.CC_SUBMISSION_NOTIFIER_ENABLED ?? 'true').toLowerCase() === 'true',
   ccSubmissionNotifierIntervalMs: parsePositiveInt(
     env.CC_SUBMISSION_NOTIFIER_INTERVAL_MS,

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -257,11 +257,13 @@ void applyStartupConfigOverrides().then(() => {
     cubbySyncWorker.start();
     characterSubmissionNotifier.start();
     startCubbyChannelMonitor(client);
-    startCharacterTicketMonitor(client, {
-      webBaseUrl: config.webAppBaseUrl,
-      creationRulesUrl: config.ccCreationRulesUrl,
-      ...(config.ccTicketCategoryIds.size > 0 ? { ticketCategoryIds: config.ccTicketCategoryIds } : {}),
-    });
+    if (config.ccTicketMonitorEnabled) {
+      startCharacterTicketMonitor(client, {
+        webBaseUrl: config.webAppBaseUrl,
+        creationRulesUrl: config.ccCreationRulesUrl,
+        ...(config.ccTicketCategoryIds.size > 0 ? { ticketCategoryIds: config.ccTicketCategoryIds } : {}),
+      });
+    }
     startHuntConsequenceMonitor(client, huntConsequenceCfg);
   });
 


### PR DESCRIPTION
## Summary
- Moves Character Creator tools (Drafts, Loresheet Restrictions) out of Settings and into a dedicated **Char. Creator** section in the sidebar nav
- Adds `CC_TICKET_MONITOR_ENABLED` env var (default `true`) so dev bots can opt out of posting welcome messages in ticket channels — prevents dev bot from firing in prod when a ticket is opened

## Test plan
- [ ] Settings page no longer shows CC card
- [ ] Sidebar shows "Char. Creator" section with Drafts and Loresheet Restrictions links
- [ ] Dev bot: set `CC_TICKET_MONITOR_ENABLED=false` (or `CC_TICKET_CATEGORY_IDS=<dev-category-id>`) — opening a ticket in prod should not trigger welcome message
- [ ] Prod bot: ticket monitor still fires normally with `CC_TICKET_MONITOR_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)