### PR TITLE
fix: bulk INSERT for discord activity record + scan reliability

### DIFF
--- a/apps/bot/src/services/activityBackfillScanner.ts
+++ b/apps/bot/src/services/activityBackfillScanner.ts
@@ -16,7 +16,7 @@ import { CUBBY_CATEGORY_NAMES } from './cubbyChannels';
 
 const MESSAGES_PER_FETCH = 100;
 // Flush to API every this many accumulated entries
-const FLUSH_THRESHOLD = 500;
+const FLUSH_THRESHOLD = 200;
 // Pause between channels to avoid Discord request timeouts
 const CHANNEL_DELAY_MS = 500;
 // Pause between paginated batches within a single channel

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1668,7 +1668,9 @@ def discord_activity_record():
         return jsonify({'error': 'too many entries'}), 400
 
     _valid_categories = {'ic', 'ooc', 'rolls', 'cubby'}
-    flushed = 0
+
+    # Validate and collect entries
+    valid: list[dict] = []
     for entry in entries:
         discord_id = str(entry.get('discord_id', '')).strip()
         date = str(entry.get('date', '')).strip()
@@ -1679,39 +1681,56 @@ def discord_activity_record():
             continue
         if not discord_id or not date or category not in _valid_categories or count <= 0:
             continue
+        valid.append({'did': discord_id, 'dt': date, 'cat': category, 'cnt': count})
+
+    # Bulk upsert all entries in one statement to avoid N round-trips to Turso.
+    # libsql supports up to 32766 bound variables; 4 per row × 500 rows = 2000, well within limit.
+    if valid:
+        placeholders = ', '.join(f'(:did_{i}, :dt_{i}, :cat_{i}, :cnt_{i})' for i in range(len(valid)))
+        params = {}
+        for i, row in enumerate(valid):
+            params[f'did_{i}'] = row['did']
+            params[f'dt_{i}'] = row['dt']
+            params[f'cat_{i}'] = row['cat']
+            params[f'cnt_{i}'] = row['cnt']
         db.session.execute(
             text(
-                "INSERT INTO discord_post_counts (discord_id, date, category, count)"
-                " VALUES (:did, :dt, :cat, :cnt)"
-                " ON CONFLICT(discord_id, date, category)"
-                " DO UPDATE SET count = discord_post_counts.count + excluded.count"
+                f"INSERT INTO discord_post_counts (discord_id, date, category, count)"
+                f" VALUES {placeholders}"
+                f" ON CONFLICT(discord_id, date, category)"
+                f" DO UPDATE SET count = discord_post_counts.count + excluded.count"
             ),
-            {'did': discord_id, 'dt': date, 'cat': category, 'cnt': count},
+            params,
         )
-        flushed += 1
 
-    # Optional names dict: { discord_id: display_name }
+    # Optional names dict: { discord_id: display_name } — bulk upsert
     from datetime import datetime, timezone
     names = body.get('names', {})
     if isinstance(names, dict):
         ts = datetime.now(timezone.utc).isoformat()
-        for discord_id, display_name in names.items():
-            discord_id = str(discord_id).strip()
-            display_name = str(display_name).strip()[:200]
-            if not discord_id or not display_name:
-                continue
+        valid_names = [
+            (str(did).strip(), str(name).strip()[:200])
+            for did, name in names.items()
+            if str(did).strip() and str(name).strip()
+        ]
+        if valid_names:
+            name_placeholders = ', '.join(f'(:did_{i}, :name_{i}, :ts)' for i in range(len(valid_names)))
+            name_params: dict = {'ts': ts}
+            for i, (did, name) in enumerate(valid_names):
+                name_params[f'did_{i}'] = did
+                name_params[f'name_{i}'] = name
             db.session.execute(
                 text(
-                    "INSERT INTO discord_display_names (discord_id, display_name, updated_at)"
-                    " VALUES (:did, :name, :ts)"
-                    " ON CONFLICT(discord_id)"
-                    " DO UPDATE SET display_name=excluded.display_name, updated_at=excluded.updated_at"
+                    f"INSERT INTO discord_display_names (discord_id, display_name, updated_at)"
+                    f" VALUES {name_placeholders}"
+                    f" ON CONFLICT(discord_id)"
+                    f" DO UPDATE SET display_name=excluded.display_name, updated_at=excluded.updated_at"
                 ),
-                {'did': discord_id, 'name': display_name, 'ts': ts},
+                name_params,
             )
 
     db.session.commit()
-    return jsonify({'ok': True, 'flushed': flushed})
+    return jsonify({'ok': True, 'flushed': len(valid)})
 
 
 @bp.route('/periods/recent', methods=['GET'])


### PR DESCRIPTION
## Critical fix: site unresponsive during backfill scans

### Root cause

`POST /api/discord-activity/record` was executing N individual `db.session.execute()` calls in a loop — each one a separate HTTP round-trip to Turso. With 500 entries at ~200ms each = ~100 seconds per request, consistently blowing Cloud Run's 2-minute timeout and returning 504s, making the site unresponsive during backfill scans.

### Changes

**`api.py` — bulk INSERT:**
- Collect and validate all entries first, then issue a single `INSERT ... VALUES (…), (…), … ON CONFLICT DO UPDATE` statement
- Same for display names
- libsql supports 32,766 bound variables; 500 rows × 4 params = 2,000 — well within limit
- One Turso round-trip instead of 500

**`activityBackfillScanner.ts` — reduce flush threshold:**
- Lower `FLUSH_THRESHOLD` from 500 → 200 entries per flush for smaller, more frequent payloads

## Test plan

- [ ] Merge, web auto-deploys
- [ ] Rebuild bot on Ursula
- [ ] Run `/lasombra scan-activity category:cubby` — confirm no more 504s in Cloud Run logs and site stays responsive
- [ ] Check Reports page for data after scan completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)