### PR TITLE
Character creator overhaul + player XP adjustments visibility

### DIFF
--- a/apps/character-app/src/data/Loresheets.ts
+++ b/apps/character-app/src/data/Loresheets.ts
@@ -2426,27 +2426,27 @@ export const LORESHEETS: Loresheet[] = [
             {
                 dot: 1,
                 name: "The Art of Negotiation",
-                description: "As a skilled diplomat, advisor, or negotiator reflecting the legacy of Tegyrius, when you mediate between two opposing individuals or groups you receive a two-dice bonus to Intimidation or Persuasion skill tests.",
+                description: "As a skilled diplomat, advisor, or negotiator, the legacy of Tegyrius is reflected in you. When you mediate between two opposing individuals or groups, you receive a two-dice bonus to Intimidation or Persuasion skill tests.",
             },
             {
                 dot: 2,
                 name: "The Pen is Mightier",
-                description: "Following in the footsteps of Tegyrius, you value knowledge and hone your mental abilities as much as your fighting skills. You have access to a Banu Haqim library transplanted from Alamut during the Schism — a two-dot Haven (••) with a two-dot Library (••) — but its contents are sought by one of the Shepherds of Ur-Shulgi, counting as a two-dot Adversary.",
+                description: "Following in the footsteps of Tegyrius, you value knowledge and choose to hone your mental abilities just as much as you do your fighting skills. As a protégé of Tegyrius, you have access to a Banu Haqim library transplanted from Alamut during the Schism. The library counts as a two-dot Haven (••) with a two-dot Library (••), but its contents are being sought after by one of the Shepherds of Ur-Shulgi, counting as a two-dot Adversary.",
             },
             {
                 dot: 3,
                 name: "Hear My Words",
-                description: "You are a known ally of Tegyrius, and when you speak, others listen. As a source of wisdom and restraint, you get three additional dice for any social test against a Banu Haqim of the same sect, and two additional dice for any social test against a Banu Haqim of a different sect.",
+                description: "You are a known ally of Tegyrius, and when you speak, others listen. As a source of wisdom and restraint, you get three additional dice for any social test against another Banu Haqim of the same sect, and two additional dice for any social test against a Banu Haqim of a different sect.",
             },
             {
                 dot: 4,
                 name: "Perception is Power",
-                description: "You sat on the Council of Scrolls in Alamut, and under Tegyrius' guidance learned that one cannot fight what one cannot see. You have access to the Auspex Discipline and may buy dots using experience points as if it were one of your clan Disciplines.",
+                description: "In the hallowed halls of Alamut, the Council of Scrolls dedicated their unlives to the pursuit of academic knowledge. But when Ur-Shulgi awoke and seized the Black Throne, the Council disbanded. You sat on the Council, and under Tegyrius' guidance, learned that one cannot fight what one cannot see. You have access to the Auspex Discipline and may buy dots using experience points as if it was one of your clan Disciplines.",
             },
             {
                 dot: 5,
                 name: "A Matter of Honor",
-                description: "Not only were you a guest of honor at the Vermillion Wedding, but Tegyrius himself owes you a debt of gratitude. Once per chronicle, Tegyrius functions as a five-dot Mawla and uses his lofty position to aid you as best he can, short of violating the alliance between the Camarilla and the Ashirra.",
+                description: "Not only were you a guest of honor at the Vermillion Wedding, but Tegyrius himself owes you a debt of gratitude. Perhaps you assisted in his negotiations with the Camarilla, or maybe you saved his life several years ago. Once per chronicle, Tegyrius functions as a five-dot Mawla, and uses his lofty position to aid you as best he can (short of violating the alliance between the Camarilla and the Ashirra).",
             },
         ],
     },
