### PR TITLE
fix: restrict findCubbyChannel to cubby categories

### DIFF
--- a/apps/bot/src/services/cubbyChannels.ts
+++ b/apps/bot/src/services/cubbyChannels.ts
@@ -37,10 +37,20 @@ function isNotificationChannel(channel: GuildBasedChannel | null | undefined): c
 export async function findCubbyChannel(guild: Guild, characterName: string): Promise<NotificationChannel | null> {
   const target = normalizeChannelName(characterName);
   const channels = await guild.channels.fetch();
+
+  // Restrict to cubby categories (same logic as buildCubbyChannelMap).
+  const cubbyParentIds = new Set<string>();
   for (const channel of channels.values()) {
-    if (!isNotificationChannel(channel)) {
-      continue;
+    if (channel && channel.type === ChannelType.GuildCategory) {
+      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+        cubbyParentIds.add(channel.id);
+      }
     }
+  }
+
+  for (const channel of channels.values()) {
+    if (!isNotificationChannel(channel)) continue;
+    if (!channel.parentId || !cubbyParentIds.has(channel.parentId)) continue;
     if (normalizeChannelName(channel.name) === target) {
       return channel;
     }
@@ -51,9 +61,9 @@ export async function findCubbyChannel(guild: Guild, characterName: string): Pro
     return null;
   }
   for (const thread of activeThreads.threads.values()) {
-    if (!isNotificationChannel(thread)) {
-      continue;
-    }
+    if (!isNotificationChannel(thread)) continue;
+    const parent = channels.get(thread.parentId ?? '');
+    if (!parent?.parentId || !cubbyParentIds.has(parent.parentId)) continue;
     if (normalizeChannelName(thread.name) === target) {
       return thread;
     }


### PR DESCRIPTION
## Summary

`claimReminderService` and `autoPeriodCloser` both call `findCubbyChannel`, which was doing a guild-wide name search with no category restriction. Any thread or channel in the server whose normalized name matched a character name — including threads inside the OOC "Character Profiles" category — would receive XP claim reminders and period-close notifications incorrectly.

`a0f5ca5` fixed `buildCubbyChannelMap` (used by the review notifier) with the same category filter, but `findCubbyChannel` was missed.

This applies the identical cubby category restriction to `findCubbyChannel`: only channels/threads whose parent category name exactly matches one of the four cubby category names (`ancilla character cubbies`, `neonate character cubbies`, `fledgeling character cubbies`, `mortal character cubbies`) are eligible.

## Affected services

- `claimReminderService` — sunrise XP submission reminders
- `autoPeriodCloser` — period-close missed-claim notices
- `xp.ts` staff cubby-reminder command

## Test plan

- [ ] Confirm a claim reminder is still sent to a character's actual cubby channel
- [ ] Confirm no message is sent to a same-named thread in an OOC/other category

🤖 Generated with [Claude Code](https://claude.com/claude-code)