### PR TITLE
Character creator: flatten generator steps to list/collapsible style

### DIFF
--- a/apps/character-app/src/generator/components/CeremoniesPicker.tsx
+++ b/apps/character-app/src/generator/components/CeremoniesPicker.tsx
@@ -54,122 +54,124 @@ const DetailRow = ({ label, value }: { label: string; value: string }) => (
     </div>
 )
 
-const CeremonyCard = ({
+const CeremonyRow = ({
     ceremony,
     canTake,
-    onTake
+    onTake,
 }: {
     ceremony: Ceremony
     canTake: boolean
     onTake: () => void
 }) => {
-    const [hovered, setHovered] = useState(false)
-    const isHighlighted = hovered && canTake
+    const [expanded, setExpanded] = useState(false)
     const prerequisiteLabel = getCeremonyPrerequisiteLabel(ceremony)
 
     return (
-        <div
-            style={{
-                display: "flex",
-                flexDirection: "column",
-                height: "100%",
-                padding: "14px 16px",
-                borderRadius: 10,
-                border: `1px solid ${isHighlighted ? rgba(RAW_RED, 0.45) : "rgba(125, 91, 72, 0.25)"}`,
-                background: isHighlighted
-                    ? "linear-gradient(180deg, rgba(40, 14, 18, 0.85) 0%, rgba(20, 7, 10, 0.9) 100%)"
-                    : "linear-gradient(180deg, rgba(18, 13, 16, 0.55) 0%, rgba(8, 6, 8, 1) 100%)",
-                transition: "background 180ms ease, border-color 180ms ease",
-                marginBottom: 10
-            }}
-        >
-            <Group justify="space-between" align="flex-start" mb={6}>
+        <div style={{ borderBottom: "1px solid rgba(125, 91, 72, 0.15)", opacity: canTake ? 1 : 0.55 }}>
+            {/* Collapsed header */}
+            <button
+                onClick={() => setExpanded((e) => !e)}
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    width: "100%",
+                    padding: "10px 14px",
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    textAlign: "left" as const,
+                }}
+            >
+                <Badge variant="light" color="pink" radius="sm" size="xs" style={{ flexShrink: 0 }}>
+                    lv {ceremony.level}
+                </Badge>
                 <Text
                     style={{
+                        flex: 1,
                         fontFamily: "Cinzel, Georgia, serif",
                         fontSize: "0.88rem",
                         fontWeight: 700,
                         color: canTake ? "rgba(244, 236, 232, 0.95)" : rgba(RAW_GREY, 0.54),
                         letterSpacing: "0.04em",
-                        flex: 1
                     }}
                 >
                     {ceremony.name}
                 </Text>
-                <Badge variant="light" color="pink" radius="sm" size="xs" style={{ flexShrink: 0 }}>
-                    lv {ceremony.level}
-                </Badge>
-            </Group>
+                {!canTake && (
+                    <Text
+                        style={{
+                            flexShrink: 0,
+                            fontFamily: "Inter, sans-serif",
+                            fontSize: "0.72rem",
+                            color: "rgb(255, 112, 112)",
+                        }}
+                    >
+                        needs {prerequisiteLabel}
+                    </Text>
+                )}
+                <span style={{ color: "rgba(220, 210, 205, 0.45)", fontSize: "0.8rem", flexShrink: 0 }}>
+                    {expanded ? "▲" : "▼"}
+                </span>
+            </button>
 
-            <Text
-                style={{
-                    fontFamily: "Crimson Text, Georgia, serif",
-                    fontSize: "0.95rem",
-                    color: canTake ? rgba(RAW_GREY, 0.7) : rgba(RAW_GREY, 0.46),
-                    lineHeight: 1.45,
-                    marginBottom: 10,
-                    minHeight: "5.6rem"
-                }}
-            >
-                {upcase(ceremony.summary)}
-            </Text>
-            {!canTake ? (
-                <Text
-                    style={{
-                        fontFamily: "Inter, sans-serif",
-                        fontSize: "0.78rem",
-                        color: "rgb(255, 112, 112)",
-                        fontWeight: 700,
-                        marginBottom: 10,
-                        textShadow: "0 1px 2px rgba(0, 0, 0, 0.75)"
-                    }}
-                >
-                    Requires '{prerequisiteLabel}'
-                </Text>
-            ) : null}
+            {/* Expanded body */}
+            {expanded && (
+                <Box px={14} pb={14}>
+                    <Text
+                        style={{
+                            fontFamily: "Crimson Text, Georgia, serif",
+                            fontSize: "0.95rem",
+                            color: canTake ? rgba(RAW_GREY, 0.7) : rgba(RAW_GREY, 0.46),
+                            lineHeight: 1.45,
+                            marginBottom: 10,
+                        }}
+                    >
+                        {upcase(ceremony.summary)}
+                    </Text>
 
-            <div
-                style={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr 1fr",
-                    gap: "4px 16px",
-                    marginBottom: 12,
-                    padding: "8px 10px",
-                    borderRadius: 6,
-                    background: "rgba(255, 255, 255, 0.03)",
-                    border: "1px solid rgba(255, 255, 255, 0.05)"
-                }}
-            >
-                <DetailRow label="Dice Pool" value={ceremony.dicePool} />
-                <DetailRow label="Time" value={ceremony.requiredTime} />
-                <DetailRow label="Requires" value={prerequisiteLabel} />
-                <DetailRow label="Rouse Checks" value={String(ceremony.rouseChecks)} />
-            </div>
+                    <div
+                        style={{
+                            display: "grid",
+                            gridTemplateColumns: "1fr 1fr",
+                            gap: "4px 16px",
+                            marginBottom: 12,
+                            padding: "8px 10px",
+                            borderRadius: 6,
+                            background: "rgba(255, 255, 255, 0.03)",
+                            border: "1px solid rgba(255, 255, 255, 0.05)",
+                        }}
+                    >
+                        <DetailRow label="Dice Pool" value={ceremony.dicePool} />
+                        <DetailRow label="Time" value={ceremony.requiredTime} />
+                        <DetailRow label="Requires" value={prerequisiteLabel} />
+                        <DetailRow label="Rouse Checks" value={String(ceremony.rouseChecks)} />
+                    </div>
 
-            <Button
-                size="xs"
-                variant="outline"
-                color="red"
-                fullWidth
-                mt="auto"
-                onMouseEnter={() => setHovered(true)}
-                onMouseLeave={() => setHovered(false)}
-                disabled={!canTake}
-                styles={{
-                    root: {
-                        borderColor: isHighlighted ? rgba(RAW_RED, 0.85) : rgba(RAW_RED, 0.4),
-                        background: isHighlighted ? rgba(RAW_RED, 0.24) : rgba(RAW_RED, 0.08),
-                        letterSpacing: "0.14em",
-                        textTransform: "uppercase",
-                        fontFamily: "Cinzel, Georgia, serif",
-                        fontSize: "0.72rem",
-                        cursor: canTake ? "pointer" : "not-allowed"
-                    }
-                }}
-                onClick={onTake}
-            >
-                Take {ceremony.name}
-            </Button>
+                    <Group justify="flex-end">
+                        <Button
+                            size="xs"
+                            variant="outline"
+                            color="red"
+                            disabled={!canTake}
+                            styles={{
+                                root: {
+                                    borderColor: rgba(RAW_RED, 0.5),
+                                    background: rgba(RAW_RED, 0.08),
+                                    letterSpacing: "0.12em",
+                                    textTransform: "uppercase",
+                                    fontFamily: "Cinzel, Georgia, serif",
+                                    fontSize: "0.72rem",
+                                    cursor: canTake ? "pointer" : "not-allowed",
+                                },
+                            }}
+                            onClick={onTake}
+                        >
+                            Take {ceremony.name}
+                        </Button>
+                    </Group>
+                </Box>
+            )}
         </div>
     )
 }