@@ -2542,7 +2542,7 @@ export const LORESHEETS: Loresheet[] = [
             {
                 dot: 4,
                 name: "Hero of the Revolution",
-                description: "You were pivotal to the success of the Revolt and your compatriots know it. Once per story, you may call on former allies to summon an Anarch gang to your aid — five neonates, each with 4 dots in Disciplines (no power higher than level three) and a General Difficulty of 4/3. They only help if the action can be presented as part of the righteous struggle against the Camarilla.",
+                description: "Not only were you in Los Angeles, you were pivotal to the success of the Revolt and your compatriots know it. You fought in a crucial battle or stopped an important VIP from escaping. Once per story, you may call on former allies to summon an Anarch gang to your aid — five neonates, each with 4 dots in Disciplines (no power higher than level three) and a General Difficulty of 4/3. They only help if the action can be presented as part of the righteous struggle against the Camarilla.",
             },
             {
                 dot: 5,

--- a/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
@@ -461,9 +461,15 @@ export const essentialMeritsAndFlaws: MeritsAndFlaws[] = [
                 excludes: []
             },
             {
-                name: "Allies",
-                cost: [1, 2, 3, 4, 5],
-                summary: "group of mortals to advise or help you",
+                name: "Allies: Effectiveness",
+                cost: [1, 2, 3, 4],
+                summary: "how capable your ally group is. ● weak mortal (likely useless in violence). ●● average mortal or tight-knit group of weak mortals (church group, NGO chapter). ●●● gifted mortal or dangerous average group (street gang, blue-collar union local). ●●●● deadly mortal, gifted mortal with supernatural power, or well-armed group (private security squad, Mafia bratva). Effectiveness + Reliability combined may not exceed 6.",
+                excludes: []
+            },
+            {
+                name: "Allies: Reliability",
+                cost: [1, 2, 3],
+                summary: "how dependable your ally group is. ● appear about half the time. ●● appear within 1–10 hours (roll a die). ●●● appear as soon as possible. Effectiveness + Reliability combined may not exceed 6.",
                 excludes: []
             },
             {
@@ -499,7 +505,7 @@ export const essentialMeritsAndFlaws: MeritsAndFlaws[] = [
             {
                 name: "Enemy",
                 cost: [1, 2],
-                summary: "group of mortals that want to harm you",
+                summary: "mortal group working against you, rated two dots below their Effectiveness. ● enemy at Effectiveness ●●● (gifted mortal or dangerous group). ●● enemy at Effectiveness ●●●● (deadly mortal, well-armed group). Number of enemy groups equals number of player characters.",
                 excludes: []
             },
             {

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -28,10 +28,10 @@ import {
 } from "../../data/MeritsAndFlaws"
 import { PredatorTypes } from "../../data/PredatorType"
 import { globals } from "../../globals"
-import { Loresheets } from "./Loresheets"
+import { LORESHEETS, LoresheetDot } from "~/data/Loresheets"
+import { IconCheck } from "@tabler/icons-react"
 import { updateHealthAndWillpowerAndBloodPotencyAndHumanity } from "../utils"
 import {
-    generatorScrollableAreaStyle,
     generatorScrollableContentStyle,
     generatorScrollableShellStyle
 } from "./sharedGeneratorScrollableLayout"
@@ -53,6 +53,29 @@ const flawIcon = () => {
 }
 const meritIcon = () => {
     return <FontAwesomeIcon icon={faPlay} rotation={270} style={{ color: "rgb(47, 158, 68)" }} />
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+    core: "Core",
+    camarilla: "Camarilla",
+    anarch: "Anarch",
+    chicago: "Chicago by Night",
+    "players-guide": "Player's Guide",
+    "gehenna-war": "Gehenna War",
+    "in-memoriam": "In Memoriam",
+    "tattered-facade": "Tattered Facade",
+    "blood-sigils": "Blood Sigils",
+    "cults-of-the-blood-gods": "Cults of the Blood Gods",
+    "chicago-folios": "Chicago Folios",
+    "children-of-the-blood": "Children of the Blood",
+    "book-of-nod-apocrypha": "Book of Nod Apocrypha",
+    "let-the-streets-run-red": "Let the Streets Run Red",
+    "fall-of-london": "The Fall of London",
+    "forbidden-religions": "Forbidden Religions",
+    "trails-of-ash-and-bone": "Trails of Ash and Bone",
+    download: "Download",
+    "winters-teeth": "Winter's Teeth",
+    custom: "Nashville",
 }
 
 type MeritOrFlawCardProps = {
@@ -262,7 +285,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
     const theme = useMantineTheme()
     const phoneScreen = globals.isPhoneScreen
 
-    const [activeTab, setActiveTab] = useState<string | null>("merits")
+    const [activeTab, setActiveTab] = useState<string | null>("backgrounds")
     const [resetTarget, setResetTarget] = useState<ResetTarget>(null)
 
     const [pickedMeritsAndFlaws, setPickedMeritsAndFlaws] = useState<MeritFlaw[]>([
@@ -300,6 +323,35 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
     const [remainingThinbloodMeritPoints, setRemainingThinbloodMeritPoints] = useState(
         tbFlawCount - tbMeritCount
     )
+
+    const [expandedLoresheetIds, setExpandedLoresheetIds] = useState<Set<string>>(new Set())
+    const toggleLoresheetExpanded = (id: string) => {
+        setExpandedLoresheetIds(prev => {
+            const next = new Set(prev)
+            if (next.has(id)) { next.delete(id) } else { next.add(id) }
+            return next
+        })
+    }
+    const isLoresheetDotSelected = (dotName: string) =>
+        pickedMeritsAndFlaws.some(m => m.name === dotName && m.type === "merit")
+    const toggleLoresheetDot = (dot: LoresheetDot) => {
+        const selected = isLoresheetDotSelected(dot.name)
+        const cost = dot.dot
+        if (selected) {
+            setPickedMeritsAndFlaws(prev => prev.filter(m => m.name !== dot.name))
+            setRemainingMerits(prev => prev + cost)
+        } else {
+            if (remainingMerits < cost) return
+            setPickedMeritsAndFlaws(prev => [...prev, {
+                name: dot.name,
+                level: cost,
+                summary: dot.description,
+                excludes: [] as string[],
+                type: "merit" as const
+            }])
+            setRemainingMerits(prev => prev - cost)
+        }
+    }
 
     const predatorTypePickedNames = useMemo(
         () => new Set(character.predatorType.pickedMeritsAndFlaws.map((item) => item.name)),
@@ -433,10 +485,10 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                 <div style={generatorScrollableContentStyle}>
                     <GeneratorStepHero
                         leadText="Shape your"
-                        accentText="Merits & Flaws"
-                        description="Define what empowers you, what complicates your unlife, and which loresheets still fit your story."
+                        accentText="Backgrounds, Merits & Flaws"
+                        description="Spend merit points on loresheet dots under Backgrounds, then pick your Merits and Flaws."
                         maxWidth={720}
-                        marginBottom={phoneScreen ? 8 : 10}
+                        marginBottom={8}
                     />
                     <Grid m={0} gutter="sm" mb="sm">
                         <Grid.Col span={isThinBlood ? (phoneScreen ? 6 : 4) : 6}>
@@ -507,17 +559,231 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                 <div style={{ flexShrink: 0, padding: "0 20px" }}>
                     <div style={generatorScrollableContentStyle}>
                         <Tabs.List>
-                            <Tabs.Tab value="merits" style={activeTab === "merits" ? activeTabStyle : undefined}>
-                                Merits & Flaws
+                            <Tabs.Tab value="backgrounds" style={activeTab === "backgrounds" ? activeTabStyle : undefined}>
+                                Backgrounds
                             </Tabs.Tab>
-                            <Tabs.Tab value="loresheets" style={activeTab === "loresheets" ? activeTabStyle : undefined}>
-                                Loresheets
+                            <Tabs.Tab value="merits" style={activeTab === "merits" ? activeTabStyle : undefined}>
+                                Merits
+                            </Tabs.Tab>
+                            <Tabs.Tab value="flaws" style={activeTab === "flaws" ? activeTabStyle : undefined}>
+                                Flaws
                             </Tabs.Tab>
                         </Tabs.List>
                     </div>
                 </div>
 
-                {/* Merits & Flaws panel */}
+                {/* Backgrounds panel */}
+                <Tabs.Panel value="backgrounds">
+                    <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "0 20px" }}>
+                        <div style={{ ...generatorScrollableContentStyle, height: "100%", display: "flex", flexDirection: "column" }}>
+                            <ScrollArea style={{ flex: 1, minHeight: 0 }} pb={8} type="always" scrollbarSize={nightfallScrollbarSize} styles={nightfallScrollAreaStyles}>
+                                <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 700, margin: "0 auto", paddingTop: 8, paddingBottom: 40 }}>
+                                    {LORESHEETS
+                                        .filter(ls => !ls.clanRestriction?.length || ls.clanRestriction.includes(character.clan))
+                                        .map(ls => {
+                                            const isExpanded = expandedLoresheetIds.has(ls.id)
+                                            const purchasedCount = ls.dots.filter(d => isLoresheetDotSelected(d.name)).length
+                                            return (
+                                                <div
+                                                    key={ls.id}
+                                                    style={{
+                                                        borderRadius: 10,
+                                                        border: `1px solid ${purchasedCount > 0 ? rgba(RAW_RED, 0.35) : "rgba(125, 91, 72, 0.35)"}`,
+                                                        background: "rgba(26, 20, 24, 0.88)",
+                                                        overflow: "hidden",
+                                                    }}
+                                                >
+                                                    <button
+                                                        onClick={() => toggleLoresheetExpanded(ls.id)}
+                                                        style={{
+                                                            display: "flex",
+                                                            alignItems: "center",
+                                                            justifyContent: "space-between",
+                                                            gap: 12,
+                                                            width: "100%",
+                                                            padding: "14px 18px 12px",
+                                                            background: "transparent",
+                                                            border: "none",
+                                                            borderBottom: isExpanded ? "1px solid rgba(125, 91, 72, 0.2)" : "none",
+                                                            cursor: "pointer",
+                                                            textAlign: "left",
+                                                            fontFamily: "inherit",
+                                                        }}
+                                                    >
+                                                        <div style={{ flex: 1, minWidth: 0 }}>
+                                                            <p style={{
+                                                                margin: 0,
+                                                                fontFamily: "Cinzel, Georgia, serif",
+                                                                fontSize: "0.95rem",
+                                                                fontWeight: 600,
+                                                                letterSpacing: "0.06em",
+                                                                color: "rgba(244, 236, 232, 0.95)",
+                                                            }}>
+                                                                {ls.name}
+                                                            </p>
+                                                            {ls.requiresStPermission && (
+                                                                <p style={{
+                                                                    margin: "3px 0 0",
+                                                                    fontFamily: "Inter, Segoe UI, sans-serif",
+                                                                    fontSize: "0.68rem",
+                                                                    letterSpacing: "0.08em",
+                                                                    textTransform: "uppercase" as const,
+                                                                    color: "rgba(195, 155, 90, 0.4)",
+                                                                }}>
+                                                                    Requires ST approval
+                                                                </p>
+                                                            )}
+                                                        </div>
+                                                        <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                                                            {purchasedCount > 0 && (
+                                                                <span style={{
+                                                                    padding: "2px 8px",
+                                                                    borderRadius: 4,
+                                                                    border: `1px solid ${rgba(RAW_RED, 0.45)}`,
+                                                                    background: rgba(RAW_RED, 0.12),
+                                                                    fontFamily: "Inter, Segoe UI, sans-serif",
+                                                                    fontSize: "0.62rem",
+                                                                    letterSpacing: "0.1em",
+                                                                    textTransform: "uppercase" as const,
+                                                                    color: rgba(RAW_RED, 0.7),
+                                                                }}>
+                                                                    {purchasedCount} dot{purchasedCount !== 1 ? "s" : ""}
+                                                                </span>
+                                                            )}
+                                                            <span style={{
+                                                                padding: "3px 8px",
+                                                                borderRadius: 4,
+                                                                border: "1px solid rgba(125, 91, 72, 0.3)",
+                                                                fontFamily: "Inter, Segoe UI, sans-serif",
+                                                                fontSize: "0.62rem",
+                                                                letterSpacing: "0.1em",
+                                                                textTransform: "uppercase" as const,
+                                                                color: "rgba(220, 210, 205, 0.6)",
+                                                            }}>
+                                                                {SOURCE_LABELS[ls.source] ?? ls.source}
+                                                            </span>
+                                                            <span style={{ color: "rgba(220, 210, 205, 0.45)", fontSize: "0.8rem" }}>
+                                                                {isExpanded ? "▲" : "▼"}
+                                                            </span>
+                                                        </div>
+                                                    </button>
+
+                                                    {isExpanded && (
+                                                        <div style={{ padding: "8px 0" }}>
+                                                            {ls.dots.map(dot => {
+                                                                const dotAvailable = !dot.clanRestriction?.length || dot.clanRestriction.includes(character.clan)
+                                                                const selected = isLoresheetDotSelected(dot.name)
+                                                                const cost = dot.dot
+                                                                const clickable = dotAvailable && (selected || remainingMerits >= cost)
+                                                                return (
+                                                                    <button
+                                                                        key={dot.dot}
+                                                                        onClick={() => { if (clickable) toggleLoresheetDot(dot) }}
+                                                                        style={{
+                                                                            display: "flex",
+                                                                            alignItems: "flex-start",
+                                                                            gap: 14,
+                                                                            width: "100%",
+                                                                            padding: "10px 18px",
+                                                                            background: selected ? rgba(RAW_RED, 0.07) : "transparent",
+                                                                            border: "none",
+                                                                            borderBottom: "1px solid rgba(125, 91, 72, 0.12)",
+                                                                            cursor: clickable ? "pointer" : "not-allowed",
+                                                                            textAlign: "left",
+                                                                            fontFamily: "inherit",
+                                                                            transition: "background 150ms ease",
+                                                                            opacity: clickable ? 1 : 0.38,
+                                                                        }}
+                                                                    >
+                                                                        <div style={{
+                                                                            flexShrink: 0,
+                                                                            width: 20,
+                                                                            height: 20,
+                                                                            marginTop: 1,
+                                                                            borderRadius: 4,
+                                                                            border: `1.5px solid ${selected ? rgba(RAW_RED, 1) : "rgba(125, 91, 72, 0.5)"}`,
+                                                                            background: selected ? rgba(RAW_RED, 0.15) : "transparent",
+                                                                            display: "flex",
+                                                                            alignItems: "center",
+                                                                            justifyContent: "center",
+                                                                            transition: "all 150ms ease",
+                                                                        }}>
+                                                                            {selected && <IconCheck size={12} color={rgba(RAW_RED, 1)} strokeWidth={2.5} />}
+                                                                        </div>
+                                                                        <div style={{ flex: 1, minWidth: 0 }}>
+                                                                            <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+                                                                                <span style={{
+                                                                                    fontFamily: "Inter, Segoe UI, sans-serif",
+                                                                                    fontSize: "0.65rem",
+                                                                                    letterSpacing: "0.1em",
+                                                                                    color: selected ? rgba(RAW_RED, 0.45) : "rgba(220, 210, 205, 0.6)",
+                                                                                    flexShrink: 0,
+                                                                                }}>
+                                                                                    {"●".repeat(dot.dot)}{"○".repeat(5 - dot.dot)}
+                                                                                </span>
+                                                                                <span style={{
+                                                                                    fontFamily: "Crimson Text, Georgia, serif",
+                                                                                    fontSize: "0.92rem",
+                                                                                    fontWeight: 600,
+                                                                                    color: "rgba(244, 236, 232, 0.95)",
+                                                                                }}>
+                                                                                    {dot.name}
+                                                                                </span>
+                                                                                {!dotAvailable && dot.clanRestriction && (
+                                                                                    <span style={{
+                                                                                        fontFamily: "Inter, Segoe UI, sans-serif",
+                                                                                        fontSize: "0.62rem",
+                                                                                        letterSpacing: "0.08em",
+                                                                                        textTransform: "uppercase" as const,
+                                                                                        color: "rgba(195, 155, 90, 0.4)",
+                                                                                    }}>
+                                                                                        {dot.clanRestriction.join(" / ")} only
+                                                                                    </span>
+                                                                                )}
+                                                                            </div>
+                                                                            <p style={{
+                                                                                margin: "3px 0 0",
+                                                                                fontFamily: "Crimson Text, Georgia, serif",
+                                                                                fontSize: "0.85rem",
+                                                                                color: "rgba(220, 210, 205, 0.6)",
+                                                                                lineHeight: 1.4,
+                                                                            }}>
+                                                                                {dot.description}
+                                                                            </p>
+                                                                        </div>
+                                                                        <div style={{
+                                                                            flexShrink: 0,
+                                                                            padding: "4px 10px",
+                                                                            borderRadius: 6,
+                                                                            border: `1px solid ${selected ? rgba(RAW_RED, 0.4) : "rgba(125, 91, 72, 0.25)"}`,
+                                                                            background: selected ? rgba(RAW_RED, 0.1) : "rgba(255, 255, 255, 0.03)",
+                                                                            textAlign: "center",
+                                                                        }}>
+                                                                            <div style={{
+                                                                                fontFamily: "Cinzel, Georgia, serif",
+                                                                                fontSize: "0.85rem",
+                                                                                fontWeight: 700,
+                                                                                color: selected ? rgba(RAW_RED, 1) : "rgba(220, 210, 205, 0.6)",
+                                                                            }}>
+                                                                                {cost} pt{cost !== 1 ? "s" : ""}
+                                                                            </div>
+                                                                        </div>
+                                                                    </button>
+                                                                )
+                                                            })}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            )
+                                        })
+                                    }
+                                </div>
+                            </ScrollArea>
+                        </div>
+                    </div>
+                </Tabs.Panel>
+
+                {/* Merits panel */}
                 <Tabs.Panel value="merits">
                     <div
                         style={{
@@ -528,109 +794,70 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                             padding: "0 20px"
                         }}
                     >
-                        {isThinBlood && phoneScreen ? (
-                            <Text
-                                ta="center"
-                                style={{
-                                    flexShrink: 0,
-                                    fontFamily: "Crimson Text, Georgia, serif",
-                                    fontSize: "1.05rem",
-                                    color: theme.colors.grape[3],
-                                    padding: "4px 0 8px"
-                                }}
-                            >
-                                Pick Thin-blood flaws to gain Thin-blood merit points
-                            </Text>
-                        ) : null}
-
-                        {phoneScreen ? (
-                            /* Phone: single scrollable column */
-                            <ScrollArea {...columnScrollProps}>
-                                <Stack gap="sm" pb="xl">
-                                    {isThinBlood ? (
-                                        <>
-                                            <Stack gap="sm">
-                                                <GeneratorSectionDivider label="Thin-blood merits" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                                {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                            </Stack>
-                                            <Stack gap="sm">
-                                                <GeneratorSectionDivider label="Thin-blood flaws" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                                {essentialThinbloodMeritsAndFlaws.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                            </Stack>
-                                            <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
-                                        </>
-                                    ) : null}
-                                    {essentialMeritsAndFlaws.map((cat) => (
+                        <ScrollArea {...columnScrollProps}>
+                            <Stack gap="sm" pb="xl">
+                                {isThinBlood ? (
+                                    <Stack gap="sm">
+                                        <GeneratorSectionDivider label="Thin-blood merits" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                        {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                    </Stack>
+                                ) : null}
+                                {essentialMeritsAndFlaws.map((cat) =>
+                                    cat.merits.length > 0 ? (
                                         <Stack gap="sm" key={cat.title}>
                                             <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
                                             {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                            {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
                                         </Stack>
-                                    ))}
-                                </Stack>
-                            </ScrollArea>
-                        ) : (
-                            /* Desktop: two independent scroll columns */
-                            <div style={{ display: "flex", flex: 1, minHeight: 0, gap: 16, overflow: "hidden", paddingTop: 4 }}>
-                                <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-                                    <ScrollArea {...columnScrollProps}>
-                                        <Stack gap="sm" pb="xl">
-                                            {isThinBlood ? (
-                                                <Stack gap="sm">
-                                                    <GeneratorSectionDivider label="Thin-blood merits" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                                    {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                                </Stack>
-                                            ) : null}
-                                            {essentialMeritsAndFlaws
-                                                .filter((_, i) => i % 2 === 0)
-                                                .map((cat) => (
-                                                    <Stack gap="sm" key={cat.title}>
-                                                        <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                                        {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                                        {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                                    </Stack>
-                                                ))}
-                                        </Stack>
-                                    </ScrollArea>
-                                </div>
-                                <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-                                    <ScrollArea {...columnScrollProps}>
-                                        <Stack gap="sm" pb="xl">
-                                            {isThinBlood ? (
-                                                <>
-                                                    <Stack gap="sm">
-                                                        <GeneratorSectionDivider label="Thin-blood flaws" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                                        {essentialThinbloodMeritsAndFlaws.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                                    </Stack>
-                                                    <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
-                                                </>
-                                            ) : null}
-                                            {essentialMeritsAndFlaws
-                                                .filter((_, i) => i % 2 !== 0)
-                                                .map((cat) => (
-                                                    <Stack gap="sm" key={cat.title}>
-                                                        <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                                        {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                                        {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                                    </Stack>
-                                                ))}
-                                        </Stack>
-                                    </ScrollArea>
-                                </div>
-                            </div>
-                        )}
+                                    ) : null
+                                )}
+                            </Stack>
+                        </ScrollArea>
                     </div>
                 </Tabs.Panel>
 
-                {/* Loresheets panel */}
-                <Tabs.Panel value="loresheets">
-                    <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "0 20px", maxWidth: 960, marginLeft: "auto", marginRight: "auto", width: "100%" }}>
-                        <ScrollArea style={{ flex: 1, minHeight: 0 }} pb={8} type="always" scrollbarSize={nightfallScrollbarSize} styles={nightfallScrollAreaStyles}>
-                            <Loresheets
-                                character={character}
-                                getMeritOrFlawLine={getMeritOrFlawLine}
-                                pickedMeritsAndFlaws={pickedMeritsAndFlaws}
-                            />
+                {/* Flaws panel */}
+                <Tabs.Panel value="flaws">
+                    <div
+                        style={{
+                            ...generatorScrollableContentStyle,
+                            height: "100%",
+                            display: "flex",
+                            flexDirection: "column",
+                            padding: "0 20px"
+                        }}
+                    >
+                        <ScrollArea {...columnScrollProps}>
+                            <Stack gap="sm" pb="xl">
+                                {isThinBlood ? (
+                                    <>
+                                        <Text
+                                            ta="center"
+                                            style={{
+                                                flexShrink: 0,
+                                                fontFamily: "Crimson Text, Georgia, serif",
+                                                fontSize: "1.05rem",
+                                                color: theme.colors.grape[3],
+                                                padding: "4px 0 8px"
+                                            }}
+                                        >
+                                            Pick Thin-blood flaws to gain Thin-blood merit points
+                                        </Text>
+                                        <Stack gap="sm">
+                                            <GeneratorSectionDivider label="Thin-blood flaws" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                            {essentialThinbloodMeritsAndFlaws.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                        </Stack>
+                                        <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
+                                    </>
+                                ) : null}
+                                {essentialMeritsAndFlaws.map((cat) =>
+                                    cat.flaws.length > 0 ? (
+                                        <Stack gap="sm" key={cat.title}>
+                                            <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                            {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                        </Stack>
+                                    ) : null
+                                )}
+                            </Stack>
                         </ScrollArea>
                     </div>
                 </Tabs.Panel>

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -324,6 +324,10 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
         tbFlawCount - tbMeritCount
     )
 
+    const BACKGROUND_TITLES = new Set(["🏠 Haven", "💰 Resources", "🧛 Kindred", "👱 Mortals"])
+    const backgroundCategories = essentialMeritsAndFlaws.filter((cat) => BACKGROUND_TITLES.has(cat.title))
+    const meritFlawCategories = essentialMeritsAndFlaws.filter((cat) => !BACKGROUND_TITLES.has(cat.title))
+
     const [expandedLoresheetIds, setExpandedLoresheetIds] = useState<Set<string>>(new Set())
     const toggleLoresheetExpanded = (id: string) => {
         setExpandedLoresheetIds(prev => {
@@ -563,10 +567,10 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                 Backgrounds
                             </Tabs.Tab>
                             <Tabs.Tab value="merits" style={activeTab === "merits" ? activeTabStyle : undefined}>
-                                Merits
+                                Merits & Flaws
                             </Tabs.Tab>
-                            <Tabs.Tab value="flaws" style={activeTab === "flaws" ? activeTabStyle : undefined}>
-                                Flaws
+                            <Tabs.Tab value="loresheets" style={activeTab === "loresheets" ? activeTabStyle : undefined}>
+                                Loresheets
                             </Tabs.Tab>
                         </Tabs.List>
                     </div>
@@ -574,6 +578,31 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
 
                 {/* Backgrounds panel */}
                 <Tabs.Panel value="backgrounds">
+                    <div
+                        style={{
+                            ...generatorScrollableContentStyle,
+                            height: "100%",
+                            display: "flex",
+                            flexDirection: "column",
+                            padding: "0 20px"
+                        }}
+                    >
+                        <ScrollArea {...columnScrollProps}>
+                            <Stack gap="sm" pb="xl">
+                                {backgroundCategories.map((cat) => (
+                                    <Stack gap="sm" key={cat.title}>
+                                        <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                        {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                        {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                    </Stack>
+                                ))}
+                            </Stack>
+                        </ScrollArea>
+                    </div>
+                </Tabs.Panel>
+
+                {/* Loresheets panel (collapsible) */}
+                <Tabs.Panel value="loresheets">
                     <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "0 20px" }}>
                         <div style={{ ...generatorScrollableContentStyle, height: "100%", display: "flex", flexDirection: "column" }}>
                             <ScrollArea style={{ flex: 1, minHeight: 0 }} pb={8} type="always" scrollbarSize={nightfallScrollbarSize} styles={nightfallScrollAreaStyles}>
@@ -783,7 +812,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                     </div>
                 </Tabs.Panel>
 
-                {/* Merits panel */}
+                {/* Merits & Flaws panel */}
                 <Tabs.Panel value="merits">
                     <div
                         style={{
@@ -794,73 +823,97 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                             padding: "0 20px"
                         }}
                     >
-                        <ScrollArea {...columnScrollProps}>
-                            <Stack gap="sm" pb="xl">
-                                {isThinBlood ? (
-                                    <Stack gap="sm">
-                                        <GeneratorSectionDivider label="Thin-blood merits" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                        {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                    </Stack>
-                                ) : null}
-                                {essentialMeritsAndFlaws.map((cat) =>
-                                    cat.merits.length > 0 ? (
+                        {isThinBlood && phoneScreen ? (
+                            <Text
+                                ta="center"
+                                style={{
+                                    flexShrink: 0,
+                                    fontFamily: "Crimson Text, Georgia, serif",
+                                    fontSize: "1.05rem",
+                                    color: theme.colors.grape[3],
+                                    padding: "4px 0 8px"
+                                }}
+                            >
+                                Pick Thin-blood flaws to gain Thin-blood merit points
+                            </Text>
+                        ) : null}
+                        {phoneScreen ? (
+                            <ScrollArea {...columnScrollProps}>
+                                <Stack gap="sm" pb="xl">
+                                    {isThinBlood ? (
+                                        <>
+                                            <Stack gap="sm">
+                                                <GeneratorSectionDivider label="Thin-blood merits" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                                {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                            </Stack>
+                                            <Stack gap="sm">
+                                                <GeneratorSectionDivider label="Thin-blood flaws" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                                {essentialThinbloodMeritsAndFlaws.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                            </Stack>
+                                            <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
+                                        </>
+                                    ) : null}
+                                    {meritFlawCategories.map((cat) => (
                                         <Stack gap="sm" key={cat.title}>
                                             <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
                                             {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                            {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
                                         </Stack>
-                                    ) : null
-                                )}
-                            </Stack>
-                        </ScrollArea>
+                                    ))}
+                                </Stack>
+                            </ScrollArea>
+                        ) : (
+                            <div style={{ display: "flex", flex: 1, minHeight: 0, gap: 16, overflow: "hidden", paddingTop: 4 }}>
+                                <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+                                    <ScrollArea {...columnScrollProps}>
+                                        <Stack gap="sm" pb="xl">
+                                            {isThinBlood ? (
+                                                <Stack gap="sm">
+                                                    <GeneratorSectionDivider label="Thin-blood merits" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                                    {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                                </Stack>
+                                            ) : null}
+                                            {meritFlawCategories
+                                                .filter((_, i) => i % 2 === 0)
+                                                .map((cat) => (
+                                                    <Stack gap="sm" key={cat.title}>
+                                                        <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                                        {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                                        {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                                    </Stack>
+                                                ))}
+                                        </Stack>
+                                    </ScrollArea>
+                                </div>
+                                <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+                                    <ScrollArea {...columnScrollProps}>
+                                        <Stack gap="sm" pb="xl">
+                                            {isThinBlood ? (
+                                                <>
+                                                    <Stack gap="sm">
+                                                        <GeneratorSectionDivider label="Thin-blood flaws" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                                        {essentialThinbloodMeritsAndFlaws.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                                    </Stack>
+                                                    <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
+                                                </>
+                                            ) : null}
+                                            {meritFlawCategories
+                                                .filter((_, i) => i % 2 !== 0)
+                                                .map((cat) => (
+                                                    <Stack gap="sm" key={cat.title}>
+                                                        <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
+                                                        {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
+                                                        {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
+                                                    </Stack>
+                                                ))}
+                                        </Stack>
+                                    </ScrollArea>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 </Tabs.Panel>
 
-                {/* Flaws panel */}
-                <Tabs.Panel value="flaws">
-                    <div
-                        style={{
-                            ...generatorScrollableContentStyle,
-                            height: "100%",
-                            display: "flex",
-                            flexDirection: "column",
-                            padding: "0 20px"
-                        }}
-                    >
-                        <ScrollArea {...columnScrollProps}>
-                            <Stack gap="sm" pb="xl">
-                                {isThinBlood ? (
-                                    <>
-                                        <Text
-                                            ta="center"
-                                            style={{
-                                                flexShrink: 0,
-                                                fontFamily: "Crimson Text, Georgia, serif",
-                                                fontSize: "1.05rem",
-                                                color: theme.colors.grape[3],
-                                                padding: "4px 0 8px"
-                                            }}
-                                        >
-                                            Pick Thin-blood flaws to gain Thin-blood merit points
-                                        </Text>
-                                        <Stack gap="sm">
-                                            <GeneratorSectionDivider label="Thin-blood flaws" accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                            {essentialThinbloodMeritsAndFlaws.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                        </Stack>
-                                        <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
-                                    </>
-                                ) : null}
-                                {essentialMeritsAndFlaws.map((cat) =>
-                                    cat.flaws.length > 0 ? (
-                                        <Stack gap="sm" key={cat.title}>
-                                            <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                            {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                        </Stack>
-                                    ) : null
-                                )}
-                            </Stack>
-                        </ScrollArea>
-                    </div>
-                </Tabs.Panel>
             </Tabs>
 
             {/* ── Confirm button ── */}

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -489,8 +489,8 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                 <div style={generatorScrollableContentStyle}>
                     <GeneratorStepHero
                         leadText="Shape your"
-                        accentText="Backgrounds, Merits & Flaws"
-                        description="Spend merit points on loresheet dots under Backgrounds, then pick your Merits and Flaws."
+                        accentText="Advantages"
+                        description="Spend your points on Backgrounds, Merits & Flaws, and Loresheets."
                         maxWidth={720}
                         marginBottom={8}
                     />

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -330,20 +330,19 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
     const ADVANCED_BG_TITLES = new Set(["Haven", "Resources", "Fame", "Influence"])
 
     type MeritFlawEntry = { item: MeritOrFlaw; entryType: "merit" | "flaw" }
-    const allBackgroundEntries: MeritFlawEntry[] = [
-        ...essentialMeritsAndFlaws
-            .filter((cat) => ESSENTIAL_BG_TITLES.has(cat.title))
-            .flatMap((cat) => [
-                ...cat.merits.map((m) => ({ item: m, entryType: "merit" as const })),
-                ...cat.flaws.map((f) => ({ item: f, entryType: "flaw" as const })),
-            ]),
-        ...advancedMeritsAndFlaws
-            .filter((cat) => ADVANCED_BG_TITLES.has(cat.title))
-            .flatMap((cat) => [
-                ...cat.merits.map((m) => ({ item: m, entryType: "merit" as const })),
-                ...cat.flaws.map((f) => ({ item: f, entryType: "flaw" as const })),
-            ]),
-    ].sort((a, b) => a.item.name.localeCompare(b.item.name))
+    // Essential entries first, then advanced — advanced wins on duplicate names
+    const _bgEntryMap = new Map<string, MeritFlawEntry>()
+    for (const cat of essentialMeritsAndFlaws.filter((cat) => ESSENTIAL_BG_TITLES.has(cat.title))) {
+        for (const m of cat.merits) _bgEntryMap.set(m.name, { item: m, entryType: "merit" })
+        for (const f of cat.flaws)  _bgEntryMap.set(f.name, { item: f, entryType: "flaw" })
+    }
+    for (const cat of advancedMeritsAndFlaws.filter((cat) => ADVANCED_BG_TITLES.has(cat.title))) {
+        for (const m of cat.merits) _bgEntryMap.set(m.name, { item: m, entryType: "merit" })
+        for (const f of cat.flaws)  _bgEntryMap.set(f.name, { item: f, entryType: "flaw" })
+    }
+    const allBackgroundEntries = [..._bgEntryMap.values()].sort((a, b) =>
+        a.item.name.localeCompare(b.item.name)
+    )
 
     // M&F categories: essentials (non-background) + advanced (non-background)
     const essentialMFCategories = essentialMeritsAndFlaws.filter((cat) => !ESSENTIAL_BG_TITLES.has(cat.title))
@@ -358,18 +357,20 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
             return next
         })
     }
-    const isLoresheetDotSelected = (dotName: string) =>
-        pickedMeritsAndFlaws.some(m => m.name === dotName && m.type === "merit")
-    const toggleLoresheetDot = (dot: LoresheetDot) => {
-        const selected = isLoresheetDotSelected(dot.name)
+    const loresheetDotKey = (lsName: string, dotName: string) => `${lsName}: ${dotName}`
+    const isLoresheetDotSelected = (lsName: string, dotName: string) =>
+        pickedMeritsAndFlaws.some(m => m.name === loresheetDotKey(lsName, dotName) && m.type === "merit")
+    const toggleLoresheetDot = (lsName: string, dot: LoresheetDot) => {
+        const key = loresheetDotKey(lsName, dot.name)
+        const selected = isLoresheetDotSelected(lsName, dot.name)
         const cost = dot.dot
         if (selected) {
-            setPickedMeritsAndFlaws(prev => prev.filter(m => m.name !== dot.name))
+            setPickedMeritsAndFlaws(prev => prev.filter(m => m.name !== key))
             setRemainingMerits(prev => prev + cost)
         } else {
             if (remainingMerits < cost) return
             setPickedMeritsAndFlaws(prev => [...prev, {
-                name: dot.name,
+                name: key,
                 level: cost,
                 summary: dot.description,
                 excludes: [] as string[],
@@ -629,7 +630,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                         .filter(ls => !ls.clanRestriction?.length || ls.clanRestriction.includes(character.clan))
                                         .map(ls => {
                                             const isExpanded = expandedLoresheetIds.has(ls.id)
-                                            const purchasedCount = ls.dots.filter(d => isLoresheetDotSelected(d.name)).length
+                                            const purchasedCount = ls.dots.filter(d => isLoresheetDotSelected(ls.name, d.name)).length
                                             return (
                                                 <div
                                                     key={ls.id}
@@ -719,13 +720,13 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                                         <div style={{ padding: "8px 0" }}>
                                                             {ls.dots.map(dot => {
                                                                 const dotAvailable = !dot.clanRestriction?.length || dot.clanRestriction.includes(character.clan)
-                                                                const selected = isLoresheetDotSelected(dot.name)
+                                                                const selected = isLoresheetDotSelected(ls.name, dot.name)
                                                                 const cost = dot.dot
                                                                 const clickable = dotAvailable && (selected || remainingMerits >= cost)
                                                                 return (
                                                                     <button
                                                                         key={dot.dot}
-                                                                        onClick={() => { if (clickable) toggleLoresheetDot(dot) }}
+                                                                        onClick={() => { if (clickable) toggleLoresheetDot(ls.name, dot) }}
                                                                         style={{
                                                                             display: "flex",
                                                                             alignItems: "flex-start",

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -20,6 +20,7 @@ import { trackEvent } from "../../utils/analytics"
 import { Character, MeritFlaw } from "../../data/Character"
 import { clans } from "../../data/Clans"
 import {
+    advancedMeritsAndFlaws,
     essentialMeritsAndFlaws,
     essentialThinbloodMeritsAndFlaws,
     isThinbloodFlaw,
@@ -324,9 +325,30 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
         tbFlawCount - tbMeritCount
     )
 
-    const BACKGROUND_TITLES = new Set(["🏠 Haven", "💰 Resources", "🧛 Kindred", "👱 Mortals"])
-    const backgroundCategories = essentialMeritsAndFlaws.filter((cat) => BACKGROUND_TITLES.has(cat.title))
-    const meritFlawCategories = essentialMeritsAndFlaws.filter((cat) => !BACKGROUND_TITLES.has(cat.title))
+    // Categories treated as Backgrounds (shown in alphabetical flat list)
+    const ESSENTIAL_BG_TITLES = new Set(["🏠 Haven", "💰 Resources", "🧛 Kindred", "👱 Mortals"])
+    const ADVANCED_BG_TITLES = new Set(["Haven", "Resources", "Fame", "Influence"])
+
+    type MeritFlawEntry = { item: MeritOrFlaw; entryType: "merit" | "flaw" }
+    const allBackgroundEntries: MeritFlawEntry[] = [
+        ...essentialMeritsAndFlaws
+            .filter((cat) => ESSENTIAL_BG_TITLES.has(cat.title))
+            .flatMap((cat) => [
+                ...cat.merits.map((m) => ({ item: m, entryType: "merit" as const })),
+                ...cat.flaws.map((f) => ({ item: f, entryType: "flaw" as const })),
+            ]),
+        ...advancedMeritsAndFlaws
+            .filter((cat) => ADVANCED_BG_TITLES.has(cat.title))
+            .flatMap((cat) => [
+                ...cat.merits.map((m) => ({ item: m, entryType: "merit" as const })),
+                ...cat.flaws.map((f) => ({ item: f, entryType: "flaw" as const })),
+            ]),
+    ].sort((a, b) => a.item.name.localeCompare(b.item.name))
+
+    // M&F categories: essentials (non-background) + advanced (non-background)
+    const essentialMFCategories = essentialMeritsAndFlaws.filter((cat) => !ESSENTIAL_BG_TITLES.has(cat.title))
+    const advancedMFCategories = advancedMeritsAndFlaws.filter((cat) => !ADVANCED_BG_TITLES.has(cat.title))
+    const allMFCategories = [...essentialMFCategories, ...advancedMFCategories]
 
     const [expandedLoresheetIds, setExpandedLoresheetIds] = useState<Set<string>>(new Set())
     const toggleLoresheetExpanded = (id: string) => {
@@ -589,13 +611,9 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                     >
                         <ScrollArea {...columnScrollProps}>
                             <Stack gap="sm" pb="xl">
-                                {backgroundCategories.map((cat) => (
-                                    <Stack gap="sm" key={cat.title}>
-                                        <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
-                                        {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
-                                        {cat.flaws.map((f) => getMeritOrFlawLine(f, "flaw"))}
-                                    </Stack>
-                                ))}
+                                {allBackgroundEntries.map((entry) =>
+                                    getMeritOrFlawLine(entry.item, entry.entryType)
+                                )}
                             </Stack>
                         </ScrollArea>
                     </div>
@@ -853,7 +871,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                             <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
                                         </>
                                     ) : null}
-                                    {meritFlawCategories.map((cat) => (
+                                    {allMFCategories.map((cat) => (
                                         <Stack gap="sm" key={cat.title}>
                                             <GeneratorSectionDivider label={cat.title} accentAlpha={0.32} titleSize="0.96rem" lineHeight={1} marginY="xs" />
                                             {cat.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
@@ -873,7 +891,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                                     {essentialThinbloodMeritsAndFlaws.merits.map((m) => getMeritOrFlawLine(m, "merit"))}
                                                 </Stack>
                                             ) : null}
-                                            {meritFlawCategories
+                                            {allMFCategories
                                                 .filter((_, i) => i % 2 === 0)
                                                 .map((cat) => (
                                                     <Stack gap="sm" key={cat.title}>
@@ -897,7 +915,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                                     <Divider w="100%" my="sm" color="rgba(255, 255, 255, 0.1)" />
                                                 </>
                                             ) : null}
-                                            {meritFlawCategories
+                                            {allMFCategories
                                                 .filter((_, i) => i % 2 !== 0)
                                                 .map((cat) => (
                                                     <Stack gap="sm" key={cat.title}>

--- a/apps/character-app/src/generator/steps.ts
+++ b/apps/character-app/src/generator/steps.ts
@@ -50,7 +50,7 @@ const allGeneratorSteps: GeneratorStep[] = [
     { id: "rituals", label: "Rituals" },
     { id: "ceremonies", label: "Ceremonies" },
     { id: "touchstones", label: "Touchstones", progressKey: "touchstones" },
-    { id: "merits", label: "Merits & Flaws", progressKey: "merits" },
+    { id: "merits", label: "Advantages", progressKey: "merits" },
     { id: "loresheet", label: "Loresheets" },
     { id: "in-memoriam", label: "Oceans of Time" },
     { id: "final", label: "Review & Submit" },

--- a/apps/character-app/src/pages/CreatorPage.tsx
+++ b/apps/character-app/src/pages/CreatorPage.tsx
@@ -240,7 +240,7 @@ export default function CreatorPage() {
                 style={{
                     flex: 1,
                     minHeight: 0,
-                    backgroundImage: "linear-gradient(rgba(10,10,20,0.78), rgba(16,21,40,0.88)), url('/static/images/music.png')",
+                    backgroundImage: "linear-gradient(rgba(10,10,20,0.92), rgba(16,21,40,0.96)), url('/static/images/music.png')",
                     backgroundSize: "cover",
                     backgroundPosition: "center",
                     display: "flex",

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -416,34 +416,51 @@
 </div>
 
 <!-- Approved Claims History -->
-<div class="card mb-4">
+<div class="card mb-4" id="xp-claims-history">
     <div class="card-header">
         <h5 class="mb-0"><i class="bi bi-journal-check"></i> XP Claims History</h5>
     </div>
     <div class="card-body">
-        {% if approved_claims %}
+        {% if approved_claims or ledger %}
         <div class="table-responsive">
             <table class="table table-dark table-striped mb-0">
                 <thead>
                     <tr>
-                        <th>Period</th>
-                        <th>XP Awarded</th>
+                        <th>Type</th>
+                        <th>XP Change</th>
                         <th>Date</th>
-                        {% if approved_claims[0].st_notes is defined %}
-                        <th>ST Notes</th>
-                        {% endif %}
+                        <th>Notes</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for claim in approved_claims %}
                     <tr>
                         <td>{{ claim.play_period }}</td>
-                        <td>
-                            <span class="badge bg-success">+{{ claim.approved_xp }}</span>
-                        </td>
+                        <td><span class="badge bg-success">+{{ claim.approved_xp }}</span></td>
                         <td>{{ claim.review_date or claim.timestamp }}</td>
                         <td>{{ claim.st_notes if claim.st_notes and not claim.st_notes.startswith('STAFF ADJUSTMENT') else '' }}</td>
                     </tr>
+                    {% endfor %}
+                    {% for entry in ledger %}
+                    {% if entry.awarded != 0 or entry.spent != 0 %}
+                    <tr class="table-secondary">
+                        <td><span class="badge bg-secondary">Staff Adjustment</span></td>
+                        <td>
+                            {% if entry.awarded > 0 %}
+                            <span class="badge bg-success">+{{ entry.awarded }}</span>
+                            {% elif entry.awarded < 0 %}
+                            <span class="badge bg-danger">{{ entry.awarded }}</span>
+                            {% endif %}
+                            {% if entry.spent > 0 %}
+                            <span class="badge bg-warning text-dark">−{{ entry.spent }} spend</span>
+                            {% elif entry.spent < 0 %}
+                            <span class="badge bg-info text-dark">+{{ entry.spent|abs }} spend refund</span>
+                            {% endif %}
+                        </td>
+                        <td>{{ entry.date }}</td>
+                        <td>{{ entry.reason | replace('Staff Adjustment: ', '') | replace('Staff Adjustment (removal): ', '') | replace('Staff Refund: ', '') | replace('Staff Adjustment (add spend): ', '') }}</td>
+                    </tr>
+                    {% endif %}
                     {% endfor %}
                 </tbody>
             </table>
@@ -616,60 +633,6 @@
     </div>
 </div>
 
-<!-- XP Ledger (collapsible) -->
-{% if ledger %}
-<div class="card mb-4">
-    <div class="card-header" data-bs-toggle="collapse" data-bs-target="#xp-ledger" role="button" style="cursor: pointer;">
-        <h5 class="mb-0">
-            <i class="bi bi-journal-text"></i> XP Ledger
-            <span class="badge bg-secondary ms-2">{{ ledger|length }} entries</span>
-            <i class="bi bi-chevron-down float-end"></i>
-        </h5>
-    </div>
-    <div class="collapse" id="xp-ledger">
-        <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-dark table-striped table-sm mb-0">
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Awarded</th>
-                            <th>Spent</th>
-                            <th>Balance</th>
-                            <th>Reason</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% set ns = namespace(balance=0) %}
-                        {% for entry in ledger|reverse %}
-                        {% set ns.balance = ns.balance + entry.awarded - entry.spent %}
-                        <tr>
-                            <td>{{ entry.date }}</td>
-                            <td>
-                                {% if entry.awarded %}
-                                <span class="text-success">+{{ entry.awarded }}</span>
-                                {% endif %}
-                            </td>
-                            <td>
-                                {% if entry.spent %}
-                                <span class="text-danger">-{{ entry.spent }}</span>
-                                {% endif %}
-                            </td>
-                            <td>
-                                <span class="{% if ns.balance >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                    {{ ns.balance }}
-                                </span>
-                            </td>
-                            <td>{{ entry.reason }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-</div>
-{% endif %}
 
 <!-- XP Cost Reference (collapsed) -->
 <div class="card mb-4">
@@ -728,7 +691,7 @@
         <i class="bi bi-bookmark-star"></i>
         <span>Wish List</span>
     </button>
-    <a href="#xp-ledger" class="player-bottom-nav-item" id="bottom-history-btn">
+    <a href="#xp-claims-history" class="player-bottom-nav-item" id="bottom-history-btn">
         <i class="bi bi-journal-text"></i>
         <span>History</span>
     </a>
@@ -757,7 +720,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     document.getElementById('bottom-history-btn')?.addEventListener('click', function(e) {
         e.preventDefault();
-        document.getElementById('xp-ledger')?.closest('.card').scrollIntoView({ behavior: 'smooth', block: 'start' });
+        document.getElementById('xp-claims-history')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
     document.getElementById('bottom-wishlist-btn')?.addEventListener('click', function() {
         expandAndScroll('wish-list');

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -442,7 +442,7 @@
                     </tr>
                     {% endfor %}
                     {% for entry in ledger %}
-                    {% if entry.awarded != 0 or entry.spent != 0 %}
+                    {% if (entry.awarded != 0 or entry.spent != 0) and 'claim approved' not in entry.reason %}
                     <tr class="table-secondary">
                         <td><span class="badge bg-secondary">Staff Adjustment</span></td>
                         <td>


### PR DESCRIPTION
## Summary

- **Character creator: Advantages step redesign** — renamed step from Merits & Flaws to Advantages; restructured into three tabs: Backgrounds, Merits & Flaws, and Loresheets
- **Backgrounds tab: alphabetical flat list** — all background merits/flaws (Core + Players Guide) sorted A–Z; no confusing subsection headers
- **Merits & Flaws tab: surface advanced sourcebook content** — `advancedMeritsAndFlaws` (Players Guide, Forbidden Religions, Tattered Facade, Live from the Succubus Club, etc.) now visible alongside Core content
- **Allies: two-rating system** — split into Allies: Effectiveness (1–4) and Allies: Reliability (1–3) with per-dot descriptions from the Core book; Enemy flaw updated with proper mechanics
- **Background readability fix** — darken background image overlay (0.78/0.88 → 0.92/0.96 opacity) so text in the Advantages step is legible
- **Player portal: XP adjustments now visible** — staff XP adjustments (grant, remove, refund, add spend) appear inline in the XP Claims History table as "Staff Adjustment" rows; removes the separate collapsed XP Ledger card that players would miss

## Test plan

- [ ] Character creator: Advantages step shows three tabs (Backgrounds, Merits & Flaws, Loresheets)
- [ ] Backgrounds tab: entries appear in alphabetical order with no category headers
- [ ] Merits & Flaws tab: sourcebook entries visible (Famous Face, Luck of the Devil, Bond Resistance, Cult merits, etc.)
- [ ] Allies: Effectiveness and Allies: Reliability appear as separate entries with descriptions
- [ ] Loresheets tab: all sourcebook loresheets collapsible, defaults collapsed
- [ ] Player portal `/player/<name>`: after a staff XP adjustment, the adjustment appears in XP Claims History as a "Staff Adjustment" row

🤖 Generated with [Claude Code](https://claude.com/claude-code)