### PR TITLE
fix: normalize YYYYMMDD dates to ISO in /api/periods/recent

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1734,13 +1734,19 @@ def periods_recent():
         .limit(count)
         .all()
     )
+    def _iso(d: str) -> str:
+        d = (d or '').strip()
+        if len(d) == 8 and d.isdigit():
+            return f'{d[:4]}-{d[4:6]}-{d[6:]}'
+        return d
+
     return jsonify({
         'periods': [
             {
                 'label': p.period_label,
                 'nightNumber': p.night_number,
-                'startDate': p.start_date or '',
-                'endDate': p.end_date or '',
+                'startDate': _iso(p.start_date),
+                'endDate': _iso(p.end_date),
             }
             for p in rows
         ]


### PR DESCRIPTION
Period start_date/end_date are stored as YYYYMMDD; the scanner compares them against ISO message dates (YYYY-MM-DD), so string comparison was always wrong. Normalize to YYYY-MM-DD before returning.

## Summary

- What changed?
- Why?

## Checklist

- [ ] Tests added/updated where appropriate
- [ ] `./venv/bin/pytest -q` passes locally
- [ ] Docs updated (`README.md`, `CHANGELOG.md`, or release notes) if needed
- [ ] No secrets/tokens included in code, logs, or screenshots

### Shared Contract Change Checklist (if touching `packages/api-contract` or `packages/rules`)

- [ ] Updated both web and bot consumers (or confirmed no consumer impact)
- [ ] Added/updated contract tests in both apps
- [ ] Documented rollout/rollback plan for contract version consumers

## Validation

- Steps used to verify behavior:
  1.
  2.
  3.

## Risks / Rollback

- Known risks:
- Rollback plan:
