### PR TITLE
Advantages step: alphabetical backgrounds, advanced M&F, PG data

### DIFF
--- a/apps/character-app/src/data/Ceremonies.ts
+++ b/apps/character-app/src/data/Ceremonies.ts
@@ -37,6 +37,17 @@ export const Ceremonies: Ceremony[] = [
         prerequisitePowers: ["The Binding Fetter"]
     },
     {
+        name: "Knowing Stone",
+        summary: "Identify the locations and existences of specific ghosts. The caster must know the ghost's name.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: defaultDicePool,
+        ingredients: "A stone and the ghost's name",
+        level: 1,
+        discipline: "oblivion",
+        prerequisitePowers: ["Ashes to Ashes", "The Binding Fetter"]
+    },
+    {
         name: "Traveler's Call",
         summary:
             "Send a vision of your surroundings through Oblivion to call another Shalimite to you.",
@@ -82,6 +93,28 @@ export const Ceremonies: Ceremony[] = [
         level: 2,
         discipline: "oblivion",
         prerequisitePowers: ["Where the Shroud Thins"]
+    },
+    {
+        name: "Ashen Relic",
+        summary: "Preserve a Kindred's body against decay. Three successes in the margin preserves more completely.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: defaultDicePool,
+        ingredients: "",
+        level: 2,
+        discipline: "oblivion",
+        prerequisitePowers: ["Ashes to Ashes", "Oblivion's Sight"]
+    },
+    {
+        name: "Maw of Ahriman",
+        summary: "Open a portal to the Abyss, usually within the caster's own mouth. The caster cannot speak until the portal is cancelled or the next sunrise.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: defaultDicePool,
+        ingredients: "",
+        level: 2,
+        discipline: "oblivion",
+        prerequisitePowers: []
     },
     {
         name: "Host Spirit",
@@ -178,6 +211,28 @@ export const Ceremonies: Ceremony[] = [
         prerequisitePowers: ["Shadow Perspective", "Touch of Oblivion"]
     },
     {
+        name: "Shallow Slumber",
+        summary: "Reduce time spent in torpor.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: defaultDicePool,
+        ingredients: "",
+        level: 3,
+        discipline: "oblivion",
+        prerequisitePowers: ["Passion Feast", "Touch of Oblivion"]
+    },
+    {
+        name: "Wisdom of the Dead",
+        summary: "Gain information by speaking with a corpse skull or severed head. Add two dice to the pool if still carrying the skull or head for the rest of the night.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: defaultDicePool,
+        ingredients: "A corpse skull or severed head",
+        level: 3,
+        discipline: "oblivion",
+        prerequisitePowers: ["Where the Shroud Thins", "Oblivion's Sight"]
+    },
+    {
         name: "Bind the Spirit",
         summary:
             "Anchor a compelled wraith to a place or person, causing its strongest emotions to haunt the target.",
@@ -191,7 +246,7 @@ export const Ceremonies: Ceremony[] = [
         prerequisitePowers: ["Necrotic Plague"]
     },
     {
-        name: "Split the Shroud",
+        name: "Split the Veil",
         summary:
             "Tear open the boundary to the Shadowlands, making passage easier and allowing ghosts through if widened enough.",
         rouseChecks: 1,
@@ -212,7 +267,7 @@ export const Ceremonies: Ceremony[] = [
         ingredients: "The vampire's saliva",
         level: 4,
         discipline: "oblivion",
-        prerequisitePowers: ["Touch of Oblivion"]
+        prerequisitePowers: ["Necrotic Plague"]
     },
     {
         name: "Death Rattle",

--- a/apps/character-app/src/data/MeritsAndFlaws.ts
+++ b/apps/character-app/src/data/MeritsAndFlaws.ts
@@ -21,6 +21,7 @@ export type MeritsAndFlaws = {
     merits: MeritOrFlaw[]
     flaws: MeritOrFlaw[]
     complexity?: MeritFlawComplexity
+    restriction?: "caitiff" | "ghoul"
 }
 
 export type RequirementFunction = (character: Character) => boolean

--- a/apps/character-app/src/data/MeritsAndFlawsAdvanced.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsAdvanced.ts
@@ -194,6 +194,12 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
         ],
         flaws: [
             {
+                name: "Outdated Preference",
+                cost: [2],
+                summary: "your preferred vessel has become nearly impossible to find (castrati, quaalude addicts, footmen, etc). You must force mortals to fit your preference, or always spend 1 Willpower to feed.",
+                excludes: []
+            },
+            {
                 name: "Vegan",
                 cost: [2],
                 summary: "feed only from animals; human blood costs Willpower",
@@ -232,6 +238,12 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
         complexity: "advanced",
         merits: [
             {
+                name: "Object of Power",
+                cost: [1, 2, 3],
+                summary: "a rare and powerful item. ● set of uncommonly lucky dice: reroll one non-Hunger die once per story. ●● Grimoire: +1 die to all Level 1 Ritual tests. ●●● golden eye amulet: free Premonition warning once per session when someone is about to harm you.",
+                excludes: []
+            },
+            {
                 name: "Luck of the Devil",
                 cost: [4],
                 summary: "once per session, shift a misfortune onto someone nearby",
@@ -264,6 +276,12 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
             }
         ],
         flaws: [
+            {
+                name: "Cursed Object",
+                cost: [1],
+                summary: "something you own wants you dead. Once per session at a time determined by the Storyteller, you must reroll a successful test, risking failure instead.",
+                excludes: []
+            },
             {
                 name: "Starving Decay",
                 cost: [2],
@@ -351,7 +369,14 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
                 excludes: []
             }
         ],
-        flaws: []
+        flaws: [
+            {
+                name: "Banned From...",
+                cost: [1, 2, 3],
+                summary: "barred from a Kindred-ruled city. ● small city (Portland, Salzburg). ●● mid-sized city (Venice, Sacramento). ●●● large city (Paris, Tokyo, Cairo). Getting in anyway causes serious trouble.",
+                excludes: []
+            }
+        ]
     },
     {
         title: "Cult",
@@ -824,6 +849,32 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
                 name: "Distressing Fangs",
                 cost: [1],
                 summary: "the Blood gave you strange, unsettling teeth; -1 die to Social pools with mortals",
+                excludes: []
+            }
+        ]
+    },
+    {
+        title: "Archaic",
+        complexity: "advanced",
+        merits: [
+            {
+                name: "Custodian of History",
+                cost: [1],
+                summary: "an elder confided their version of a lost age to you. Choose one subject (Book of Nod, First Inquisition, Constantinople, Revelations of the Dark Mother, Antiquity and Carthage, etc.): +1 die to all Skill tests pertaining to it.",
+                excludes: []
+            }
+        ],
+        flaws: [
+            {
+                name: "Grief Phobia",
+                cost: [1],
+                summary: "a lost Touchstone left you with a permanent phobia for something that reminds you of them. -1 die to all tests made in the presence of your phobic stimulus. Can be taken once per lost Touchstone.",
+                excludes: []
+            },
+            {
+                name: "Old Tricks",
+                cost: [1],
+                summary: "you've never mastered the modern age: all your Skill specialties must be Archaic specialties.",
                 excludes: []
             }
         ]

--- a/apps/character-app/src/data/MeritsAndFlawsAdvanced.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsAdvanced.ts
@@ -129,6 +129,12 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
         complexity: "advanced",
         merits: [
             {
+                name: "Up All Night",
+                cost: [2, 4],
+                summary: "for Blush of Life, eating/drinking, and sexual intercourse, treat Humanity as 1 higher (●●) or 2 higher (●●●●). Cannot combine with other Humanity-treating-as-higher effects. Nosferatu cannot select; Hecata can only select at 2 dots.",
+                excludes: []
+            },
+            {
                 name: "Famous Face",
                 cost: [1],
                 summary: "look like a celebrity; helps socially but makes you memorable",
@@ -544,9 +550,28 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
                 cost: [5],
                 summary: "you cannot be blood bound",
                 excludes: ["Bondslave", "Bond Junkie", "Long Bond"]
+            },
+            {
+                name: "Bonds of Fealty",
+                cost: [2],
+                summary: "requires Dominate. Your Dominate powers do not require eye contact when targeting someone blood bound to you. You still need to communicate your instructions, but need not be physically present.",
+                excludes: []
+            },
+            {
+                name: "Enduring Bond",
+                cost: [1],
+                summary: "your blood bonds last longer than normal. Complete and partial blood bonds only weaken every other month, not every month.",
+                excludes: ["Short Bond"]
             }
         ],
-        flaws: []
+        flaws: [
+            {
+                name: "Two Masters",
+                cost: [1],
+                summary: "you can be Blood Bound to two individuals simultaneously. May cause complications if you drink Kindred blood recreationally.",
+                excludes: []
+            }
+        ]
     },
     {
         title: "Influence",
@@ -852,6 +877,69 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
                 excludes: []
             }
         ]
+    },
+    {
+        title: "Blood Ties",
+        complexity: "advanced",
+        merits: [
+            {
+                name: "Consanguineous Sense",
+                cost: [1],
+                summary: "your Blood calls out to close relations. Instinctively recognize direct bloodline members within a few paces. Resolve + Awareness vs Difficulty 3 to confirm if a Kindred within ~3m shares your bloodline (but not their exact Generation distance). Not available to Caitiff or Duskborn.",
+                excludes: []
+            },
+            {
+                name: "Consanguineous Influence",
+                cost: [2],
+                summary: "mental Disciplines are more effective on those of the same bloodline: +1 die against any clan member or direct ancestor/descendant, or +2 dice if only one or two generations removed. Not available to Caitiff or Duskborn.",
+                excludes: []
+            },
+            {
+                name: "Sins of the Fathers",
+                cost: [2, 3],
+                summary: "after committing diablerie on a direct ancestor or descendant, you show no telltale signs. Powers like Scry the Soul or A Taste for Blood do not detect the crime. ●●●: extends to any member of your own clan. Caitiff and Duskborn cannot take the 3-dot version.",
+                excludes: []
+            }
+        ],
+        flaws: []
+    },
+    {
+        title: "Diablerie",
+        complexity: "advanced",
+        merits: [],
+        flaws: [
+            {
+                name: "Blatant Diablerist",
+                cost: [1],
+                summary: "telltale signs of diablerie are always noticeable to those who can sense it. Powers such as Scry the Soul or A Taste for Blood always reveal diablerie, even on an otherwise failed test. Can only be taken at creation if the character has a history of diablerie.",
+                excludes: []
+            },
+            {
+                name: "Inherited Bane",
+                cost: [1],
+                summary: "you suffer another clan's bane in addition to your own (e.g., Tremere may take the Salubri clan bane).",
+                excludes: []
+            }
+        ]
+    },
+    {
+        title: "Psychological",
+        complexity: "advanced",
+        merits: [
+            {
+                name: "Soothed Beast",
+                cost: [1],
+                summary: "choose a Storyteller character as your obsession. Once per session when in their presence, ignore one Bestial Failure or Messy Critical. If they die, gain 3 Stains but choose a new obsession at the start of the next session.",
+                excludes: []
+            },
+            {
+                name: "False Love",
+                cost: [1],
+                summary: "choose a Storyteller character as your obsession. When in their presence, treat Humanity as 1 higher (max 10) for Blush of Life, eating/drinking, and intercourse. Does not combine with other Humanity-treating-as-higher effects. If they die, gain 3 Stains but choose a new obsession next session.",
+                excludes: ["Up All Night"]
+            }
+        ],
+        flaws: []
     },
     {
         title: "Archaic",

--- a/apps/character-app/src/data/MeritsAndFlawsAdvanced.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsAdvanced.ts
@@ -667,6 +667,12 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
         complexity: "advanced",
         merits: [
             {
+                name: "Check the Trunk",
+                cost: [1],
+                summary: "easy access to an armory or cache of tools (Resources 2 value cap); +2 dice to Preparedness pools for items within that band",
+                excludes: []
+            },
+            {
                 name: "Pack Diablerie",
                 cost: [2],
                 summary:
@@ -698,6 +704,126 @@ export const advancedMeritsAndFlaws: MeritsAndFlaws[] = [
                 cost: [1],
                 summary:
                     "Masquerade enforcers distrust your attempt to live too much like a mortal",
+                excludes: []
+            }
+        ]
+    },
+    {
+        title: "◐ Caitiff specific",
+        complexity: "advanced",
+        restriction: "caitiff",
+        merits: [
+            {
+                name: "Favored Blood",
+                cost: [4],
+                summary: "buy dots in any Discipline without tasting that Discipline's blood first",
+                excludes: ["Muddled Blood"]
+            },
+            {
+                name: "Mark of Caine",
+                cost: [2],
+                summary: "+2 dice to intimidate or cow vampires who believe in the myth of Caine; diablerists cannot add Blood Potency vs you and failure on their roll results in a bestial failure",
+                excludes: []
+            },
+            {
+                name: "Mockingbird",
+                cost: [3],
+                summary: "for one night after drinking 1 Hunger die of blood from a vampire, borrow one of their Discipline powers (up to your highest Discipline level); mimic donor's bane at their severity during this time; once per night",
+                excludes: []
+            },
+            {
+                name: "Sun-Scarred",
+                cost: [5],
+                summary: "first turn of sunlight: no Health damage, 1 Aggravated Willpower damage, auto-succeed terror frenzy roll; remainder of scene: all sun Health damage becomes Superficial",
+                excludes: []
+            },
+            {
+                name: "Uncle Fangs",
+                cost: [3],
+                summary: "easy access to a local coterie of 3–5 thin-bloods; treat as Allies (undead); they often know street events early and may provide Alchemical concoctions",
+                excludes: ["Liquidator"]
+            }
+        ],
+        flaws: [
+            {
+                name: "Befouling Vitae",
+                cost: [2],
+                summary: "any mortal you Embrace or kill by feeding returns as a wight within a few nights; the local Prince or Baron will hear about it",
+                excludes: []
+            },
+            {
+                name: "Clan Curse",
+                cost: [2],
+                summary: "suffer a clan bane of your choice (likely your sire's) at half severity, minimum 1; can sometimes help you pass for that clan",
+                excludes: []
+            },
+            {
+                name: "Debt Peon",
+                cost: [2],
+                summary: "owe boons to a high-Status vampire who never considers them settled; two-dice penalty to Social combat against you in front of other Kindred; refusal adds the Shunned flaw and risks a Blood Hunt",
+                excludes: []
+            },
+            {
+                name: "Liquidator",
+                cost: [1],
+                summary: "thin-bloods shun and avoid you; -2 dice to Social skill pools against thin-bloods except Intimidation",
+                excludes: ["Uncle Fangs"]
+            },
+            {
+                name: "Muddled Blood",
+                cost: [1],
+                summary: "must drink blood of someone with a Discipline to buy dots in it, even if you already possess it",
+                excludes: ["Favored Blood"]
+            },
+            {
+                name: "Walking Omen",
+                cost: [2],
+                summary: "scrying, premonitions, and fortune-telling in your domain regularly point to you as a source of disaster; at least one serious altercation per story as oracles or hunters seek you out",
+                excludes: []
+            },
+            {
+                name: "Word-Scarred",
+                cost: [1],
+                summary: "your body is covered in ancient vampiric lore text; the major occult force in the chronicle seeks to imprison, flense, or otherwise neutralize you; others who read the full text learn a terrible Gehenna secret",
+                excludes: []
+            }
+        ]
+    },
+    {
+        title: "◐ Ghoul specific",
+        complexity: "advanced",
+        restriction: "ghoul",
+        merits: [
+            {
+                name: "Blood Empathy",
+                cost: [2],
+                summary: "sense your domitor's emotional/psychological state within 1 mile; know when they are in peril or require your presence; does not allow telepathic communication",
+                excludes: []
+            },
+            {
+                name: "Unseemly Aura",
+                cost: [2],
+                summary: "your aura appears vampiric rather than mortal; may cause others to overestimate you",
+                excludes: []
+            }
+        ],
+        flaws: [
+            {
+                name: "Baneful Blood",
+                cost: [1, 2],
+                summary: "experience your first domitor's clan bane at 1 level per dot; domitor must be Lasombra, Malkavian, Ministry, Nosferatu, Ravnos, Salubri, or Toreador; bane does not change if domitor changes",
+                excludes: []
+            },
+            {
+                name: "Crone's Curse",
+                cost: [2],
+                summary: "the Blood aged you rapidly; appear at least a decade older than you are and have one fewer Health box",
+                excludes: []
+            },
+            {
+                name: "Distressing Fangs",
+                cost: [1],
+                summary: "the Blood gave you strange, unsettling teeth; -1 die to Social pools with mortals",
                 excludes: []
             }
         ]

--- a/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
@@ -224,6 +224,12 @@ export const essentialMeritsAndFlaws: MeritsAndFlaws[] = [
                 cost: [2],
                 summary: "-2 dice in Social rolls",
                 excludes: ["Beautiful", "Stunning", "Ugly"]
+            },
+            {
+                name: "Unblinking Visage",
+                cost: [1],
+                summary: "your dead body has forgotten blinking, breathing, and automatic reflexes. Count Humanity as two levels lower (minimum zero) for Blush of Life and similar life-mimicking activities.",
+                excludes: []
             }
         ]
     },
@@ -509,6 +515,12 @@ export const essentialMeritsAndFlaws: MeritsAndFlaws[] = [
                 name: "Touchstone Embraced by Your Enemies",
                 cost: [2],
                 summary: "a former Touchstone was Embraced and now runs with your enemies. A single neonate Adversary with allies; confronting them risks Stains.",
+                excludes: []
+            },
+            {
+                name: "Secret Master",
+                cost: [1],
+                summary: "requires Mawla 1+. Your Mawla has a hold over you and once per story requires a minor secret task. Failure escalates next story. Continued failure forfeits the flaw, replaced by 2+ dots of other flaws.",
                 excludes: []
             },
             {

--- a/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
@@ -493,7 +493,24 @@ export const essentialMeritsAndFlaws: MeritsAndFlaws[] = [
             }
         ],
         flaws: [
-            { name: "Adversary", cost: [1], summary: "kindred enemy", excludes: [] },
+            {
+                name: "Adversary",
+                cost: [1, 2, 3, 4, 5],
+                summary: "Kindred who opposes you, rated by their Status or relevant Trait. ● Neonate. ●● Ancilla. ●●● Elder. ●●●● Primogen or Anarch Revolutionary Council member. ●●●●● Prince or Baron.",
+                excludes: []
+            },
+            {
+                name: "Shameful Childe",
+                cost: [1],
+                summary: "you Embraced someone and abandoned them. They're out there somewhere, and sooner or later they'll come back to confront you.",
+                excludes: []
+            },
+            {
+                name: "Touchstone Embraced by Your Enemies",
+                cost: [2],
+                summary: "a former Touchstone was Embraced and now runs with your enemies. A single neonate Adversary with allies; confronting them risks Stains.",
+                excludes: []
+            },
             {
                 name: "Suspect",
                 cost: [1],
@@ -541,7 +558,7 @@ export const essentialMeritsAndFlaws: MeritsAndFlaws[] = [
                 name: "Retainer",
                 cost: [1, 2, 3],
                 summary:
-                    "loyal mortal servant, 1 - weak lowlife, 3 - skilled professional retainer",
+                    "loyal servant. ● weak mortal (child, criminal lowlife, or horror nerd). ●● average mortal or ghoul with no Advantages (family servant, human lover, dominated thrall). ●●● gifted mortal or ghoul with supernatural abilities, competent enough to act independently.",
                 excludes: []
             },
             {

--- a/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
+++ b/apps/character-app/src/data/MeritsAndFlawsEssentials.ts
@@ -56,6 +56,42 @@ export const thinbloodMeritsAndFlaws: MeritsAndFlaws = {
             excludes: []
         },
         {
+            name: "Abhorrent Blood",
+            cost: [1],
+            summary: "other vampires cannot stomach your blood; anyone trying to drink from you must spend 2 Willpower per turn to continue; mortals and Thin-blood Alchemy unaffected",
+            excludes: []
+        },
+        {
+            name: "Faith-Proof",
+            cost: [1],
+            summary: "too close to mortality for True Faith to affect you",
+            excludes: []
+        },
+        {
+            name: "Low Appetite",
+            cost: [1],
+            summary: "when rising at Hunger 0 or 1, roll two dice on your Rouse Check and take the highest",
+            excludes: []
+        },
+        {
+            name: "Lucid Dreamer",
+            cost: [1],
+            summary: "you dream and can recall them; once per session ask the ST for a clue from the previous night's memories or a story hint suitable for dream revelation",
+            excludes: []
+        },
+        {
+            name: "Mortality's Mien",
+            cost: [1],
+            summary: "your aura appears mortal rather than vampiric; +2 dice to any attempt to appear mortal",
+            excludes: []
+        },
+        {
+            name: "Swift Feeder",
+            cost: [1],
+            summary: "slake 1 Hunger in one turn including licking the wound closed; once per scene",
+            excludes: []
+        },
+        {
             name: "Memories of the Fallen",
             cost: [2],
             summary: "Ashe visions make some Blood Alchemy rolls critically stronger",
@@ -100,6 +136,54 @@ export const thinbloodMeritsAndFlaws: MeritsAndFlaws = {
             name: "Vitae Dependency",
             cost: [1],
             summary: "Need to drink Vampire vitae once a week to use Disciplines",
+            excludes: []
+        },
+        {
+            name: "Heliophobia",
+            cost: [1],
+            summary: "fear sunlight as though a full vampire; susceptible to terror frenzy from sunlight",
+            excludes: []
+        },
+        {
+            name: "Night Terrors",
+            cost: [1],
+            summary: "once per session night terrors onset and you take a -1 die penalty to all actions for the rest of the scene",
+            excludes: []
+        },
+        {
+            name: "Plague Bearer",
+            cost: [1],
+            summary: "still susceptible to mortal illness; roll a die per Hunger slaked when feeding — on a 1 you catch something (ST determines effect); only slaking to Hunger 0 cures you; can infect those you feed on",
+            excludes: []
+        },
+        {
+            name: "Sloppy Drinker",
+            cost: [1],
+            summary: "make Dex + Medicine vs difficulty = Hunger slaked after feeding to close wound marks; on failure the wound is too ragged, risking the Masquerade",
+            excludes: []
+        },
+        {
+            name: "Sun-Faded",
+            cost: [1],
+            summary: "cannot use Disciplines or Thin-blood Alchemy in sunlight; indoors by day suffer -2 dice penalty as long as no sunlight reaches you",
+            excludes: []
+        },
+        {
+            name: "Supernatural Tell",
+            cost: [1],
+            summary: "other supernatural entities can sense your presence; -2 dice from Stealth pools against supernatural opponents including other vampires",
+            excludes: []
+        },
+        {
+            name: "Twilight Presence",
+            cost: [1],
+            summary: "mortals and Kindred are uncomfortable around you; -1 die from Social pools with everyone except other thin-bloods",
+            excludes: []
+        },
+        {
+            name: "Unending Hunger",
+            cost: [1],
+            summary: "your Beast always hungers for more; slake 1 fewer Hunger than other thin-bloods per scene",
             excludes: []
         },
         {

--- a/apps/character-app/src/data/Rituals.ts
+++ b/apps/character-app/src/data/Rituals.ts
@@ -1,10 +1,64 @@
 import { Ritual } from "./Disciplines"
 
 export const Rituals: Ritual[] = [
+    // Level 1
+    {
+        name: "Astromancy",
+        summary: "Learn information such as Skills, Desires, and Convictions about a target person. Knowing their correct birth or Embrace date adds 1 die to the Ritual pool.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Beelzebeatit",
+        summary: "Make a small area repellent to animals, vermin, plants, and other lesser living creatures. Directed or controlled creatures are not prevented from entering.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Vinegar or alcohol",
+        level: 1
+    },
+    {
+        name: "Bind the Accusing Tongue",
+        summary: "Prevent the target from communicating anything negative about the caster. The victim can break free by rolling Composure + Resolve.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Blood Apocrypha",
+        summary: "Embed messages into blood or vessels. The first person receives the message if they are the intended recipient or if they possess A Taste for Blood.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Blood Missive",
+        summary: "Send messages through blood. The first person to taste the blood receives the message as if it were intended for them, or if they possess A Taste for Blood.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "The caster's blood",
+        level: 1
+    },
+    {
+        name: "Blood to Water",
+        summary: "Turn blood into water, removing all traces of blood.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
     {
         name: "Blood Walk",
-        summary:
-            "Use blood to learn about a subjects generation, name, sire and - on a crit - any active Blood Bonds.",
+        summary: "Use blood to learn about a subject's generation, name, sire, and — on a crit — any active Blood Bonds. Requires one Rouse Check from the subject.",
         rouseChecks: 1,
         requiredTime: "1 hour",
         dicePool: "Intelligence + Blood Sorcery",
@@ -12,19 +66,35 @@ export const Rituals: Ritual[] = [
         level: 1
     },
     {
-        name: "Clinging of the Insect",
-        summary:
-            "Drink blood mixed with a freshly crushed spider to cling to walls like an insect.",
+        name: "Bloody Message",
+        summary: "Write a blood message onto a remembered reflective surface for a chosen type of viewer. Make the Ritual Roll when enchanting the surface.",
         rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A mirror, human blood, and UV light",
+        level: 1
+    },
+    {
+        name: "Clinging of the Insect",
+        summary: "Drink blood mixed with a freshly crushed spider to cling to walls like an insect. The user must cling with both hands and feet.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "Living spider, your own blood",
         level: 1
     },
     {
+        name: "Coax the Garden",
+        summary: "Animate nearby plant life to hinder and harm anyone in the ritual area except the caster.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Human blood and poppy seeds",
+        level: 1
+    },
+    {
         name: "Craft Bloodstone",
-        summary:
-            "Slowly soak blood into a small magnet. Once done, you sense the direction and rough distance of the stone for a week.",
+        summary: "Slowly soak blood into a small magnet. Once done, sense the direction and rough distance of the stone for a week. A caster may have up to as many stones as their Resolve.",
         rouseChecks: 1,
         requiredTime: "3 nights",
         dicePool: "Intelligence + Blood Sorcery",
@@ -32,107 +102,117 @@ export const Rituals: Ritual[] = [
         level: 1
     },
     {
-        name: "Wake with Evenings Freshness",
-        summary:
-            "When threatened during the day after performing this ritual, awaken and ignore daytime penalties for a scene.",
+        name: "Douse the Fear",
+        summary: "Briefly steady yourself against fire, gaining a bonus to resist terror frenzy from flames. The power wears off once the scene ends.",
         rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Burnt bones of a rooster",
-        level: 1
-    },
-    {
-        name: "Ward against Ghouls",
-        summary:
-            "Place a ward on a small object. When a ghoul tries to touch it, roll your Ritual roll. If you succeed, the Ghoul cannot touch it and is damaged.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "asd",
-        level: 1
-    },
-    {
-        name: "Coax the Garden",
-        summary:
-            "Animate nearby plant life to hinder and harm anyone in the ritual area except the caster.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Human blood and poppy seeds",
-        level: 1
-    },
-    {
-        name: "Dampen the Fear",
-        summary:
-            "Briefly steady yourself against fire, gaining a bonus to resist terror frenzy from flames.",
-        rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "5 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "A holy object exposed to flame",
         level: 1
     },
     {
-        name: "Seal the Brand",
-        summary:
-            "Make a tattoo, scar, brand, or similar body modification permanent on vampiric flesh.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Molten silver poured over the body modification",
-        level: 1
-    },
-    {
-        name: "Letter Ward",
-        summary:
-            "Seal a letter so anyone except the intended recipient is burned and the message is destroyed.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Pigeon blood, wax, and dog blood",
-        level: 1
-    },
-    {
-        name: "Bloody Message",
-        summary:
-            "Write a blood message onto a remembered reflective surface for a chosen type of viewer.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A mirror, human blood, and UV light",
-        level: 1
-    },
-    {
-        name: "Beelzebeatit",
-        summary:
-            "Make a small area repellent to animals, vermin, plants, and other lesser living creatures.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Vinegar or alcohol",
-        level: 1
-    },
-    {
         name: "Enrich the Blood",
-        summary:
-            "Make a human vessel's blood richer so a smaller drink slakes more Hunger for a short time.",
+        summary: "Make a human vessel's blood richer so a smaller drink slakes more Hunger for a short time. Does not work on Kindred vitae.",
         rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "5 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "A vial of the target's blood and fresh human blood",
         level: 1
     },
     {
-        name: "As Fog on Water",
-        summary: "Walk silently across the surface of a body of water for the rest of the night.",
+        name: "Herd Ward (Minor)",
+        summary: "Ward a single member of a herd to prevent unauthorized feeding. Make the Ritual Roll when someone else tries to feed from them.",
         rouseChecks: 1,
-        requiredTime: "10min",
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Letter Ward",
+        summary: "Seal a letter so anyone except the intended recipient is burned and the message is destroyed. Make the Ritual Roll if anyone other than the recipient opens it.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Pigeon blood, wax, and dog blood",
+        level: 1
+    },
+    {
+        name: "Revealing the Crimson Trail",
+        summary: "Reveal traces of spilled blood at the caster's current location. Very old traces require a Resolve + Awareness test.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Sanguine Tidings",
+        summary: "Make a message appear on a mirror when a specific type of person comes nearby. The message disappears once read.",
+        rouseChecks: 0,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Seal the Brand",
+        summary: "Make a tattoo, scar, brand, or similar body modification permanent on vampiric flesh. The process inflicts 1 Superficial damage.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Molten silver poured over the body modification",
+        level: 1
+    },
+    {
+        name: "Shared Memory",
+        summary: "Observe another's In Memoriam. Participants can observe events and offer advice but cannot directly influence them.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    {
+        name: "Wake with Evening's Freshness",
+        summary: "When threatened during the day after performing this ritual, awaken and ignore daytime penalties for a scene. Do not make the Ritual Roll until true danger appears.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Burnt bones of a rooster",
+        level: 1
+    },
+    {
+        name: "Ward Against Ghouls",
+        summary: "Place a ward on a small object. When a ghoul tries to touch it, make the Ritual Roll — on a success, the ghoul cannot touch it and is damaged. Uses standard rules for Wards.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 1
+    },
+    // Level 2
+    {
+        name: "As Fog on Water",
+        summary: "Walk silently across the surface of a body of water for the rest of the night. Can be ended early.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "A piece of wood from a ship and water",
         level: 2
     },
     {
+        name: "Calling the Aura's Remnants",
+        summary: "Speak with the residual aura of someone who has died. The aura retains memories only up to the time of death.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
         name: "Calix Secretus",
-        summary: "Store your vitae inside a small object and release it later with a command word.",
+        summary: "Store your vitae inside a small object and release it later with a command word. Two Rouse Checks stored will slake one Hunger.",
         rouseChecks: 1,
         requiredTime: "1 hour",
         dicePool: "Intelligence + Blood Sorcery",
@@ -140,98 +220,198 @@ export const Rituals: Ritual[] = [
         level: 2
     },
     {
-        name: "Soporific Touch",
-        summary:
-            "Turn your vitae into a touch-activated narcotic that weakens Composure and Resolve resistance.",
+        name: "Communicate with Kindred Sire",
+        summary: "Create a long-distance telepathic link between Sire and Childe. A major disturbance on either side breaks the connection.",
         rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "10 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Hashish or another narcotic substance",
+        ingredients: "",
         level: 2
     },
     {
-        name: "The Shroud of Silence",
-        summary: "Seal a room so no sound can escape until the focus is removed or the scene ends.",
+        name: "Craftmaster",
+        summary: "Temporarily gain dots and a specialty in Academics, Craft, Performance, or Science. Dots replace existing dots in that skill, but grant an extra die if the caster already has the specialty. On a total failure, the caster takes Aggravated Damage.",
         rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "10 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Woven cloth, a golden ring, and vitae from an Obfuscate user",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Depths of Nightmare",
+        summary: "Curse someone with nightmares that cause Willpower damage which cannot be healed during the Ritual's duration. On a total failure, the victim has pleasant dreams and is pointed toward the caster.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Elemental Grasp",
+        summary: "Command your chosen element to interfere with a target. The target takes Superficial Health damage and must roll to continue. Gain +1 die to the Ritual pool if the element is already naturally active.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
         level: 2
     },
     {
         name: "Enhance Dyscrasia",
-        summary:
-            "Amplify a vessel's Dyscrasia so several Kindred can benefit from it over three nights.",
+        summary: "Amplify a vessel's Dyscrasia so several Kindred can benefit from it over three nights.",
         rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "10 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "A resonant personal object belonging to the target",
         level: 2
     },
     {
-        name: "Fire in the Blood",
-        summary:
-            "Burn a target's blood from afar, causing painful superficial damage and physical penalties.",
+        name: "Eyes of Babel",
+        summary: "Consume the eyes and tongue of a victim to gain the ability to read and speak any language known by them. This Ritual may incur Stains.",
         rouseChecks: 1,
-        requiredTime: "15min",
+        requiredTime: "10 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Target's blood, their image, and a red candle or iron lighter",
+        ingredients: "The victim's eyes and tongue",
+        level: 2
+    },
+    {
+        name: "Illuminate Trail of Prey",
+        summary: "Follow the trail of a specific person. The victim's face must be known to the caster.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Le Sang de l'Amour",
+        summary: "Create a mystical connection between two people who desire each other at the time of casting. Both can use Resolve + Awareness to estimate where the other is. On a total failure of the Ritual, the roll disorients them and temporarily reduces Composure by one.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Silentia Mortis",
+        summary: "Replicate Silence of Death (Obfuscate ●), creating a radius of silence. If cast on someone other than the caster, they must also make a Rouse Check.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Soporific Touch",
+        summary: "Turn your vitae into a touch-activated narcotic that weakens the victim's resistance to mundane manipulation or mind-altering Disciplines. The Ritual Roll is contested against the victim's Stamina + Resolve.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Hashish or another narcotic substance",
+        level: 2
+    },
+    {
+        name: "Shroud of Silence",
+        summary: "Seal a room so no sound can escape until the focus is removed or the scene ends. Requires vitae from a Kindred who possesses Obfuscate.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Woven cloth, a golden ring, and vitae from an Obfuscate user",
+        level: 2
+    },
+    {
+        name: "Stolen Memory",
+        summary: "Access your sire's memories. Can reach grandsire or beyond with a Difficulty increase of 2 per generation past the sire.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Tiamat Glistens",
+        summary: "Attune yourself to a place of power (Furcus), gaining bonuses to Rituals cast there. Only one caster can be attuned at a time; if another performs the Ritual, the original caster immediately loses their bonus.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Truth of Blood",
+        summary: "Discern truth from lies in a target's speech. The target resists with Composure + Occult. Cannot get past memory-wiping Disciplines.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Resolve + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Unseen Underground",
+        summary: "Become invisible while underground. Immediately ends if the caster goes above ground or takes hostile actions; otherwise lasts one hour.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Viscera Garden",
+        summary: "Grow Blood-addicted plants that can consume corpses. Kindred can eat them without slaking Hunger but they stay down. Mortals who ingest a plant become more susceptible to Disciplines.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Ward against Spirits",
+        summary: "Protect a small object against spirits. Uses standard rules for Wards.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Warding Circle against Ghouls",
+        summary: "Protect an area against Ghouls. Uses standard rules for Wards.",
+        rouseChecks: 3,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 2
+    },
+    {
+        name: "Web of Hunger",
+        summary: "Avoid the pull of the Beckoning. Normally a 4th level Ritual, but reduced to 2nd level when used with the required dagger.",
+        rouseChecks: 1,
+        requiredTime: "10 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A special dagger",
+        level: 2
+    },
+    // Level 3
+    {
+        name: "Bladed Hands",
+        summary: "Sharpen the caster's hands into weapons. Treated as a light piercing Brawl weapon with a +2 modifier.",
+        rouseChecks: 2,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
         level: 3
     },
     {
-        name: "One With the Blade",
-        summary:
-            "Dedicate a melee weapon to yourself so it resists decay and can be anointed for combat.",
+        name: "Blood Sigil",
+        summary: "Create a tattoo on a Kindred that also contains a hidden message. Read it with a Resolve + Occult roll or Sense the Unseen (Auspex ●). The caster can remove it by spending Willpower and touching the tattoo.",
         rouseChecks: 1,
-        requiredTime: "1 night",
+        requiredTime: "15 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A melee weapon immersed in the caster's vitae",
-        level: 3
-    },
-    {
-        name: "Herd Ward",
-        summary:
-            "Ward a mortal or shelter so another vampire is burned and repelled when they try to feed there.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Scorpion poison and the caster's vitae",
-        level: 3
-    },
-    {
-        name: "Sleep of Judas",
-        summary:
-            "Prepare a supernatural narcotic that can incapacitate vampires and kill mortals or ghouls.",
-        rouseChecks: 1,
-        requiredTime: "15min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Blood from a mystical landmark and opium",
-        level: 3
-    },
-    {
-        name: "Communal Vigor",
-        summary:
-            "Strengthen a pack's Vaulderie so members share the priest's Blood Potency for the night.",
-        rouseChecks: 1,
-        requiredTime: "15min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A fingernail from the pack priest",
-        level: 3
-    },
-    {
-        name: "Galvanic Ruination",
-        summary:
-            "Destroy nearby electrical systems, usually knocking out lights, alarms, cars, and cameras.",
-        rouseChecks: 1,
-        requiredTime: "5min",
-        dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A copper coin smeared with the caster's blood",
+        ingredients: "",
         level: 3
     },
     {
         name: "Bloodless Feast",
-        summary:
-            "Transmute an unconscious human's life into clear vitae that can sate Hunger but invites diablerie.",
+        summary: "Transmute an unconscious human's life into clear vitae that can sate Hunger. Those who consume enough of it become weaker to diablerie. May incur Stains.",
         rouseChecks: 1,
         requiredTime: "3 hours",
         dicePool: "Intelligence + Blood Sorcery",
@@ -239,59 +419,261 @@ export const Rituals: Ritual[] = [
         level: 3
     },
     {
-        name: "Grim Chrysalis",
-        summary:
-            "Spit out a protective cocoon that shields you from sunlight and accelerates healing or reshaping.",
+        name: "Communal Vigor",
+        summary: "Strengthen a pack's Vaulderie so members share the priest's Blood Potency for the night. The Priest gains +3 bonus dice on Dominate and Presence tests against packmates.",
         rouseChecks: 1,
-        requiredTime: "15min",
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A fingernail from the pack priest",
+        level: 3
+    },
+    {
+        name: "Dagon's Call",
+        summary: "Rupture the blood vessels of a victim from afar. Can be used up to two additional times the same night, each costing another Rouse Check. Opposed by Stamina + Resolve.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Resolve + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Deflection of Wooden Doom",
+        summary: "Protect yourself from being staked. Do not make the Ritual Roll until actually staked.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Elemental Shelter",
+        summary: "Meld with your chosen element, similar to Earth Meld (Protean ●●●). Fire Kolduns must resist terror frenzy before casting. The caster's form can be detected with Wits + Awareness or Sense the Unseen. If the bonded element is removed, the Koldun enters torpor.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Essence of Air",
+        summary: "Allows for flight. The Camarilla frowns upon this Ritual due to its Masquerade dangers.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Eyes of the Past",
+        summary: "See what happened at the caster's current location in the past. Only holds events within the last five years.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Fire in the Blood",
+        summary: "Burn a target's blood from afar, causing painful Superficial damage and physical penalties. A victim can only be affected by this Ritual once per night.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Target's blood, their image, and a red candle or iron lighter",
+        level: 3
+    },
+    {
+        name: "Firewalker",
+        summary: "Allow yourself and your comrades to become resistant to fire. The required fingertip removal must all come from the caster, even when cast on others.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "The caster's fingertips",
+        level: 3
+    },
+    {
+        name: "Galvanic Ruination",
+        summary: "Destroy nearby electrical systems, knocking out lights, alarms, cars, and cameras in a warehouse or three-story building. Extend to additional buildings by increasing Difficulty by 1 per building.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A copper coin smeared with the caster's blood",
+        level: 3
+    },
+    {
+        name: "Gentle Mind",
+        summary: "Protect the mind of a target against Frenzy. The caster must share blood with the target and cannot cast this on themselves.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Grim Chrysalis",
+        summary: "Spit out a protective cocoon that shields from sunlight and accelerates healing or reshaping. The cocoon is hard and provides some protection from outside damage.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "Human hair and a moth or butterfly",
         level: 3
     },
     {
-        name: "Feast of Ashes",
-        summary:
-            "Curse a vampire so they vomit blood for a night and can only sate Hunger with ashes.",
-        rouseChecks: 1,
-        requiredTime: "20min",
+        name: "Haunted House",
+        summary: "Make a haven appear as if it's haunted. The effects last for 10 years.",
+        rouseChecks: 3,
+        requiredTime: "15 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A parchment bearing the target's name, burned to ash",
-        level: 4
+        ingredients: "",
+        level: 3
     },
     {
-        name: "Guided Memory",
-        summary:
-            "Drink a willing Kindred's prepared vitae to relive their memories and temporarily unlock gifts.",
+        name: "Herd Ward (Major)",
+        summary: "Ward a door to protect multiple herd members within against unauthorized feeding. Make the Ritual Roll when someone else tries to feed from the herd.",
         rouseChecks: 1,
-        requiredTime: "20min",
+        requiredTime: "15 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Another vampire's vitae, dried rosemary, and poppies or forget-me-nots",
-        level: 4
+        ingredients: "Scorpion poison and the caster's vitae",
+        level: 3
     },
     {
-        name: "Invisible Chains of Binding",
-        summary:
-            "Prepare a chain link that can pin a target in place and hinder their physical defenses.",
+        name: "Illusion of Peaceful Death",
+        summary: "Make a corpse appear as if it died a natural death. The body must have at least half of its blood remaining to succeed.",
         rouseChecks: 1,
-        requiredTime: "1 hour",
+        requiredTime: "15 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A chain link inscribed with the caster's blood",
-        level: 4
+        ingredients: "",
+        level: 3
     },
     {
-        name: "Seek the Gathered Vitae",
-        summary:
-            "Sense a nearby concentration of Kindred vitae and track its direction for an hour.",
+        name: "Illusion of Perfection",
+        summary: "Become a nondescript, unremarkable person to blend into crowds, similar to Mask of a Thousand Faces (Obfuscate).",
         rouseChecks: 1,
-        requiredTime: "5min",
+        requiredTime: "15 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "Red ink, pomegranate juice, white paper or cloth, and a large top",
-        level: 4
+        ingredients: "",
+        level: 3
     },
     {
-        name: "The Balm of Bathory",
-        summary:
-            "Brew a blood balm that temporarily restores youthful beauty but becomes addictive and toxic.",
+        name: "Nepenthe",
+        summary: "Create a draught that removes Stains, but prolonged use makes those Stains permanent. Using Nepenthe two sessions in a row causes one Stain to become permanent (cumulative).",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "One with the Blade",
+        summary: "Dedicate a melee weapon to yourself so it resists decay and can be anointed for combat. Only one weapon can hold this ritual at a time.",
+        rouseChecks: 1,
+        requiredTime: "1 night",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A melee weapon immersed in the caster's vitae",
+        level: 3
+    },
+    {
+        name: "Sanguine Watcher",
+        summary: "Create a small rat from vitae that can observe or steal on the caster's behalf. Instructions must be very explicit.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Seeing with the Sky's Eyes",
+        summary: "Observe a target from above. Ask one question about their location and surroundings per success. Critical Wins grant 3 extra questions and can reveal Ambitions, Desires, Convictions, and Humanity.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Seeking Tiamat",
+        summary: "Find veins of the Earth (Furcae). Costs one Rouse Check and Aggravated Health damage. Critical Wins discover the closest vein and point toward 2 Furcae on that vein.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Sleep of Judas",
+        summary: "Prepare a supernatural narcotic that can incapacitate vampires and kill mortals or ghouls. Make the Ritual Roll when the target is drugged.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Blood from a mystical landmark and opium",
+        level: 3
+    },
+    {
+        name: "Soul of the Hemonculus",
+        summary: "Create a Hemonculus — a shrivelled, smaller, weaker version of the caster who must obey every command. Immune to sunlight but cannot be Embraced, made into a ghoul, or Blood Bonded. Kindred slake no Hunger from drinking its blood.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Stone of the True Form",
+        summary: "Dispel illusions and Discipline-altered creatures. Must throw the stone with Dexterity + Athletics. On a win: illusions dispelled, shapeshifters painfully returned to original form, Discipline-made beings separated into components. Target resists with Resolve + Occult.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "The Unseen Change",
+        summary: "Force Lupines entering the area into Wolf Form. They resist with a contested Willpower roll; on failure they enter Lupus Form instead.",
+        rouseChecks: 3,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Trespass",
+        summary: "Flow through any crevice that blood can fit through to move through a building undetected. Unlike Incorporeal Passage, the caster can be attacked if noticed.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Viral Haruspex",
+        summary: "Gather information from everyone in an area suffering from a certain disease. The caster must drink from someone infected with that disease within 24 hours before casting.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Blood of someone infected with the target disease",
+        level: 3
+    },
+    {
+        name: "Ward against Lupines",
+        summary: "Protect a small object against Werewolves. Uses standard rules for Wards.",
+        rouseChecks: 1,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    {
+        name: "Warding Circle against Spirits",
+        summary: "Protect an area against spirits. Uses standard rules for Wards.",
+        rouseChecks: 3,
+        requiredTime: "15 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 3
+    },
+    // Level 4
+    {
+        name: "Balm of Bathory",
+        summary: "Brew a blood balm from young mortal blood that temporarily grants the Stunning (••••) Merit. Each subsequent use requires double the mortal blood of the last batch.",
         rouseChecks: 1,
         requiredTime: "1 hour",
         dicePool: "Intelligence + Blood Sorcery",
@@ -299,29 +681,180 @@ export const Rituals: Ritual[] = [
         level: 4
     },
     {
-        name: "Eden's Bounty",
-        summary:
-            "Draw small amounts of blood from nearby mortals through a tree to reduce the caster's Hunger.",
+        name: "Compel the Inanimate",
+        summary: "Give a simple command to an inanimate object that it follows a few minutes later. The caster must remain in the same general area. Detectable with Sense the Unseen (Auspex ●) via a contested roll.",
         rouseChecks: 1,
-        requiredTime: "25min",
+        requiredTime: "20 min",
         dicePool: "Intelligence + Blood Sorcery",
-        ingredients: "A corpse, a living tree, a fresh apple, and a rotten apple",
-        level: 5
+        ingredients: "",
+        level: 4
     },
     {
-        name: "Creatio Ignis",
-        summary:
-            "Coat your arms in vitae that catches fire first, letting you wield flame by touch for a scene.",
+        name: "Defense of the Sacred Haven",
+        summary: "Protect a haven with mystical darkness from sunlight. The Ritual Roll is made once the sun rises.",
         rouseChecks: 1,
-        requiredTime: "25min",
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Egregore Consultation",
+        summary: "By hosting an illness, access the collective experiences of everyone in the area with that illness to enhance Skills. Skills very common locally can grant up to +2 extra dice.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Eyes of the Nighthawk",
+        summary: "Take control of a carnivorous bird and act through them. The caster can use most non-physical Disciplines through the bird.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Feast of Ashes",
+        summary: "Curse a vampire so they vomit blood for a night and can only sate Hunger with ashes (minimum Hunger 3). Contested against the victim's Resolve + Willpower.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A parchment bearing the target's name, burned to ash",
+        level: 4
+    },
+    {
+        name: "Guided Memory",
+        summary: "Drink a willing Kindred's prepared vitae to relive their memories guided by them. Can be used to unlock Discipline powers, Merits, and other gifts.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Another vampire's vitae, dried rosemary, and poppies or forget-me-nots",
+        level: 4
+    },
+    {
+        name: "Incorporeal Passage",
+        summary: "The caster's form becomes ghost-like, allowing them to pass through solid matter. They may only interact with the world through speech and sight.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Innocence of the Child's Heart",
+        summary: "Block Scry the Soul (Auspex) to hide evidence of diablerie and other vampiric traits. Extremely rare — only learned by obtaining Nicolai's notes or by Storyteller discretion.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Innocence's Veil",
+        summary: "Temporarily make traces of Diablerie undetectable. Cannot be detected by A Taste for Blood or Scry the Soul.",
+        rouseChecks: 0,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Invisible Chains of Binding",
+        summary: "Prepare a chain link that can pin a target in place for one hour per success in the margin and hinder their physical defenses. Ends if the chain is destroyed or removed.",
+        rouseChecks: 1,
+        requiredTime: "1 hour",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A chain link inscribed with the caster's blood",
+        level: 4
+    },
+    {
+        name: "Land's Sustenance",
+        summary: "Feed from a place of power, turning it into a place of suffering where injuries are more severe. Lasts until end of the Story. Once per session, automatically pass Rouse Checks equal to the Ritual margin.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Protean Curse",
+        summary: "Transform a target into a bat, similar to Metamorphosis (Protean). Cannot be used on the caster.",
+        rouseChecks: 2,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Rending the Sweet Earth",
+        summary: "Pull a vampire from the earth who is using Earth Meld (Protean). Automatically awakens the target unless they are in torpor or the Ritual Roll is a Critical Win.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Riding the Earth's Vein",
+        summary: "Travel from one Furcus to a random other. The caster has no control over the destination. One-way; only activates where first cast.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Seek the Gathered Vitae",
+        summary: "Sense a concentration of Kindred vitae with a collective Blood Potency of 13 or higher and track its direction for an hour. Ghouls count as 1/4 and Duskborn as 1/2.",
+        rouseChecks: 1,
+        requiredTime: "5 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "Red ink, pomegranate juice, white paper or cloth, and a large top",
+        level: 4
+    },
+    {
+        name: "Ward against Cainites",
+        summary: "Protect a small object against Kindred. Uses standard rules for Wards. A vampire examining the ward may read the caster's name with an Intelligence + Auspex vs. Intelligence + Blood Sorcery roll.",
+        rouseChecks: 1,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    {
+        name: "Warding Circle against Lupines",
+        summary: "Protect an area against Werewolves. Uses standard rules for Wards.",
+        rouseChecks: 3,
+        requiredTime: "20 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 4
+    },
+    // Level 5
+    {
+        name: "Antebrachia Ignium",
+        summary: "Coat your arms in vitae that catches fire, letting you wield flame by touch for a scene. The caster is only resistant to fire on their arms.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "Enough vitae to coat both arms and a source of flame",
         level: 5
     },
     {
+        name: "Atrocity's Release",
+        summary: "Reverse the effects of Diablerie. Can be resisted with a Resolve + Blood Sorcery test.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 5
+    },
+    {
         name: "Dominion",
-        summary:
-            "Claim a building as your domain, blocking others from using Animalism, Auspex, Dominate, or Presence there.",
+        summary: "Claim a building as your domain, blocking others from using Animalism, Auspex, Dominate, or Presence there. The area of effect is determined by the number of Rouse Checks spent.",
         rouseChecks: 1,
         requiredTime: "3 hours",
         dicePool: "Intelligence + Blood Sorcery",
@@ -329,13 +862,93 @@ export const Rituals: Ritual[] = [
         level: 5
     },
     {
+        name: "Eden's Bounty",
+        summary: "Draw blood from nearby mortals through a tree to reduce the caster's Hunger. Mortals suffer −1 die to Physical rolls and 1 Aggravated health damage for the remainder of the chapter. May incur Stains.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A corpse, a living tree, a fresh apple, and a rotten apple",
+        level: 5
+    },
+    {
+        name: "Elemental Attack",
+        summary: "Command your chosen element to attack a foe. Can be a Chain Ritual. Gain +1 die if the element is naturally active. Chained with Elemental Grasp and Tiamat Glistens, becomes a natural disaster (tornado, magma flow, tsunami, etc.).",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 5
+    },
+    {
+        name: "Escape to True Sanctuary",
+        summary: "Create a one-way portal between two ritual circles. Requires 12 Rouse Checks total. A caster may only have one set of circles active at a time.",
+        rouseChecks: 12,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 5
+    },
+    {
+        name: "Fisher King",
+        summary: "Become one with your land, gaining access to its secrets. Can be a Chain Ritual. Use Wits + Streetwise or Survival to ask questions about the land; gain one extra question per session. Lasts until end of the story. Chained with Land's Sustenance and Compel the Inanimate, casters gain complete control and can heal 5 Aggravated damage total each night.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 5
+    },
+    {
+        name: "Heart of Stone",
+        summary: "Turn your heart to stone, preventing staking. Causes emotional detachment, penalizing Remorse rolls and active Social-related rolls. Cannot use Presence during the Ritual's duration, but gain a bonus when resisting its use on you.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 5
+    },
+    {
+        name: "Reawakened Vigor",
+        summary: "Regain Blood Potency faster after extended torpor. Inflicts Aggravated damage on anyone other than the caster.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
+        level: 5
+    },
+    {
+        name: "Shaft of Belated Dissolution",
+        summary: "Create a stake that seeks out a vampire's heart. Even if the initial attack misses the heart, a splinter breaks off and moves toward it — if it finds the heart, the target faces Final Death.",
+        rouseChecks: 2,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "A wooden stake",
+        level: 5
+    },
+    {
         name: "Simulacrum Gate",
-        summary:
-            "Build a sacrificial replica doorway that allows multiple vampires to cross vast distances.",
+        summary: "Build a sacrificial replica doorway that allows multiple vampires to cross vast distances. May incur Stains.",
         rouseChecks: 1,
         requiredTime: "weeks",
         dicePool: "Intelligence + Blood Sorcery",
         ingredients: "Replica materials, mortal sacrifices, and a vampire sacrifice",
+        level: 5
+    },
+    {
+        name: "Transferring the Soul",
+        summary: "Take over a new body through the act of diablerie. Requires another Kindred with Oblivion ●●●●●, or a single Kindred possessing both Blood Sorcery ●●●●● and Oblivion ●●●●●.",
+        rouseChecks: 1,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery and Intelligence + Oblivion",
+        ingredients: "",
+        level: 5
+    },
+    {
+        name: "Warding Circle against Cainites",
+        summary: "Protect an area against Kindred. Uses standard rules for Wards.",
+        rouseChecks: 3,
+        requiredTime: "25 min",
+        dicePool: "Intelligence + Blood Sorcery",
+        ingredients: "",
         level: 5
     }
 ]

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -347,7 +347,11 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
     // M&F categories: essentials (non-background) + advanced (non-background)
     const essentialMFCategories = essentialMeritsAndFlaws.filter((cat) => !ESSENTIAL_BG_TITLES.has(cat.title))
     const advancedMFCategories = advancedMeritsAndFlaws.filter((cat) => !ADVANCED_BG_TITLES.has(cat.title))
-    const allMFCategories = [...essentialMFCategories, ...advancedMFCategories]
+    const allMFCategories = [...essentialMFCategories, ...advancedMFCategories].filter((cat) => {
+        if (cat.restriction === "caitiff") return character.clan === "Caitiff"
+        if (cat.restriction === "ghoul") return character.age_category === "ghoul"
+        return true
+    })
 
     const [expandedLoresheetIds, setExpandedLoresheetIds] = useState<Set<string>>(new Set())
     const toggleLoresheetExpanded = (id: string) => {


### PR DESCRIPTION
## Summary

- **Advantages step redesign**: renamed step label to \"Advantages\"; three-tab layout — Backgrounds | Merits & Flaws | Loresheets
- **Backgrounds tab**: flat alphabetical list (no section headers); sources all four essential background categories + advanced (Haven, Resources, Fame, Influence); deduplicated by name (advanced entries win)
- **Merits & Flaws tab**: now includes `advancedMeritsAndFlaws` non-background categories (Players Guide, Forbidden Religions, Tattered Facade, Live from the Succubus Club content)
- **Allies**: split into \"Allies: Effectiveness\" (1–4) and \"Allies: Reliability\" (1–3) with per-dot Core book descriptions; max combined 6
- **Players Guide M&F data**: Caitiff-specific (5 merits, 7 flaws), Ghoul-specific (2 merits, 3 flaws), Thin-blood additions (6 merits, 8 flaws), Check the Trunk
- **Restriction filtering**: Caitiff M&F only shown when clan = Caitiff; Ghoul M&F only shown when age_category = ghoul
- **Loresheet dot key fix**: keys stored as `"${ls.name}: ${dot.name}"` to prevent cross-loresheet selection conflicts
- **Player portal**: staff XP ledger adjustments shown inline in Claims History table
- **Background overlay**: darkened for readability

## Test plan

- [ ] Backgrounds tab shows A–Z flat list (no section headers), includes Haven/Resources/Fame/Influence from advanced, Influence deduped (advanced version wins with proper excludes)
- [ ] Merits & Flaws tab shows PG categories (Looks, Feeding, Mythic, Bonding, etc.)
- [ ] Caitiff M&F section only visible when clan = Caitiff
- [ ] Ghoul M&F section only visible when age_category = ghoul
- [ ] Thin-blood PG merits/flaws visible for Thin-blood characters
- [ ] Allies: Effectiveness (1–4) and Allies: Reliability (1–3) both appear in Backgrounds; combined cap note in summary
- [ ] Loresheets: selecting dots from different loresheets with same dot name don't conflict
- [ ] Player portal /player/<name>: staff XP adjustments appear in Claims History table, not a separate card

🤖 Generated with [Claude Code](https://claude.com/claude-code)