@@ -240,11 +242,10 @@ const CeremoniesPicker = ({ character, setCharacter, nextStep }: CeremoniesPicke
 
                         <div
                             style={{
-                                display: "grid",
-                                gridTemplateColumns: phoneScreen ? "1fr" : "1fr 1fr",
-                                alignItems: "stretch",
-                                gap: 12,
-                                columnGap: 12
+                                borderRadius: 8,
+                                border: "1px solid rgba(125, 91, 72, 0.2)",
+                                background: "rgba(18, 13, 16, 0.55)",
+                                overflow: "hidden",
                             }}
                         >
                             {levelOneCeremonies.map((ceremony) => {
@@ -252,9 +253,8 @@ const CeremoniesPicker = ({ character, setCharacter, nextStep }: CeremoniesPicke
                                     character,
                                     ceremony
                                 )
-
                                 return (
-                                    <CeremonyCard
+                                    <CeremonyRow
                                         key={ceremony.name}
                                         ceremony={ceremony}
                                         canTake={canTake}

--- a/apps/character-app/src/generator/components/LoresheetPicker.tsx
+++ b/apps/character-app/src/generator/components/LoresheetPicker.tsx
@@ -103,6 +103,16 @@ export default function LoresheetPicker({ character, setCharacter, nextStep }: L
         cc.getRestrictions().then((r) => setBannedIds(new Set(r.loresheets))).catch(() => {})
     }, [])
 
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+    const toggleExpanded = (id: string) => {
+        setExpandedIds((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) next.delete(id)
+            else next.add(id)
+            return next
+        })
+    }
+
     const visibleLoresheets = LORESHEETS.filter(
         (ls) => isLoresheetAvailable(ls, clan) && !bannedIds.has(ls.id),
     )
@@ -225,28 +235,41 @@ export default function LoresheetPicker({ character, setCharacter, nextStep }: L
                             margin: "0 auto",
                         }}
                     >
-                        {visibleLoresheets.map((loresheet) => (
+                        {visibleLoresheets.map((loresheet) => {
+                            const isExpanded = expandedIds.has(loresheet.id)
+                            const purchasedCount = (character.loresheet_purchases ?? []).filter(
+                                (p) => p.loresheet_id === loresheet.id,
+                            ).length
+
+                            return (
                             <div
                                 key={loresheet.id}
                                 style={{
                                     borderRadius: 10,
-                                    border: `1px solid ${C_BORDER}`,
+                                    border: `1px solid ${purchasedCount > 0 ? rgba(RAW_RED, 0.35) : C_BORDER}`,
                                     background: C_CARD,
                                     overflow: "hidden",
                                 }}
                             >
-                                {/* Loresheet header */}
-                                <div
+                                {/* Loresheet header — clickable toggle */}
+                                <button
+                                    onClick={() => toggleExpanded(loresheet.id)}
                                     style={{
-                                        padding: "14px 18px 12px",
-                                        borderBottom: `1px solid rgba(125, 91, 72, 0.2)`,
                                         display: "flex",
                                         alignItems: "center",
                                         justifyContent: "space-between",
                                         gap: 12,
+                                        width: "100%",
+                                        padding: "14px 18px 12px",
+                                        background: "transparent",
+                                        border: "none",
+                                        borderBottom: isExpanded ? `1px solid rgba(125, 91, 72, 0.2)` : "none",
+                                        cursor: "pointer",
+                                        textAlign: "left",
+                                        fontFamily: "inherit",
                                     }}
                                 >
-                                    <div>
+                                    <div style={{ flex: 1, minWidth: 0 }}>
                                         <p
                                             style={{
                                                 margin: 0,
@@ -274,26 +297,49 @@ export default function LoresheetPicker({ character, setCharacter, nextStep }: L
                                             </p>
                                         )}
                                     </div>
-                                    {/* Source badge */}
-                                    <span
-                                        style={{
-                                            flexShrink: 0,
-                                            padding: "3px 8px",
-                                            borderRadius: 4,
-                                            border: `1px solid rgba(125, 91, 72, 0.3)`,
-                                            fontFamily: FONT_UI,
-                                            fontSize: "0.62rem",
-                                            letterSpacing: "0.1em",
-                                            textTransform: "uppercase",
-                                            color: C_MUTED,
-                                        }}
-                                    >
-                                        {sourceLabel(loresheet.source)}
-                                    </span>
-                                </div>
+                                    <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                                        {/* Purchased dots badge */}
+                                        {purchasedCount > 0 && (
+                                            <span
+                                                style={{
+                                                    padding: "2px 8px",
+                                                    borderRadius: 4,
+                                                    border: `1px solid ${rgba(RAW_RED, 0.45)}`,
+                                                    background: rgba(RAW_RED, 0.12),
+                                                    fontFamily: FONT_UI,
+                                                    fontSize: "0.62rem",
+                                                    letterSpacing: "0.1em",
+                                                    textTransform: "uppercase",
+                                                    color: C_RED_DIM,
+                                                }}
+                                            >
+                                                {purchasedCount} dot{purchasedCount !== 1 ? "s" : ""}
+                                            </span>
+                                        )}
+                                        {/* Source badge */}
+                                        <span
+                                            style={{
+                                                padding: "3px 8px",
+                                                borderRadius: 4,
+                                                border: `1px solid rgba(125, 91, 72, 0.3)`,
+                                                fontFamily: FONT_UI,
+                                                fontSize: "0.62rem",
+                                                letterSpacing: "0.1em",
+                                                textTransform: "uppercase",
+                                                color: C_MUTED,
+                                            }}
+                                        >
+                                            {sourceLabel(loresheet.source)}
+                                        </span>
+                                        {/* Chevron */}
+                                        <span style={{ color: "rgba(220, 210, 205, 0.45)", fontSize: "0.8rem" }}>
+                                            {isExpanded ? "▲" : "▼"}
+                                        </span>
+                                    </div>
+                                </button>
 
-                                {/* Dots */}
-                                <div style={{ padding: "8px 0" }}>
+                                {/* Dots — only when expanded */}
+                                {isExpanded && <div style={{ padding: "8px 0" }}>
                                     {loresheet.dots.map((dotEntry) => {
                                         const purchased = isPurchased(character, loresheet.id, dotEntry.dot)
                                         const dotAvailable = isDotAvailable(dotEntry, clan)
@@ -431,9 +477,10 @@ export default function LoresheetPicker({ character, setCharacter, nextStep }: L
                                             </button>
                                         )
                                     })}
-                                </div>
+                                </div>}
                             </div>
-                        ))}
+                        )
+                        })}
                     </div>
 
                     {/* Continue button */}

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -169,71 +169,73 @@ const MeritOrFlawCard = memo(
             <Box
                 key={lineKey}
                 style={{
-                    padding: phoneScreen ? "12px" : "14px 16px",
-                    borderRadius: 14,
-                    border: `1px solid ${alreadyPickedItem ? selectedBorder : baseBorder}`,
-                    background: alreadyPickedItem ? selectedBg : baseBg,
+                    padding: phoneScreen ? "8px 10px" : "9px 12px",
+                    borderRadius: 5,
+                    borderLeft: alreadyPickedItem ? `3px solid ${accentColor}` : "3px solid transparent",
+                    borderBottom: `1px solid ${alreadyPickedItem ? selectedBorder : baseBorder}`,
+                    background: alreadyPickedItem ? selectedBg : "transparent",
                     opacity: isExcluded ? 0.5 : 1,
-                    transition: "background 180ms ease, border-color 180ms ease"
+                    transition: "background 180ms ease",
                 }}
             >
-                <Group justify="space-between" align="flex-start" gap="sm" mb={6}>
+                <Group justify="space-between" align="center" gap="xs" wrap="nowrap">
                     <Text
                         style={{
                             fontFamily: "Cinzel, Georgia, serif",
-                            fontSize: phoneScreen ? "0.88rem" : "0.94rem",
+                            fontSize: phoneScreen ? "0.84rem" : "0.88rem",
                             fontWeight: 600,
                             lineHeight: 1.3,
                             color: alreadyPickedItem ? accentColor : "rgba(244, 236, 232, 0.94)",
-                            flex: 1
+                            flex: 1,
+                            minWidth: 0,
                         }}
                     >
                         {icon} &nbsp;<span>{meritOrFlaw.name}</span>
                     </Text>
+                    <Group gap={4} style={{ flexShrink: 0 }}>
+                        {meritOrFlaw.cost.map((i) => createButton(i))}
+                        {alreadyPickedItem ? (
+                            <Button
+                                onClick={() => {
+                                    setPickedMeritsAndFlaws((prev) =>
+                                        prev.filter((m) => m.name !== meritOrFlaw.name)
+                                    )
+                                    if (isThinbloodFlaw(meritOrFlaw.name)) {
+                                        setRemainingThinbloodMeritPoints((prev) => prev - 1)
+                                    } else if (isThinbloodMerit(meritOrFlaw.name)) {
+                                        setRemainingThinbloodMeritPoints((prev) => prev + 1)
+                                    } else if (type === "flaw") {
+                                        setRemainingFlaws((prev) => prev + cost)
+                                    } else {
+                                        setRemainingMerits((prev) => prev + cost)
+                                    }
+                                }}
+                                size="xs"
+                                variant="subtle"
+                                color="yellow"
+                                styles={{ root: { paddingLeft: 6, paddingRight: 6 } }}
+                            >
+                                ×
+                            </Button>
+                        ) : null}
+                    </Group>
                 </Group>
 
                 <Text
                     style={{
                         fontFamily: "Crimson Text, Georgia, serif",
-                        fontSize: phoneScreen ? "0.95rem" : "1rem",
-                        lineHeight: 1.45,
+                        fontSize: phoneScreen ? "0.88rem" : "0.92rem",
+                        lineHeight: 1.4,
                         color: meritInPredatorType
                             ? "rgba(212, 176, 105, 0.88)"
                             : isExcluded
-                              ? rgba(RAW_GREY, 0.72)
-                              : rgba(RAW_GREY, 0.88)
+                              ? rgba(RAW_GREY, 0.6)
+                              : rgba(RAW_GREY, 0.72),
+                        marginTop: 2,
                     }}
                 >
                     {summaryText}
                 </Text>
-
-                <Group gap={6} mt={10}>
-                    {meritOrFlaw.cost.map((i) => createButton(i))}
-                    {alreadyPickedItem ? (
-                        <Button
-                            onClick={() => {
-                                setPickedMeritsAndFlaws((prev) =>
-                                    prev.filter((m) => m.name !== meritOrFlaw.name)
-                                )
-                                if (isThinbloodFlaw(meritOrFlaw.name)) {
-                                    setRemainingThinbloodMeritPoints((prev) => prev - 1)
-                                } else if (isThinbloodMerit(meritOrFlaw.name)) {
-                                    setRemainingThinbloodMeritPoints((prev) => prev + 1)
-                                } else if (type === "flaw") {
-                                    setRemainingFlaws((prev) => prev + cost)
-                                } else {
-                                    setRemainingMerits((prev) => prev + cost)
-                                }
-                            }}
-                            size="xs"
-                            variant="subtle"
-                            color="yellow"
-                            styles={{ root: { paddingLeft: 8, paddingRight: 8 } }}
-                        >
-                            Unpick
-                        </Button>
-                    ) : null}
-                </Group>
             </Box>
         )
 

--- a/apps/character-app/src/generator/components/PredatorTypePicker.tsx
+++ b/apps/character-app/src/generator/components/PredatorTypePicker.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ScrollArea, SimpleGrid, Stack, Text } from "@mantine/core"
+import { Box, Button, ScrollArea, Stack, Text } from "@mantine/core"
 import { RAW_GRAPE, RAW_GREY, RAW_RED, rgba } from "~/theme/colors"
 import { useDisclosure } from "@mantine/hooks"
 import { useEffect, useState } from "react"
@@ -100,7 +100,7 @@ const PredatorTypePicker = ({ character, setCharacter, nextStep }: PredatorTypeP
     const [specialty, setSpecialty] = useState("")
     const [discipline, setDiscipline] = useState("")
 
-    const createCard = (predatorTypeName: PredatorTypeName, meta: CategoryMeta) => {
+    const createRow = (predatorTypeName: PredatorTypeName, meta: CategoryMeta) => {
         const clanDisabled =
             clans[character.clan]?.excludedPredatorTypes?.includes(predatorTypeName) ?? false
         const isDisabled = clanDisabled || isThinBlood
@@ -121,95 +121,84 @@ const PredatorTypePicker = ({ character, setCharacter, nextStep }: PredatorTypeP
                     openModal()
                 }}
                 onMouseEnter={(e) => {
-                    if (!isDisabled && !isSelected) {
-                        e.currentTarget.style.background = meta.bgActiveColor
-                        e.currentTarget.style.borderColor = meta.borderColor
-                        e.currentTarget.style.transform = "translateY(-2px)"
-                    }
+                    if (!isDisabled && !isSelected)
+                        e.currentTarget.style.background = "rgba(255,255,255,0.04)"
                 }}
                 onMouseLeave={(e) => {
-                    e.currentTarget.style.background = isSelected
-                        ? meta.bgActiveColor
-                        : meta.bgColor
-                    e.currentTarget.style.borderColor = isSelected
-                        ? meta.borderActiveColor
-                        : meta.borderColor
-                    e.currentTarget.style.transform = "translateY(0)"
+                    e.currentTarget.style.background = isSelected ? meta.bgActiveColor : "transparent"
                 }}
                 style={{
-                    padding: "10px 12px",
-                    borderRadius: "12px",
-                    border: `1px solid ${isSelected ? meta.borderActiveColor : meta.borderColor}`,
-                    background: isSelected ? meta.bgActiveColor : meta.bgColor,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 14,
+                    padding: "9px 14px 9px 12px",
+                    borderRadius: 7,
+                    borderLeft: `3px solid ${isSelected ? meta.accentColor : "transparent"}`,
+                    border: `1px solid ${isSelected ? meta.borderActiveColor : "rgba(125, 91, 72, 0.15)"}`,
+                    background: isSelected ? meta.bgActiveColor : "transparent",
                     cursor: isDisabled ? "not-allowed" : "pointer",
                     opacity: isDisabled ? 0.38 : 1,
-                    transition:
-                        "background 200ms ease, border-color 200ms ease, transform 160ms ease",
-                    display: "flex",
-                    flexDirection: "column" as const,
-                    gap: "6px",
-                    boxShadow: isSelected ? `0 0 18px ${meta.bgActiveColor}` : "none"
+                    transition: "background 150ms ease, border-color 150ms ease",
+                    marginBottom: 4,
                 }}
             >
-                <Text
-                    style={{
-                        fontFamily: "Cinzel, Georgia, serif",
-                        fontSize: "0.95rem",
-                        fontWeight: 800,
-                        letterSpacing: "0.04em",
-                        color: "rgb(244, 236, 232)"
-                    }}
-                >
-                    {predatorTypeName}
+                {/* Name */}
+                <div style={{ flex: "0 0 auto", minWidth: phoneScreen ? 100 : 130 }}>
+                    <Text
+                        style={{
+                            fontFamily: "Cinzel, Georgia, serif",
+                            fontSize: "0.88rem",
+                            fontWeight: 700,
+                            letterSpacing: "0.03em",
+                            color: isSelected ? meta.accentColor : "rgba(244, 236, 232, 0.95)",
+                        }}
+                    >
+                        {predatorTypeName}
+                    </Text>
                     {clanDisabled && (
-                        <span
+                        <Text
                             style={{
-                                marginLeft: 8,
-                                fontSize: "0.78rem",
+                                fontSize: "0.72rem",
                                 color: "rgba(244, 236, 232, 0.35)",
                                 fontFamily: "Inter, sans-serif",
-                                fontWeight: 400,
-                                letterSpacing: 0
                             }}
                         >
                             excluded for {character.clan}
-                        </span>
+                        </Text>
                     )}
-                </Text>
+                </div>
 
+                {/* Summary */}
                 <Text
                     style={{
+                        flex: 1,
                         fontFamily: "Crimson Text, Georgia, serif",
-                        fontSize: "0.9rem",
-                        color: rgba(RAW_GREY, 0.93),
-                        lineHeight: 1.4
+                        fontSize: "0.88rem",
+                        color: rgba(RAW_GREY, 0.75),
+                        lineHeight: 1.35,
                     }}
                 >
                     {predatorType.summary}
                 </Text>
 
-                <div
-                    style={{
-                        display: "flex",
-                        gap: "4px",
-                        flexWrap: "wrap" as const,
-                        marginTop: "3px"
-                    }}
-                >
+                {/* Discipline pills */}
+                <div style={{ flexShrink: 0, display: "flex", gap: 4, flexWrap: "wrap" as const, justifyContent: "flex-end" }}>
                     {predatorType.disciplineOptions.map((disc) => (
                         <span
                             key={disc.name}
                             style={{
-                                fontSize: "0.72rem",
+                                fontSize: "0.68rem",
                                 fontFamily: "Inter, Segoe UI, sans-serif",
-                                padding: "2px 8px",
+                                padding: "2px 7px",
                                 borderRadius: "999px",
                                 background: meta.pillColor,
                                 border: `1px solid ${meta.borderColor}`,
-                                letterSpacing: "0.03em"
+                                letterSpacing: "0.03em",
+                                color: "rgba(244, 236, 232, 0.85)",
+                                whiteSpace: "nowrap" as const,
                             }}
                         >
-                            <Text fz={"xs"}>{titleCase(disc.name)}</Text>
+                            {titleCase(disc.name)}
                         </span>
                     ))}
                 </div>
@@ -233,9 +222,9 @@ const PredatorTypePicker = ({ character, setCharacter, nextStep }: PredatorTypeP
                         color={meta.accentColor}
                         lineColor={meta.lineColor}
                     />
-                    <SimpleGrid cols={phoneScreen ? 1 : 2} spacing="sm">
-                        {meta.predatorTypes.map((name) => createCard(name, meta))}
-                    </SimpleGrid>
+                    <div>
+                        {meta.predatorTypes.map((name) => createRow(name, meta))}
+                    </div>
                 </Box>
             ))}
         </Stack>

--- a/apps/character-app/src/generator/components/RitualsPicker.tsx
+++ b/apps/character-app/src/generator/components/RitualsPicker.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Button, Group, ScrollArea, Stack, Text } from "@mantine/core"
+import { Badge, Box, Button, Group, ScrollArea, Text } from "@mantine/core"
 import { RAW_GOLD, RAW_GREY, RAW_RED, rgba } from "~/theme/colors"
 import { useEffect, useState } from "react"
 import ReactGA from "react-ga4"
@@ -24,104 +24,101 @@ type RitualsPickerProps = {
 
 const GOLD_LABEL_COLOR = rgba(RAW_GOLD, 1)
 
-const RitualCard = ({ ritual, onTake }: { ritual: Ritual; onTake: () => void }) => {
-    const [hovered, setHovered] = useState(false)
+const RitualRow = ({ ritual, onTake }: { ritual: Ritual; onTake: () => void }) => {
+    const [expanded, setExpanded] = useState(false)
 
     return (
-        <div
-            style={{
-                display: "flex",
-                flexDirection: "column",
-                height: "100%",
-                padding: "14px 16px",
-                borderRadius: 10,
-                border: `1px solid ${hovered ? rgba(RAW_RED, 0.45) : "rgba(125, 91, 72, 0.25)"}`,
-                background: hovered
-                    ? "linear-gradient(180deg, rgba(40, 14, 18, 0.85) 0%, rgba(20, 7, 10, 0.9) 100%)"
-                    : "linear-gradient(180deg, rgba(18, 13, 16, 0.55) 0%, rgba(8, 6, 8, 1) 100%)",
-                transition: "background 180ms ease, border-color 180ms ease",
-                marginBottom: 10
-            }}
-        >
-            <Group justify="space-between" align="flex-start" mb={6}>
+        <div style={{ borderBottom: "1px solid rgba(125, 91, 72, 0.15)" }}>
+            {/* Collapsed header */}
+            <button
+                onClick={() => setExpanded((e) => !e)}
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    width: "100%",
+                    padding: "10px 14px",
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    textAlign: "left" as const,
+                }}
+            >
+                <Badge variant="light" color="pink" radius="sm" size="xs" style={{ flexShrink: 0 }}>
+                    lv {ritual.level}
+                </Badge>
                 <Text
                     style={{
+                        flex: 1,
                         fontFamily: "Cinzel, Georgia, serif",
                         fontSize: "0.88rem",
                         fontWeight: 700,
                         color: "rgba(244, 236, 232, 0.95)",
                         letterSpacing: "0.04em",
-                        flex: 1
                     }}
                 >
                     {ritual.name}
                 </Text>
-                <Badge variant="light" color="pink" radius="sm" size="xs" style={{ flexShrink: 0 }}>
-                    lv {ritual.level}
-                </Badge>
-            </Group>
+                <span style={{ color: "rgba(220, 210, 205, 0.45)", fontSize: "0.8rem", flexShrink: 0 }}>
+                    {expanded ? "▲" : "▼"}
+                </span>
+            </button>
 
-            <Text
-                style={{
-                    fontFamily: "Crimson Text, Georgia, serif",
-                    fontSize: "0.95rem",
-                    color: rgba(RAW_GREY, 0.7),
-                    lineHeight: 1.45,
-                    marginBottom: 10,
-                    minHeight: "5.6rem"
-                }}
-            >
-                {upcase(ritual.summary)}
-            </Text>
+            {/* Expanded body */}
+            {expanded && (
+                <Box px={14} pb={14}>
+                    <Text
+                        style={{
+                            fontFamily: "Crimson Text, Georgia, serif",
+                            fontSize: "0.95rem",
+                            color: rgba(RAW_GREY, 0.7),
+                            lineHeight: 1.45,
+                            marginBottom: 10,
+                        }}
+                    >
+                        {upcase(ritual.summary)}
+                    </Text>
 
-            <div
-                style={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr 1fr",
-                    gap: "4px 16px",
-                    marginBottom: 12,
-                    padding: "8px 10px",
-                    borderRadius: 6,
-                    background: "rgba(255, 255, 255, 0.03)",
-                    border: "1px solid rgba(255, 255, 255, 0.05)"
-                }}
-            >
-                <DetailRow label="Dice Pool" value={ritual.dicePool} />
-                <DetailRow label="Time" value={ritual.requiredTime} />
-                <DetailRow label="Ingredients" value={ritual.ingredients} />
-                <DetailRow label="Rouse Checks" value={String(ritual.rouseChecks)} />
-            </div>
+                    <div
+                        style={{
+                            display: "grid",
+                            gridTemplateColumns: "1fr 1fr",
+                            gap: "4px 16px",
+                            marginBottom: 12,
+                            padding: "8px 10px",
+                            borderRadius: 6,
+                            background: "rgba(255, 255, 255, 0.03)",
+                            border: "1px solid rgba(255, 255, 255, 0.05)",
+                        }}
+                    >
+                        <DetailRow label="Dice Pool" value={ritual.dicePool} />
+                        <DetailRow label="Time" value={ritual.requiredTime} />
+                        <DetailRow label="Ingredients" value={ritual.ingredients} />
+                        <DetailRow label="Rouse Checks" value={String(ritual.rouseChecks)} />
+                    </div>
 
-            <Button
-                size="xs"
-                variant="outline"
-                color="red"
-                fullWidth
-                mt="auto"
-                onMouseEnter={() => setHovered(true)}
-                onMouseLeave={() => setHovered(false)}
-                styles={{
-                    root: {
-                        borderColor: hovered ? rgba(RAW_RED, 0.85) : rgba(RAW_RED, 0.4),
-                        background: hovered ? rgba(RAW_RED, 0.24) : rgba(RAW_RED, 0.08),
-                        boxShadow: hovered
-                            ? `0 0 0 1px ${rgba(RAW_RED, 0.22)}, 0 0 18px ${rgba(RAW_RED, 0.18)}, 0 10px 24px ${rgba(RAW_RED, 0.18)}`
-                            : "none",
-                        transform: hovered
-                            ? "translateY(-1px) scale(1.01)"
-                            : "translateY(0) scale(1)",
-                        transition:
-                            "background 120ms ease, border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease",
-                        letterSpacing: "0.14em",
-                        textTransform: "uppercase",
-                        fontFamily: "Cinzel, Georgia, serif",
-                        fontSize: "0.72rem"
-                    }
-                }}
-                onClick={onTake}
-            >
-                Take {ritual.name}
-            </Button>
+                    <Group justify="flex-end">
+                        <Button
+                            size="xs"
+                            variant="outline"
+                            color="red"
+                            styles={{
+                                root: {
+                                    borderColor: rgba(RAW_RED, 0.5),
+                                    background: rgba(RAW_RED, 0.08),
+                                    letterSpacing: "0.12em",
+                                    textTransform: "uppercase",
+                                    fontFamily: "Cinzel, Georgia, serif",
+                                    fontSize: "0.72rem",
+                                },
+                            }}
+                            onClick={onTake}
+                        >
+                            Take {ritual.name}
+                        </Button>
+                    </Group>
+                </Box>
+            )}
         </div>
     )
 }
