### PR TITLE
Add general-purpose bot feature flag system

### DIFF
--- a/apps/bot/src/__tests__/botHeartbeatService.test.ts
+++ b/apps/bot/src/__tests__/botHeartbeatService.test.ts
@@ -46,6 +46,7 @@ describe('BotHeartbeatService', () => {
       claimReminderEnabled: true,
       passageOfTimeEnabled: false,
       huntConsequenceEnabled: true,
+      ccTicketMonitorEnabled: true,
     });
   });
 

--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -34,11 +34,13 @@ function baseBotConfig(overrides: Partial<BotConfigResponse> = {}): BotConfigRes
     huntConsequenceEnabled: null,
     restartRequested: null,
     wikiSyncRequested: null,
+    ccTicketMonitorEnabled: null,
     passageOfTimeIntervalMs: null,
     reviewNotifierIntervalMs: null,
     submissionNotifierIntervalMs: null,
     claimReminderIntervalMs: null,
     announcementsChannelId: null,
+    ccTicketCategoryIds: null,
     ...overrides,
   };
 }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -84,6 +84,9 @@ initClientCommandCollection(client);
 // Fetch DB-backed config overrides before constructing services so interval
 // overrides set in the web UI take effect immediately on this startup.
 async function applyStartupConfigOverrides(): Promise<void> {
+  // Seed CC ticket monitor from .env defaults so it works before first DB sync.
+  liveConfig.ccTicketMonitorEnabled = config.ccTicketMonitorEnabled;
+  liveConfig.ccTicketCategoryIds = new Set(config.ccTicketCategoryIds);
   try {
     const cfg = await adapter.getBotConfig();
     if (cfg.passageOfTimeIntervalMs !== null) liveConfig.passageOfTimeIntervalMs = cfg.passageOfTimeIntervalMs;
@@ -91,6 +94,12 @@ async function applyStartupConfigOverrides(): Promise<void> {
     if (cfg.submissionNotifierIntervalMs !== null) liveConfig.submissionNotifierIntervalMs = cfg.submissionNotifierIntervalMs;
     if (cfg.claimReminderIntervalMs !== null) liveConfig.claimReminderIntervalMs = cfg.claimReminderIntervalMs;
     if (cfg.announcementsChannelId) liveConfig.announcementsChannelId = cfg.announcementsChannelId;
+    if (cfg.ccTicketMonitorEnabled !== null) liveConfig.ccTicketMonitorEnabled = cfg.ccTicketMonitorEnabled;
+    if (cfg.ccTicketCategoryIds !== null) {
+      liveConfig.ccTicketCategoryIds = new Set(
+        cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
+      );
+    }
     logEvent('info', 'startup_config_loaded', { liveConfig });
   } catch (err) {
     logEvent('warn', 'startup_config_fetch_failed', { error: errorToMessage(err) });
@@ -257,13 +266,10 @@ void applyStartupConfigOverrides().then(() => {
     cubbySyncWorker.start();
     characterSubmissionNotifier.start();
     startCubbyChannelMonitor(client);
-    if (config.ccTicketMonitorEnabled) {
-      startCharacterTicketMonitor(client, {
-        webBaseUrl: config.webAppBaseUrl,
-        creationRulesUrl: config.ccCreationRulesUrl,
-        ...(config.ccTicketCategoryIds.size > 0 ? { ticketCategoryIds: config.ccTicketCategoryIds } : {}),
-      });
-    }
+    startCharacterTicketMonitor(client, {
+      webBaseUrl: config.webAppBaseUrl,
+      creationRulesUrl: config.ccCreationRulesUrl,
+    });
     startHuntConsequenceMonitor(client, huntConsequenceCfg);
   });
 

--- a/apps/bot/src/liveConfig.ts
+++ b/apps/bot/src/liveConfig.ts
@@ -16,4 +16,8 @@ export const liveConfig = {
   announcementsChannelId: null as string | null,
   /** Set to true by configSyncWorker when the web UI requests a wiki sync run. */
   wikiSyncRequested: false,
+  /** Whether the CC ticket welcome monitor is active. Seeded from .env in index.ts, then updated by ConfigSyncWorker. */
+  ccTicketMonitorEnabled: true,
+  /** Category IDs to restrict the CC ticket monitor to. Seeded from .env in index.ts, then updated by ConfigSyncWorker. */
+  ccTicketCategoryIds: new Set<string>(),
 };

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -26,11 +26,13 @@ export interface BotConfigResponse {
   huntConsequenceEnabled: boolean | null;
   restartRequested: boolean | null;
   wikiSyncRequested: boolean | null;
+  ccTicketMonitorEnabled: boolean | null;
   passageOfTimeIntervalMs: number | null;
   reviewNotifierIntervalMs: number | null;
   submissionNotifierIntervalMs: number | null;
   claimReminderIntervalMs: number | null;
   announcementsChannelId: string | null;
+  ccTicketCategoryIds: string | null;
 }
 
 export interface TrackerAdapter {

--- a/apps/bot/src/services/botHeartbeatService.ts
+++ b/apps/bot/src/services/botHeartbeatService.ts
@@ -23,6 +23,7 @@ export class BotHeartbeatService {
         claimReminderEnabled: liveConfig.claimReminderEnabled,
         passageOfTimeEnabled: liveConfig.passageOfTimeEnabled,
         huntConsequenceEnabled: liveConfig.huntConsequenceEnabled,
+        ccTicketMonitorEnabled: liveConfig.ccTicketMonitorEnabled,
         ...this.staticState,
       });
     } catch (err) {

--- a/apps/bot/src/services/characterTicketMonitor.ts
+++ b/apps/bot/src/services/characterTicketMonitor.ts
@@ -1,5 +1,6 @@
 import { ChannelType, EmbedBuilder, type Client, type NonThreadGuildBasedChannel } from 'discord.js';
 import { errorToMessage, logEvent } from '../logger';
+import { liveConfig } from '../liveConfig';
 
 const TICKET_CATEGORY_KEYWORD = 'character tickets';
 
@@ -8,12 +9,6 @@ interface CharacterTicketMonitorOptions {
     webBaseUrl: string;
     /** Optional Discord channel URL for creation rules. */
     creationRulesUrl?: string;
-    /**
-     * Optional set of category IDs to restrict monitoring to specific categories.
-     * When provided, only channels created under these exact category IDs trigger
-     * the welcome message. When absent, falls back to keyword matching on category name.
-     */
-    ticketCategoryIds?: Set<string>;
 }
 
 /**
@@ -27,13 +22,14 @@ export function startCharacterTicketMonitor(
     options: CharacterTicketMonitorOptions,
 ): void {
     client.on('channelCreate', async (channel: NonThreadGuildBasedChannel) => {
+        if (!liveConfig.ccTicketMonitorEnabled) return;
         if (channel.type !== ChannelType.GuildText) return;
 
         const parent = channel.parent;
         if (!parent) return;
 
-        const matchesCategory = options.ticketCategoryIds
-            ? options.ticketCategoryIds.has(parent.id)
+        const matchesCategory = liveConfig.ccTicketCategoryIds.size > 0
+            ? liveConfig.ccTicketCategoryIds.has(parent.id)
             : parent.name.toLowerCase().includes(TICKET_CATEGORY_KEYWORD);
         if (!matchesCategory) return;
 

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -31,12 +31,10 @@ export class ConfigSyncWorker {
       liveConfig.submissionNotifierIntervalMs = cfg.submissionNotifierIntervalMs ?? null;
       liveConfig.claimReminderIntervalMs = cfg.claimReminderIntervalMs ?? null;
       liveConfig.announcementsChannelId = cfg.announcementsChannelId ?? null;
-      if (cfg.ccTicketMonitorEnabled !== null) liveConfig.ccTicketMonitorEnabled = cfg.ccTicketMonitorEnabled;
-      if (cfg.ccTicketCategoryIds !== null) {
-        liveConfig.ccTicketCategoryIds = new Set(
-          cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
-        );
-      }
+      liveConfig.ccTicketMonitorEnabled = cfg.ccTicketMonitorEnabled ?? config.ccTicketMonitorEnabled;
+      liveConfig.ccTicketCategoryIds = cfg.ccTicketCategoryIds !== null
+        ? new Set(cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
+        : new Set(config.ccTicketCategoryIds);
       logEvent('debug', 'config_sync_done', { liveConfig });
 
       if (cfg.restartRequested) {

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -31,6 +31,12 @@ export class ConfigSyncWorker {
       liveConfig.submissionNotifierIntervalMs = cfg.submissionNotifierIntervalMs ?? null;
       liveConfig.claimReminderIntervalMs = cfg.claimReminderIntervalMs ?? null;
       liveConfig.announcementsChannelId = cfg.announcementsChannelId ?? null;
+      if (cfg.ccTicketMonitorEnabled !== null) liveConfig.ccTicketMonitorEnabled = cfg.ccTicketMonitorEnabled;
+      if (cfg.ccTicketCategoryIds !== null) {
+        liveConfig.ccTicketCategoryIds = new Set(
+          cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
+        );
+      }
       logEvent('debug', 'config_sync_done', { liveConfig });
 
       if (cfg.restartRequested) {

--- a/apps/web/app/app_settings.py
+++ b/apps/web/app/app_settings.py
@@ -28,6 +28,9 @@ EDITABLE_KEYS = {
     # Bot restart / sync signals
     'BOT_RESTART_REQUESTED',
     'BOT_WIKI_SYNC_REQUESTED',
+    # CC ticket monitor (polled by bot via /api/bot-config; applies within 1 minute)
+    'BOT_CC_TICKET_MONITOR_ENABLED',
+    'BOT_CC_TICKET_CATEGORY_IDS',
     # Bot channel IDs (polled by bot via /api/bot-config; take effect after restart)
     'BOT_ANNOUNCEMENTS_CHANNEL_ID',
     # Bot tuning (polled by bot via /api/bot-config; take effect after restart)

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -764,6 +764,7 @@ def bot_config():
         'BOT_HUNT_CONSEQUENCE_ENABLED': 'huntConsequenceEnabled',
         'BOT_RESTART_REQUESTED': 'restartRequested',
         'BOT_WIKI_SYNC_REQUESTED': 'wikiSyncRequested',
+        'BOT_CC_TICKET_MONITOR_ENABLED': 'ccTicketMonitorEnabled',
     }
     INT_KEYS = {
         'BOT_PASSAGE_OF_TIME_INTERVAL_MS': 'passageOfTimeIntervalMs',
@@ -773,6 +774,7 @@ def bot_config():
     }
     STR_KEYS = {
         'BOT_ANNOUNCEMENTS_CHANNEL_ID': 'announcementsChannelId',
+        'BOT_CC_TICKET_CATEGORY_IDS': 'ccTicketCategoryIds',
     }
     all_keys = list(BOOL_KEYS) + list(INT_KEYS) + list(STR_KEYS)
     from app.db import AppSetting
@@ -845,6 +847,7 @@ def bot_heartbeat_post():
         'passageOfTimeEnabled': 'BOT_LIVE_PASSAGE_OF_TIME_ENABLED',
         'huntConsequenceEnabled': 'BOT_LIVE_HUNT_CONSEQUENCE_ENABLED',
         'wikiSyncCapable': 'BOT_LIVE_WIKI_SYNC_CAPABLE',
+        'ccTicketMonitorEnabled': 'BOT_LIVE_CC_TICKET_MONITOR_ENABLED',
     }
     body = request.get_json(silent=True) or {}
     for field, db_key in LIVE_FLAG_KEYS.items():

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -228,6 +228,7 @@ def index():
         'BOT_CLAIM_REMINDER_ENABLED': 'BOT_LIVE_CLAIM_REMINDER_ENABLED',
         'BOT_PASSAGE_OF_TIME_ENABLED': 'BOT_LIVE_PASSAGE_OF_TIME_ENABLED',
         'BOT_HUNT_CONSEQUENCE_ENABLED': 'BOT_LIVE_HUNT_CONSEQUENCE_ENABLED',
+        'BOT_CC_TICKET_MONITOR_ENABLED': 'BOT_LIVE_CC_TICKET_MONITOR_ENABLED',
     }
     from app.db import AppSetting, WikiSyncEvent
     live_keys = list(LIVE_KEY_MAP.values())
@@ -318,6 +319,15 @@ def index():
             'editable': True,
             **_bot_flag_status('BOT_HUNT_CONSEQUENCE_ENABLED', overrides),
         },
+        {
+            'label': 'CC Ticket Monitor',
+            'key': 'BOT_CC_TICKET_MONITOR_ENABLED',
+            'env': 'CC_TICKET_MONITOR_ENABLED',
+            'interval_env': None,
+            'description': 'Posts a welcome message with a character creator link when a new ticket opens under the CC category.',
+            'editable': True,
+            **_bot_flag_status('BOT_CC_TICKET_MONITOR_ENABLED', overrides),
+        },
     ]
 
     # ── Bot channel IDs (DB-backed; take effect after bot restart) ────────
@@ -332,9 +342,21 @@ def index():
             'env': 'ANNOUNCEMENTS_CHANNEL_ID',
             'value': _eff_str('BOT_ANNOUNCEMENTS_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
+            'input_pattern': r'\d{17,20}',
             'overridden': 'BOT_ANNOUNCEMENTS_CHANNEL_ID' in overrides,
             'editable': True,
             'description': 'Channel ID for /lasombra broadcast → announcements target.',
+        },
+        {
+            'label': 'CC ticket category IDs',
+            'key': 'BOT_CC_TICKET_CATEGORY_IDS',
+            'env': 'CC_TICKET_CATEGORY_IDS',
+            'value': _eff_str('BOT_CC_TICKET_CATEGORY_IDS'),
+            'placeholder': 'e.g. 123456789012345678,987654321098765432',
+            'input_pattern': None,
+            'overridden': 'BOT_CC_TICKET_CATEGORY_IDS' in overrides,
+            'editable': True,
+            'description': 'Restrict the CC ticket monitor to these Discord category IDs (comma-separated). Leave blank to match any category named "character tickets".',
         },
     ]
 
@@ -623,6 +645,7 @@ def update():
     # Keys that store raw strings (no type coercion).
     _STR_KEYS = {
         'BOT_ANNOUNCEMENTS_CHANNEL_ID',
+        'BOT_CC_TICKET_CATEGORY_IDS',
     }
 
     # Keys that are always boolean regardless of whether they appear in app.config.
@@ -638,6 +661,7 @@ def update():
         'BOT_PASSAGE_OF_TIME_ENABLED',
         'BOT_HUNT_CONSEQUENCE_ENABLED',
         'BOT_RESTART_REQUESTED',
+        'BOT_CC_TICKET_MONITOR_ENABLED',
     }
 
     if action == 'reset':

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -382,8 +382,8 @@
                   <input type="hidden" name="action" value="set">
                   <input type="text" name="value" value="{{ c.value or '' }}"
                     placeholder="{{ c.placeholder }}"
-                    pattern="\d{17,20}" title="Discord snowflake (17–20 digits)"
-                    class="form-control form-control-sm bg-dark text-light border-secondary font-monospace" style="width:160px">
+                    {% if c.input_pattern %}pattern="{{ c.input_pattern }}" title="Discord snowflake (17–20 digits)"{% endif %}
+                    class="form-control form-control-sm bg-dark text-light border-secondary font-monospace" style="width:{% if c.input_pattern %}160{% else %}280{% endif %}px">
                   <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
                 </form>
                 {% if c.overridden %}


### PR DESCRIPTION
## Summary

- Adds `BOT_CC_TICKET_MONITOR_ENABLED` (bool toggle) and `BOT_CC_TICKET_CATEGORY_IDS` (CSV string) to the bot feature flag system — controllable from the Settings dashboard without a restart
- CC ticket monitor now checks `liveConfig` at event time; DB overrides apply within ~60 seconds via the existing config sync worker
- `.env` values seed `liveConfig` at startup so the system works on a fresh install with no DB overrides
- Generalizes the channel input pattern in the Settings template so CSV fields work alongside the existing snowflake-only fields

## Changes

**Flask:**
- `app_settings.py` — new keys added to `EDITABLE_KEYS`
- `api.py` — keys wired into `/api/bot-config` response + heartbeat live-state tracking
- `settings.py` — CC ticket monitor in Bot — Feature Flags table; category IDs in Bot — Channels table; both keys in `update()` handler
- `settings/index.html` — channel input conditionally applies snowflake `pattern` only when appropriate

**Bot:**
- `adapter.ts` — `ccTicketMonitorEnabled` + `ccTicketCategoryIds` added to `BotConfigResponse`
- `liveConfig.ts` — new fields with sensible defaults
- `index.ts` — seeds liveConfig from `.env` config before first DB sync; always starts the ticket monitor
- `configSyncWorker.ts` — applies DB overrides on every sync cycle
- `botHeartbeatService.ts` — reports `ccTicketMonitorEnabled` live state to dashboard
- `characterTicketMonitor.ts` — reads `liveConfig` at event time; removes `ticketCategoryIds` from options

## Test plan

- [ ] All 58 bot tests and 121 Flask tests pass
- [ ] Settings page shows CC Ticket Monitor toggle in Bot — Feature Flags and CC ticket category IDs in Bot — Channels
- [ ] Toggle OFF in dashboard → bot stops posting welcome messages within ~60s (no restart needed)
- [ ] Toggle ON → bot resumes
- [ ] Set category IDs in dashboard → bot restricts to those categories within ~60s
- [ ] Clear category IDs → falls back to keyword matching ("character tickets")
- [ ] `.env` values are used as defaults when no DB override exists (reset to env works)

> **Note:** This branch is based on `feat/cc-in-memoriam` (#233). Merge #233 first or the diff will include both sets of changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)