### PR TITLE
Reports: drill-down modal for breakdown rows

### DIFF
--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 
+import json
+
 from flask import Blueprint, render_template
 
 from app.auth import require_staff
@@ -85,6 +87,18 @@ def index():
 
     total_active = sum(1 for c in all_roster if c.active)
 
+    roster_json = json.dumps([
+        {
+            'name': c.character_name,
+            'clan': c.clan or '',
+            'age': c.age_category or '',
+            'sect': c.sect or '',
+            'player': c.player_discord_name or c.player_discord or '',
+            'active': c.active,
+        }
+        for c in all_roster
+    ])
+
     return render_template(
         'reports.html',
         recent_periods=recent_periods,
@@ -95,4 +109,5 @@ def index():
         by_sect=by_sect,
         total_active=total_active,
         total_all=len(all_roster),
+        roster_json=roster_json,
     )

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-import json
-
 from flask import Blueprint, render_template
 
 from app.auth import require_staff
@@ -87,7 +85,7 @@ def index():
 
     total_active = sum(1 for c in all_roster if c.active)
 
-    roster_json = json.dumps([
+    roster_list = [
         {
             'name': c.character_name,
             'clan': c.clan or '',
@@ -97,7 +95,7 @@ def index():
             'active': c.active,
         }
         for c in all_roster
-    ])
+    ]
 
     return render_template(
         'reports.html',
@@ -109,5 +107,5 @@ def index():
         by_sect=by_sect,
         total_active=total_active,
         total_all=len(all_roster),
-        roster_json=roster_json,
+        roster_list=roster_list,
     )

--- a/apps/web/app/templates/reports.html
+++ b/apps/web/app/templates/reports.html
@@ -211,7 +211,7 @@
 
 {% block scripts %}
 <script>
-const ROSTER = {{ roster_json | safe }};
+const ROSTER = {{ roster_list | tojson }};
 
 document.querySelectorAll('.drill-row').forEach(function(row) {
   row.addEventListener('mouseenter', function() { row.classList.add('table-active'); });

--- a/apps/web/app/templates/reports.html
+++ b/apps/web/app/templates/reports.html
@@ -49,11 +49,7 @@
                 <td>{{ c.clan or '—' }}</td>
                 <td class="text-capitalize">{{ c.age_category or '—' }}</td>
                 <td>{{ c.sect or '—' }}</td>
-                <td>
-                  <span class="text-muted small font-monospace">
-                    {{ c.player_discord_name or c.player_discord or '—' }}
-                  </span>
-                </td>
+                <td><span class="text-muted small font-monospace">{{ c.player_discord_name or c.player_discord or '—' }}</span></td>
               </tr>
               {% endfor %}
             </tbody>
@@ -83,7 +79,8 @@
             </thead>
             <tbody>
               {% for row in by_clan %}
-              <tr>
+              <tr class="drill-row" style="cursor:pointer;"
+                  data-key="clan" data-value="{{ row.label }}" data-label="Clan: {{ row.label }}">
                 <td>{{ row.label }}</td>
                 <td class="text-end">{{ row.active }}</td>
                 <td class="text-end text-muted">{{ row.total }}</td>
@@ -119,7 +116,8 @@
             </thead>
             <tbody>
               {% for row in by_age %}
-              <tr>
+              <tr class="drill-row" style="cursor:pointer;"
+                  data-key="age" data-value="{{ row.label }}" data-label="Age: {{ row.label }}">
                 <td class="text-capitalize">{{ row.label }}</td>
                 <td class="text-end">{{ row.active }}</td>
                 <td class="text-end text-muted">{{ row.total }}</td>
@@ -155,7 +153,8 @@
             </thead>
             <tbody>
               {% for row in by_sect %}
-              <tr>
+              <tr class="drill-row" style="cursor:pointer;"
+                  data-key="sect" data-value="{{ row.label }}" data-label="Sect: {{ row.label }}">
                 <td>{{ row.label }}</td>
                 <td class="text-end">{{ row.active }}</td>
                 <td class="text-end text-muted">{{ row.total }}</td>
@@ -177,4 +176,83 @@
   </div>{# /row #}
 
 </div>
+
+{# ── Drill-down modal ── #}
+<div class="modal fade" id="drillModal" tabindex="-1" aria-labelledby="drillModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content bg-dark border-secondary">
+      <div class="modal-header border-secondary py-2">
+        <h5 class="modal-title" id="drillModalLabel"></h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body p-0">
+        <table class="table table-dark table-sm align-middle mb-0" id="drillTable">
+          <thead>
+            <tr>
+              <th>Character</th>
+              <th>Clan</th>
+              <th>Age</th>
+              <th>Sect</th>
+              <th>Player</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody id="drillBody"></tbody>
+        </table>
+      </div>
+      <div class="modal-footer border-secondary py-2">
+        <small class="text-muted me-auto" id="drillCount"></small>
+        <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+const ROSTER = {{ roster_json | safe }};
+
+document.querySelectorAll('.drill-row').forEach(function(row) {
+  row.addEventListener('mouseenter', function() { row.classList.add('table-active'); });
+  row.addEventListener('mouseleave', function() { row.classList.remove('table-active'); });
+  row.addEventListener('click', function() {
+    const key = row.dataset.key;       // 'clan' | 'age' | 'sect'
+    const value = row.dataset.value;   // e.g. 'Hecata' or '(unknown)'
+    const label = row.dataset.label;
+
+    const matches = ROSTER.filter(function(c) {
+      const field = c[key] || '';
+      return value === '(unknown)' ? field === '' : field === value;
+    });
+
+    document.getElementById('drillModalLabel').textContent = label;
+    document.getElementById('drillCount').textContent = matches.length + ' character' + (matches.length !== 1 ? 's' : '');
+
+    const tbody = document.getElementById('drillBody');
+    tbody.innerHTML = '';
+    matches.sort(function(a, b) { return a.name.localeCompare(b.name); });
+    matches.forEach(function(c) {
+      const tr = document.createElement('tr');
+      if (!c.active) tr.classList.add('opacity-50');
+      tr.innerHTML =
+        '<td class="fw-semibold">' + _esc(c.name) + '</td>' +
+        '<td>' + _esc(c.clan || '—') + '</td>' +
+        '<td class="text-capitalize">' + _esc(c.age || '—') + '</td>' +
+        '<td>' + _esc(c.sect || '—') + '</td>' +
+        '<td><span class="text-muted small font-monospace">' + _esc(c.player || '—') + '</span></td>' +
+        '<td>' + (c.active
+          ? '<span class="badge bg-success">Active</span>'
+          : '<span class="badge bg-secondary">Inactive</span>') + '</td>';
+      tbody.appendChild(tr);
+    });
+
+    new bootstrap.Modal(document.getElementById('drillModal')).show();
+  });
+});
+
+function _esc(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Clicking any row in the clan, age, or sect breakdown tables opens a modal listing all matching characters
- Shows name, clan, age, sect, player, and active/inactive status
- Inactive characters are dimmed
- `(unknown)` rows reveal characters with that field blank
- All data served from roster JSON embedded at page load — no extra queries or routes

## Test plan

- [ ] Click a clan row (e.g. Hecata) → modal shows matching characters
- [ ] Click `(unknown)` in age breakdown → shows characters missing age field
- [ ] Inactive characters appear dimmed with "Inactive" badge
- [ ] Modal count in footer matches row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)