@@ -200,15 +197,14 @@ const RitualsPicker = ({ character, setCharacter, nextStep }: RitualsPickerProps
 
                         <div
                             style={{
-                                display: "grid",
-                                gridTemplateColumns: phoneScreen ? "1fr" : "1fr 1fr",
-                                alignItems: "stretch",
-                                gap: 12,
-                                columnGap: 12
+                                borderRadius: 8,
+                                border: "1px solid rgba(125, 91, 72, 0.2)",
+                                background: "rgba(18, 13, 16, 0.55)",
+                                overflow: "hidden",
                             }}
                         >
                             {Rituals.map((ritual) => (
-                                <RitualCard
+                                <RitualRow
                                     key={ritual.name}
                                     ritual={ritual}
                                     onTake={() => handleTake(ritual)}


### PR DESCRIPTION
## Summary

- **PredatorTypePicker**: Replaced bubble cards with flat list rows — name column, summary text (flex), discipline pills right-aligned. Colored left-border accent when selected.
- **RitualsPicker**: Each ritual is a collapsible row. Collapsed shows level badge + name + chevron. Expanded shows summary, detail grid (Dice Pool / Time / Ingredients / Rouse Checks), and Take button.
- **CeremoniesPicker**: Same collapsible pattern as rituals. Rows where `canTake=false` show "needs X" in the collapsed header and render at 0.55 opacity.
- **MeritsAndFlawsPicker**: Flattened from rounded card (full border, background) to a list row — borderLeft accent only when selected, borderBottom separator, name + level buttons on same row, summary below.
- **LoresheetPicker**: All loresheets start collapsed. Click the header to expand dots. A red-tinted dot-count badge appears in the collapsed header when any dot is purchased; the card border also turns red.

## Test plan
- [ ] Predator Type: rows display name / summary / discipline pills; selected row shows red left-border accent; excluded types are dimmed
- [ ] Rituals: click any row to expand; detail grid and Take button appear; clicking Take advances step
- [ ] Ceremonies: same as rituals; rows requiring an unmet prerequisite show "needs X" and are dimmed
- [ ] Merits & Flaws: rows show name + level buttons inline; selecting one shows red left-border; deselect with ×
- [ ] Loresheets: all start collapsed; click header to expand/collapse; purchasing a dot shows badge + red card border; XP tracker updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)