### PR TITLE
Fix review notifier posting to wrong channel

### DIFF
--- a/apps/bot/src/services/cubbyChannels.ts
+++ b/apps/bot/src/services/cubbyChannels.ts
@@ -71,8 +71,20 @@ export async function buildCubbyChannelMap(guild: Guild): Promise<Map<string, No
   const map = new Map<string, NotificationChannel>();
 
   const channels = await guild.channels.fetch();
+
+  // Restrict to channels inside a cubby category so we don't accidentally
+  // match same-named channels in other sections (e.g. Children of the Night).
+  const cubbyParentIds = new Set<string>();
   for (const channel of channels.values()) {
-    if (isNotificationChannel(channel)) {
+    if (channel && channel.type === ChannelType.GuildCategory) {
+      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+        cubbyParentIds.add(channel.id);
+      }
+    }
+  }
+
+  for (const channel of channels.values()) {
+    if (isNotificationChannel(channel) && channel.parentId && cubbyParentIds.has(channel.parentId)) {
       map.set(normalizeChannelName(channel.name), channel);
     }
   }
@@ -80,7 +92,10 @@ export async function buildCubbyChannelMap(guild: Guild): Promise<Map<string, No
   const activeThreads = await guild.channels.fetchActiveThreads().catch(() => null);
   if (activeThreads) {
     for (const thread of activeThreads.threads.values()) {
-      if (isNotificationChannel(thread)) {
+      if (!isNotificationChannel(thread)) continue;
+      // A thread's parent is a text channel; check that channel's category.
+      const parent = channels.get(thread.parentId ?? '');
+      if (parent && parent.parentId && cubbyParentIds.has(parent.parentId)) {
         map.set(normalizeChannelName(thread.name), thread);
       }
     }


### PR DESCRIPTION
## Summary
- `buildCubbyChannelMap` was mapping **all** text channels in the guild by normalized name
- Any channel with the same name as a character (e.g. an `ace` channel in Children of the Night) would match before the cubby
- Fix: build the cubby category parent ID set first, then only include channels whose `parentId` is in that set — same logic already used in `getChannelsInCubbyCategories`
- Threads are filtered the same way (check thread's parent channel's category)

## Test plan
- [ ] Approve/deny an XP claim or spend for a character whose name also appears as a channel elsewhere in the guild — verify the notification lands in the cubby, not the other channel
- [ ] Characters with no cubby still get a `review_notifier_channel_missing` error log (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)