### PR TITLE
feat: scan-activity category filter + inter-batch delay

### DIFF
--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -20,6 +20,7 @@ import { CubbySyncWorker } from '../services/cubbySyncWorker';
 import { errorToMessage, logEvent } from '../logger';
 import { startApproveWizard, findPlayerInChannel, findLatestPdf } from '../approveWizard';
 import { runActivityBackfill } from '../services/activityBackfillScanner';
+import type { ActivityCategory } from '../services/discordActivityCategories';
 import { startEditWizard } from '../editWizard';
 
 export const name = config.lasombraCommandName;
@@ -99,6 +100,15 @@ export const data = new SlashCommandBuilder()
       )
       .addStringOption((o) =>
         o.setName('until').setDescription('End date YYYY-MM-DD — defaults to today'),
+      )
+      .addStringOption((o) =>
+        o.setName('category').setDescription('Scan only one category (default: all)')
+          .addChoices(
+            { name: 'IC', value: 'ic' },
+            { name: 'OOC', value: 'ooc' },
+            { name: 'Rolls', value: 'rolls' },
+            { name: 'Cubby', value: 'cubby' },
+          ),
       ),
   )
   .addSubcommand((s) =>
@@ -412,7 +422,10 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
       scanLabel = periods.map(p => p.label).join(', ');
     }
 
-    await interaction.editReply(`Scanning channels **(${scanLabel})**…\nThis may take a few minutes.`);
+    const categoryOpt = (interaction.options.getString('category') ?? '') as ActivityCategory | '';
+    const categoryLabel = categoryOpt ? ` [${categoryOpt.toUpperCase()} only]` : '';
+
+    await interaction.editReply(`Scanning channels **(${scanLabel})**${categoryLabel}…\nThis may take a few minutes.`);
 
     try {
       const result = await runActivityBackfill(
@@ -420,9 +433,11 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
         ctx.adapter,
         sinceDate,
         untilDate,
+        undefined,
+        categoryOpt || undefined,
       );
       await interaction.editReply(
-        `Scan complete for **(${scanLabel})**.\n` +
+        `Scan complete for **(${scanLabel})**${categoryLabel}.\n` +
         `Channels scanned: **${result.channelsScanned}** | Messages counted: **${result.messagesScanned}** | Unique users: **${result.usersFound}**\n` +
         `Results are now visible on the Reports page.`,
       );

--- a/apps/bot/src/services/activityBackfillScanner.ts
+++ b/apps/bot/src/services/activityBackfillScanner.ts
@@ -17,8 +17,10 @@ import { CUBBY_CATEGORY_NAMES } from './cubbyChannels';
 const MESSAGES_PER_FETCH = 100;
 // Flush to API every this many accumulated entries
 const FLUSH_THRESHOLD = 500;
-// Pause between channels to avoid Discord rate-limit aborts
-const CHANNEL_DELAY_MS = 250;
+// Pause between channels to avoid Discord request timeouts
+const CHANNEL_DELAY_MS = 500;
+// Pause between paginated batches within a single channel
+const BATCH_DELAY_MS = 300;
 // Retry delays (ms) for channels that abort — 3 attempts after the main pass
 const RETRY_DELAYS_MS = [3_000, 8_000, 15_000];
 
@@ -86,6 +88,8 @@ async function scanChannel(
     const oldest: Message | undefined = batch.last();
     if (!oldest) break;
     before = oldest.id;
+
+    if (BATCH_DELAY_MS > 0) await sleep(BATCH_DELAY_MS);
   }
 
   return scanned;
@@ -108,6 +112,7 @@ export async function runActivityBackfill(
   sinceDate: string,
   untilDate: string,
   onProgress?: (msg: string) => void,
+  categoryFilter?: ActivityCategory,
 ): Promise<{ channelsScanned: number; messagesScanned: number; usersFound: number }> {
   const log = (msg: string) => {
     logEvent('info', 'activity_backfill', { msg });
@@ -159,7 +164,11 @@ export async function runActivityBackfill(
     }
   }
 
-  log(`Found ${toScan.length} channels/threads to scan`);
+  const filtered = categoryFilter ? toScan.filter(c => c.category === categoryFilter) : toScan;
+  if (categoryFilter) log(`Category filter: ${categoryFilter} (${filtered.length}/${toScan.length} channels)`);
+  const toProcess = categoryFilter ? filtered : toScan;
+
+  log(`Found ${toProcess.length} channels/threads to scan`);
 
   const countMap = new Map<string, Map<string, number>>();
   const nameMap = new Map<string, string>();
@@ -214,7 +223,7 @@ export async function runActivityBackfill(
 
   // Main pass
   let failed: ScanItem[] = [];
-  for (const item of toScan) {
+  for (const item of toProcess) {
     const ok = await scanOne(item);
     if (!ok) failed.push(item);
     if (CHANNEL_DELAY_MS > 0) await sleep(CHANNEL_DELAY_MS);


### PR DESCRIPTION
## Summary

- **`category` option** on `/lasombra scan-activity` — scan one category at a time (ic/ooc/rolls/cubby) instead of all 196 channels at once
- **300ms inter-batch delay** within each channel — the main cause of AbortError timeouts was rapid sequential `messages.fetch()` calls against the same endpoint with no pause between pages
- **500ms inter-channel delay** (up from 250ms)

## Usage

```
/lasombra scan-activity category:ic
/lasombra scan-activity category:ooc
/lasombra scan-activity category:rolls
/lasombra scan-activity category:cubby

# With date range:
/lasombra scan-activity category:ic since:2023-11-07
```

## Test plan

- [ ] Merge and rebuild bot on Ursula
- [ ] Run `/lasombra scan-activity category:ic` — confirm logs show only IC channels and far fewer abort warnings
- [ ] Run remaining categories
- [ ] Check Reports page shows data for all categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)