### PR TITLE
Character creator UI, bot fix, wiki nav, reports page

### DIFF
--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -145,6 +145,7 @@ def create_app():
     from .blueprints.wiki import bp as wiki_bp
     from .blueprints.character_creator import bp as character_creator_bp
     from .blueprints.cc_admin import bp as cc_admin_bp
+    from .blueprints.reports import bp as reports_bp
 
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(claims_bp, url_prefix='/claims')
@@ -159,6 +160,7 @@ def create_app():
     app.register_blueprint(wiki_bp, url_prefix='/wiki')
     app.register_blueprint(character_creator_bp)
     app.register_blueprint(cc_admin_bp)
+    app.register_blueprint(reports_bp)
     csrf.exempt(api_bp)
     csrf.exempt(character_creator_bp)
 

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -1,0 +1,98 @@
+"""Staff-facing reports — engagement and roster breakdowns."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from flask import Blueprint, render_template
+
+from app.auth import require_staff
+from app.db import DbCharacter, DbPlayPeriod, DbSpendRequest, DbXPClaim
+
+bp = Blueprint('reports', __name__)
+
+
+@bp.route('/reports')
+@require_staff
+def index():
+    # ── Last 2 IC nights ──────────────────────────────────────────────────
+    recent_periods = (
+        DbPlayPeriod.query
+        .order_by(DbPlayPeriod.night_number.desc())
+        .limit(2)
+        .all()
+    )
+
+    period_labels = []
+    engaged_chars = []
+
+    if recent_periods:
+        period_labels = [p.period_label for p in recent_periods]
+
+        # Earliest start_date across both periods → cutoff for spend requests.
+        # DbSpendRequest.timestamp is "YYYYMMDD HH:MM:SS"; start_date is "YYYY-MM-DD".
+        start_dates = [p.start_date for p in recent_periods if p.start_date]
+        ts_cutoff = (min(start_dates).replace('-', '') + ' 00:00:00') if start_dates else ''
+
+        xp_rows = (
+            DbXPClaim.query
+            .filter(DbXPClaim.play_period.in_(period_labels))
+            .with_entities(DbXPClaim.character_name)
+            .distinct()
+            .all()
+        )
+        engaged_names = {r.character_name for r in xp_rows}
+
+        if ts_cutoff:
+            spend_rows = (
+                DbSpendRequest.query
+                .filter(DbSpendRequest.timestamp >= ts_cutoff)
+                .with_entities(DbSpendRequest.character_name)
+                .distinct()
+                .all()
+            )
+            engaged_names |= {r.character_name for r in spend_rows}
+
+        engaged_chars = (
+            DbCharacter.query
+            .filter(
+                DbCharacter.character_name.in_(engaged_names),
+                DbCharacter.active == True,  # noqa: E712
+            )
+            .order_by(DbCharacter.character_name)
+            .all()
+        )
+
+    # ── Roster breakdowns ─────────────────────────────────────────────────
+    all_roster = DbCharacter.query.order_by(DbCharacter.character_name).all()
+
+    def _breakdown(key_fn):
+        totals: dict[str, int] = defaultdict(int)
+        actives: dict[str, int] = defaultdict(int)
+        for c in all_roster:
+            k = key_fn(c) or '(unknown)'
+            totals[k] += 1
+            if c.active:
+                actives[k] += 1
+        return sorted(
+            [{'label': k, 'active': actives[k], 'total': totals[k]} for k in totals],
+            key=lambda r: -r['total'],
+        )
+
+    by_clan = _breakdown(lambda c: c.clan)
+    by_age = _breakdown(lambda c: c.age_category)
+    by_sect = _breakdown(lambda c: c.sect)
+
+    total_active = sum(1 for c in all_roster if c.active)
+
+    return render_template(
+        'reports.html',
+        recent_periods=recent_periods,
+        period_labels=period_labels,
+        engaged_chars=engaged_chars,
+        by_clan=by_clan,
+        by_age=by_age,
+        by_sect=by_sect,
+        total_active=total_active,
+        total_all=len(all_roster),
+    )

--- a/apps/web/app/templates/base.html
+++ b/apps/web/app/templates/base.html
@@ -139,6 +139,14 @@
                         </a>
                     </li>
                     {% endif %}
+                    {% if is_staff %}
+                    <li class="nav-item">
+                        <a class="nav-link ps-4 {% if request.endpoint == 'reports.index' %}active{% endif %}"
+                           href="{{ url_for('reports.index') }}">
+                            <i class="bi bi-bar-chart"></i> <span>Reports</span>
+                        </a>
+                    </li>
+                    {% endif %}
                     {% if config.LOCAL_STATUS_ENABLED %}
                     <li class="nav-item">
                         <a class="nav-link {% if request.endpoint == 'local_status.status_page' %}active{% endif %}"

--- a/apps/web/app/templates/reports.html
+++ b/apps/web/app/templates/reports.html
@@ -1,0 +1,180 @@
+{% extends "base.html" %}
+
+{% block title %}Reports{% endblock %}
+
+{% block content %}
+<div class="container-fluid mt-4">
+
+  <div class="mb-4">
+    <h2 class="mb-0">Reports</h2>
+    <small class="text-muted">Roster statistics and recent engagement.</small>
+  </div>
+
+  {# ── Engagement ── #}
+  <div class="card mb-4">
+    <div class="card-header py-2 d-flex align-items-center justify-content-between">
+      <span class="fw-semibold">
+        <i class="bi bi-activity me-1"></i> Engaged Characters
+        <span class="badge bg-secondary ms-1">{{ engaged_chars | length }}</span>
+      </span>
+      <span class="text-muted small">
+        {% if period_labels %}
+          {{ period_labels | join(', ') }}
+        {% else %}
+          No play periods found
+        {% endif %}
+      </span>
+    </div>
+    <div class="card-body p-0">
+      {% if not recent_periods %}
+        <p class="text-muted p-3 mb-0">No play periods on record.</p>
+      {% elif not engaged_chars %}
+        <p class="text-muted p-3 mb-0">No XP claims or spend requests found for these periods.</p>
+      {% else %}
+        <div class="table-responsive">
+          <table class="table table-dark table-hover table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Character</th>
+                <th>Clan</th>
+                <th>Age</th>
+                <th>Sect</th>
+                <th>Player</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for c in engaged_chars %}
+              <tr>
+                <td class="fw-semibold">{{ c.character_name }}</td>
+                <td>{{ c.clan or '—' }}</td>
+                <td class="text-capitalize">{{ c.age_category or '—' }}</td>
+                <td>{{ c.sect or '—' }}</td>
+                <td>
+                  <span class="text-muted small font-monospace">
+                    {{ c.player_discord_name or c.player_discord or '—' }}
+                  </span>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+  {# ── Breakdown tables ── #}
+  <div class="row g-3">
+
+    {# By Clan #}
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header py-2 fw-semibold">
+          <i class="bi bi-diagram-3 me-1"></i> By Clan
+        </div>
+        <div class="card-body p-0">
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Clan</th>
+                <th class="text-end">Active</th>
+                <th class="text-end">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in by_clan %}
+              <tr>
+                <td>{{ row.label }}</td>
+                <td class="text-end">{{ row.active }}</td>
+                <td class="text-end text-muted">{{ row.total }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+            <tfoot class="border-top border-secondary">
+              <tr class="fw-semibold">
+                <td>Total</td>
+                <td class="text-end">{{ total_active }}</td>
+                <td class="text-end text-muted">{{ total_all }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    {# By Age #}
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header py-2 fw-semibold">
+          <i class="bi bi-hourglass-split me-1"></i> By Age
+        </div>
+        <div class="card-body p-0">
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Age</th>
+                <th class="text-end">Active</th>
+                <th class="text-end">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in by_age %}
+              <tr>
+                <td class="text-capitalize">{{ row.label }}</td>
+                <td class="text-end">{{ row.active }}</td>
+                <td class="text-end text-muted">{{ row.total }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+            <tfoot class="border-top border-secondary">
+              <tr class="fw-semibold">
+                <td>Total</td>
+                <td class="text-end">{{ total_active }}</td>
+                <td class="text-end text-muted">{{ total_all }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    {# By Sect #}
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header py-2 fw-semibold">
+          <i class="bi bi-shield-half me-1"></i> By Sect
+        </div>
+        <div class="card-body p-0">
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Sect</th>
+                <th class="text-end">Active</th>
+                <th class="text-end">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in by_sect %}
+              <tr>
+                <td>{{ row.label }}</td>
+                <td class="text-end">{{ row.active }}</td>
+                <td class="text-end text-muted">{{ row.total }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+            <tfoot class="border-top border-secondary">
+              <tr class="fw-semibold">
+                <td>Total</td>
+                <td class="text-end">{{ total_active }}</td>
+                <td class="text-end text-muted">{{ total_all }}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+
+  </div>{# /row #}
+
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Character creator UI overhaul**: ClanPicker → list rows with discipline pills; AttributePicker and SkillsPicker → dark column rows; three-column breakpoint lowered to 1100px; Merits & Flaws sticky point counters + independent column scroll
- **Loresheet fixes**: scroll fixed (flex chain repair); expanded sourcebook text
- **Influence merit added**: Mortals background merits now include Influence (1–5)
- **Player draft delete**: sidebar Switch Character modal + player portal My Characters both support deleting draft/revision_requested drafts
- **Bot `/lasombra update` AbortError fix**: download PDF to buffer before send; falls back to text-only if download fails
- **Wiki sticky nav bar**: bottom nav with Wiki Home and Player Portal links
- **Staff reports page** (`/reports`): engagement table (characters who submitted XP claims or spend requests in the last 2 IC nights), plus active/total roster breakdowns by clan, age, and sect; nav link nested under Settings in sidebar

## Test plan

- [ ] Character creator: step through wizard, verify clan picker, attributes, skills, merits all render correctly
- [ ] Loresheet tab scrolls without breaking layout
- [ ] Player can delete a draft from sidebar and from player portal
- [ ] `/lasombra update` posts sheet without AbortError
- [ ] Wiki shows sticky bottom nav bar
- [ ] `/reports` loads for staff, shows engagement table and three breakdown tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)