### PR TITLE
Staff management: show env staff, add 4 role tiers

### DIFF
--- a/apps/web/app/auth.py
+++ b/apps/web/app/auth.py
@@ -110,7 +110,8 @@ def is_allowed_discord_user(discord_id: str) -> bool:
     """Check whether a Discord user ID is in the staff allowlist (env or DB)."""
     if str(discord_id) in current_app.config['ALLOWED_DISCORD_IDS']:
         return True
-    return _get_db_staff_role(str(discord_id)) is not None
+    role = _get_db_staff_role(str(discord_id))
+    return role in ('system_helper', 'storyteller', 'moderator', 'administrator')
 
 
 def is_settings_admin() -> bool:

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -500,19 +500,39 @@ def index():
     )
     wiki_sync_runs = wiki_sync_runs[:12]
 
-    # ── Staff members (DB-managed) ─────────────────────────────────────────
+    # ── Staff members (DB-managed + env baseline) ─────────────────────────
     from app.db import AppSetting as _AppSetting
+    _ROLE_LABELS = {
+        'administrator': 'Administrator',
+        'moderator': 'Moderator',
+        'storyteller': 'Storyteller',
+        'system_helper': 'System Helper',
+    }
     db_staff = _AppSetting.query.filter(
         _AppSetting.key.like('STAFF_MEMBER_%')
     ).order_by(_AppSetting.key).all()
+    db_staff_ids = {row.key[len('STAFF_MEMBER_'):] for row in db_staff}
     staff_members = [
         {
             'discord_id': row.key[len('STAFF_MEMBER_'):],
             'role': row.value,
-            'label': 'Administrator' if row.value == 'administrator' else 'Storyteller',
+            'label': _ROLE_LABELS.get(row.value, row.value.capitalize()),
+            'source': 'db',
         }
         for row in db_staff
     ]
+    # Include env-var IDs not already in DB so the full access list is visible.
+    _admin_ids = current_app.config.get('SETTINGS_ADMIN_DISCORD_IDS', set())
+    _allowed_ids = current_app.config.get('ALLOWED_DISCORD_IDS', set())
+    for _id in sorted(_admin_ids | _allowed_ids):
+        if _id and _id not in db_staff_ids:
+            _role = 'administrator' if _id in _admin_ids else 'staff'
+            staff_members.append({
+                'discord_id': _id,
+                'role': _role,
+                'label': _ROLE_LABELS.get(_role, 'Staff'),
+                'source': 'env',
+            })
 
     return render_template(
         'settings/index.html',
@@ -699,7 +719,7 @@ def staff_add():
     if not discord_id or not discord_id.isdigit():
         flash('Invalid Discord ID — must be numeric.', 'danger')
         return redirect(url_for('settings.index'))
-    if role not in ('storyteller', 'administrator'):
+    if role not in ('system_helper', 'storyteller', 'moderator', 'administrator'):
         flash('Invalid role.', 'danger')
         return redirect(url_for('settings.index'))
     key = f'STAFF_MEMBER_{discord_id}'

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -559,13 +559,22 @@
           {% for m in staff_members %}
           <tr>
             <td><code>{{ m.discord_id }}</code></td>
-            <td><span class="badge {% if m.role == 'administrator' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">{{ m.label }}</span></td>
             <td>
+              <span class="badge {% if m.role == 'administrator' %}bg-warning text-dark{% elif m.role == 'moderator' %}bg-info text-dark{% elif m.role == 'storyteller' %}bg-primary{% else %}bg-secondary{% endif %}">
+                {{ m.label }}
+              </span>
+              {% if m.source == 'env' %}
+                <span class="badge bg-dark border border-secondary text-muted ms-1" title="Granted via environment variable — manage in server config">Env</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if m.source == 'db' %}
               <form method="POST" action="{{ url_for('settings.staff_remove') }}" class="mb-0">
                 <input type="hidden" name="discord_id" value="{{ m.discord_id }}">
                 <button type="submit" class="btn btn-sm btn-outline-danger"
                   onclick="return confirm('Remove {{ m.discord_id }} from staff?')">Remove</button>
               </form>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}
@@ -584,7 +593,9 @@
         <div class="col-auto">
           <label class="form-label small text-muted mb-1">Role</label>
           <select name="role" class="form-select form-select-sm bg-dark text-light border-secondary">
+            <option value="system_helper">System Helper</option>
             <option value="storyteller">Storyteller</option>
+            <option value="moderator">Moderator</option>
             <option value="administrator">Administrator</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary

- Staff Management now shows both DB-managed and env-var staff in one table; env entries show an **Env** badge and have no Remove button
- Added System Helper and Moderator role options alongside Storyteller and Administrator
- Role badges are colour-coded: Administrator=yellow, Moderator=teal, Storyteller=blue, System Helper=grey
- `auth.py`: explicitly enumerate valid DB roles so unknown values don't accidentally grant access

## Test plan

- [ ] Settings → Staff Management shows env-var Discord IDs with Env badge
- [ ] Add Staff form has all 4 role options
- [ ] DB-managed entries still show Remove button; env entries do not
- [ ] Adding a System Helper or Moderator via the form works and grants staff access

🤖 Generated with [Claude Code](https://claude.com/claude-code)