### PR TITLE
feat: sync staff roles from Discord (closes #240)

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -171,3 +171,14 @@ LASOMBRA_COMMAND_NAME=lasombra
 DISCORD_GUILD_ID=
 
 # Chronicle Wiki writes use WEB_APP_API_WRITE_TOKEN defined above — no extra var needed.
+
+# ---------------------------------------------------------------------------
+# Staff Role Sync — keep Discord roles as source of truth for staff membership
+# ---------------------------------------------------------------------------
+# Set to true to enable. Requires "Server Members Intent" on the bot application page.
+STAFF_ROLE_SYNC_ENABLED=false
+# Discord role IDs (defaults are the MCbN production role IDs; override if needed)
+# STAFF_ROLE_SYSTEM_HELPER_ID=1168649906324520992
+# STAFF_ROLE_STORYTELLER_ID=1168649373731790948
+# STAFF_ROLE_MODERATOR_ID=1168650352132890794
+# STAFF_ROLE_ADMINISTRATOR_ID=1168648955731648554

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -162,6 +162,11 @@ const envSchema = z.object({
   CUBBY_SYNC_STAFF_CHANNEL_ID: z.string().optional(),
   CUBBY_RETIRED_CATEGORY_ID: z.string().optional(),
   LASOMBRA_COMMAND_NAME: z.string().regex(/^[-_a-z0-9]{1,32}$/, 'LASOMBRA_COMMAND_NAME must be 1-32 chars, lowercase letters/numbers/hyphens/underscores only').optional(),
+  STAFF_ROLE_SYNC_ENABLED: z.string().optional(),
+  STAFF_ROLE_SYSTEM_HELPER_ID: z.string().optional(),
+  STAFF_ROLE_STORYTELLER_ID: z.string().optional(),
+  STAFF_ROLE_MODERATOR_ID: z.string().optional(),
+  STAFF_ROLE_ADMINISTRATOR_ID: z.string().optional(),
 });
 
 // Strip empty strings so optional fields behave as if absent.
@@ -382,6 +387,11 @@ export const config = {
   cubbySyncStaffChannelId: env.CUBBY_SYNC_STAFF_CHANNEL_ID ?? '',
   cubbyRetiredCategoryId: env.CUBBY_RETIRED_CATEGORY_ID ?? '1225070632799043685',
   lasombraCommandName: env.LASOMBRA_COMMAND_NAME ?? 'lasombra',
+  staffRoleSyncEnabled: (env.STAFF_ROLE_SYNC_ENABLED ?? 'false').toLowerCase() === 'true',
+  staffRoleSystemHelperId: env.STAFF_ROLE_SYSTEM_HELPER_ID ?? '1168649906324520992',
+  staffRoleStorytellerId: env.STAFF_ROLE_STORYTELLER_ID ?? '1168649373731790948',
+  staffRoleModeratorId: env.STAFF_ROLE_MODERATOR_ID ?? '1168650352132890794',
+  staffRoleAdministratorId: env.STAFF_ROLE_ADMINISTRATOR_ID ?? '1168648955731648554',
 };
 
 if (config.testRequesterDiscordId) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -77,14 +77,18 @@ const adapter = new WebAppAdapter(config.webAppBaseUrl, config.webAppApiToken, {
   claimContextRetryBaseMs: config.claimContextRetryBaseMs,
 });
 
-const client = new Client({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.MessageContent,
-    GatewayIntentBits.GuildMembers,
-  ],
-}) as BotClient;
+const baseIntents = [
+  GatewayIntentBits.Guilds,
+  GatewayIntentBits.GuildMessages,
+  GatewayIntentBits.MessageContent,
+];
+// GuildMembers is a privileged intent that must be enabled in the Discord
+// Developer Portal. Only request it when staff role sync actually needs it.
+if (config.staffRoleSyncEnabled) {
+  baseIntents.push(GatewayIntentBits.GuildMembers);
+}
+
+const client = new Client({ intents: baseIntents }) as BotClient;
 
 initClientCommandCollection(client);
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -56,6 +56,7 @@ import { CubbySyncWorker } from './services/cubbySyncWorker';
 import { liveConfig } from './liveConfig';
 import { BackgroundBlankReleaseService } from './services/backgroundBlankReleaseService';
 import { DiscordActivityTracker } from './services/discordActivityTracker';
+import { StaffRoleSyncService } from './services/staffRoleSyncService';
 
 // Seed liveConfig from .env values so services start with the correct initial state.
 liveConfig.reviewNotifierEnabled = config.reviewNotifierEnabled;
@@ -77,7 +78,12 @@ const adapter = new WebAppAdapter(config.webAppBaseUrl, config.webAppApiToken, {
 });
 
 const client = new Client({
-  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildMembers,
+  ],
 }) as BotClient;
 
 initClientCommandCollection(client);
@@ -224,6 +230,19 @@ void applyStartupConfigOverrides().then(() => {
     ? new DiscordActivityTracker(adapter, discordActivityGuildId)
     : null;
 
+  const staffRoleSyncGuildId = config.discordGuildId ?? config.reviewNotifierGuildId ?? '';
+  const staffRoleSync = config.staffRoleSyncEnabled && staffRoleSyncGuildId
+    ? new StaffRoleSyncService(client, adapter, {
+        guildId: staffRoleSyncGuildId,
+        roleMap: new Map([
+          [config.staffRoleSystemHelperId, 'system_helper'],
+          [config.staffRoleStorytellerId, 'storyteller'],
+          [config.staffRoleModeratorId, 'moderator'],
+          [config.staffRoleAdministratorId, 'administrator'],
+        ]),
+      })
+    : null;
+
   const configSyncWorker = new ConfigSyncWorker(adapter, config.configSyncIntervalMs);
   const wikiSyncCapable = Boolean(config.discordGuildId);
   const botHeartbeatService = new BotHeartbeatService(
@@ -278,6 +297,7 @@ void applyStartupConfigOverrides().then(() => {
     // the same second and compete for connections during backfill scans.
     // Notifiers start immediately so their cursor bootstrap isn't delayed.
     setTimeout(() => botHeartbeatService.start(), 15_000);
+    staffRoleSync?.start();
     startCubbyChannelMonitor(client);
     startCharacterTicketMonitor(client, {
       webBaseUrl: config.webAppBaseUrl,

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -119,6 +119,10 @@ export interface TrackerAdapter {
     names?: Record<string, string>,
   ): Promise<void>;
   getRecentPeriods(count?: number): Promise<Array<{ label: string; nightNumber: number; startDate: string; endDate: string }>>;
+  syncStaff(
+    operations: Array<{ action: 'upsert' | 'remove'; discord_id: string; display_name: string; role: string }>,
+    fullSync?: boolean,
+  ): Promise<{ ok: boolean; processed: number }>;
 }
 
 export type CharacterDetails = {
@@ -1225,6 +1229,19 @@ export class WebAppAdapter implements TrackerAdapter {
   private writeAuthHeaders(): Record<string, string> {
     const token = this.writeToken ?? this.legacyToken;
     return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+
+  async syncStaff(
+    operations: Array<{ action: 'upsert' | 'remove'; discord_id: string; display_name: string; role: string }>,
+    fullSync = false,
+  ): Promise<{ ok: boolean; processed: number }> {
+    const res = await this.fetchWithTimeout(`${this.baseUrl}/api/staff/sync`, {
+      method: 'POST',
+      headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ operations, full_sync: fullSync }),
+    });
+    if (!res.ok) throw new Error(`staff/sync POST failed: ${res.status}`);
+    return res.json() as Promise<{ ok: boolean; processed: number }>;
   }
 
   private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {

--- a/apps/bot/src/services/staffRoleSyncService.ts
+++ b/apps/bot/src/services/staffRoleSyncService.ts
@@ -1,0 +1,106 @@
+import type { Client, GuildMember, PartialGuildMember } from 'discord.js';
+import { errorToMessage, logEvent } from '../logger';
+import type { TrackerAdapter } from './adapter';
+
+export interface StaffRoleSyncConfig {
+  guildId: string;
+  /** Map from Discord role ID → internal role value (e.g. 'storyteller') */
+  roleMap: Map<string, string>;
+}
+
+type StaffOp = { action: 'upsert' | 'remove'; discord_id: string; display_name: string; role: string };
+
+const ROLE_PRIORITY = ['administrator', 'moderator', 'storyteller', 'system_helper'];
+
+export class StaffRoleSyncService {
+  private readonly client: Client;
+  private readonly adapter: TrackerAdapter;
+  private readonly guildId: string;
+  private readonly roleMap: Map<string, string>;
+
+  constructor(client: Client, adapter: TrackerAdapter, config: StaffRoleSyncConfig) {
+    this.client = client;
+    this.adapter = adapter;
+    this.guildId = config.guildId;
+    this.roleMap = config.roleMap;
+  }
+
+  start(): void {
+    void this.syncAll();
+    this.client.on('guildMemberUpdate', (oldMember, newMember) => {
+      void this.handleMemberUpdate(oldMember, newMember);
+    });
+  }
+
+  private getHighestRole(member: GuildMember | PartialGuildMember): string | null {
+    const memberRoleIds = new Set(member.roles.cache.keys());
+    const roleValues = new Set<string>();
+    for (const [roleId, roleValue] of this.roleMap) {
+      if (memberRoleIds.has(roleId)) roleValues.add(roleValue);
+    }
+    for (const role of ROLE_PRIORITY) {
+      if (roleValues.has(role)) return role;
+    }
+    return null;
+  }
+
+  private async syncAll(): Promise<void> {
+    if (!this.guildId) return;
+    try {
+      const guild = await this.client.guilds.fetch(this.guildId);
+      await guild.members.fetch();
+
+      const operations: StaffOp[] = [];
+      for (const [, member] of guild.members.cache) {
+        const role = this.getHighestRole(member);
+        if (role) {
+          operations.push({
+            action: 'upsert',
+            discord_id: member.id,
+            display_name: member.displayName,
+            role,
+          });
+        }
+      }
+
+      await this.adapter.syncStaff(operations, true);
+      logEvent('info', 'staff_role_sync_all', { count: operations.length });
+    } catch (err) {
+      logEvent('warn', 'staff_role_sync_all_failed', { error: errorToMessage(err) });
+    }
+  }
+
+  private async handleMemberUpdate(
+    oldMember: GuildMember | PartialGuildMember,
+    newMember: GuildMember | PartialGuildMember,
+  ): Promise<void> {
+    if (newMember.guild.id !== this.guildId) return;
+
+    const oldRole = this.getHighestRole(oldMember);
+    const newRole = this.getHighestRole(newMember);
+
+    if (oldRole === newRole) return;
+
+    try {
+      if (newRole) {
+        await this.adapter.syncStaff([{
+          action: 'upsert',
+          discord_id: newMember.id,
+          display_name: newMember.displayName,
+          role: newRole,
+        }]);
+        logEvent('info', 'staff_role_sync_upsert', { discordId: newMember.id, role: newRole });
+      } else {
+        await this.adapter.syncStaff([{
+          action: 'remove',
+          discord_id: newMember.id,
+          display_name: newMember.displayName,
+          role: '',
+        }]);
+        logEvent('info', 'staff_role_sync_remove', { discordId: newMember.id });
+      }
+    } catch (err) {
+      logEvent('warn', 'staff_role_sync_update_failed', { discordId: newMember.id, error: errorToMessage(err) });
+    }
+  }
+}

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1790,3 +1790,84 @@ def sheets_reconcile():
     except Exception as exc:
         return jsonify({'error': str(exc)}), 500
     return jsonify(summary)
+
+
+@bp.route('/staff/sync', methods=['POST'])
+@require_bot_scope('write')
+def staff_sync():
+    """Sync staff role membership from Discord.
+
+    Accepts a list of upsert/remove operations and optionally performs a full
+    replacement (removes any DB staff entries not present in the upsert list).
+
+    Body:
+      {
+        "operations": [
+          {"action": "upsert", "discord_id": "...", "display_name": "...", "role": "storyteller"},
+          {"action": "remove", "discord_id": "..."}
+        ],
+        "full_sync": true   // optional: remove DB entries not in this payload
+      }
+    """
+    from app.db import AppSetting, db
+    body = request.get_json(silent=True) or {}
+    operations = body.get('operations', [])
+    full_sync = bool(body.get('full_sync', False))
+
+    if not isinstance(operations, list):
+        return jsonify({'error': 'operations must be an array'}), 400
+
+    valid_roles = {'system_helper', 'storyteller', 'moderator', 'administrator'}
+    valid_actions = {'upsert', 'remove'}
+
+    upserted_ids: set[str] = set()
+
+    for op in operations:
+        action = op.get('action')
+        discord_id = str(op.get('discord_id', '')).strip()
+        if not discord_id or action not in valid_actions:
+            return jsonify({'error': f'Invalid operation: {op}'}), 400
+
+        if action == 'upsert':
+            role = op.get('role')
+            if role not in valid_roles:
+                return jsonify({'error': f'Invalid role: {role}'}), 400
+            display_name = str(op.get('display_name', '')).strip()
+            member_key = f'STAFF_MEMBER_{discord_id}'
+            name_key = f'STAFF_NAME_{discord_id}'
+            row = AppSetting.query.get(member_key)
+            if row:
+                row.value = role
+            else:
+                db.session.add(AppSetting(key=member_key, value=role))
+            name_row = AppSetting.query.get(name_key)
+            if name_row:
+                name_row.value = display_name
+            else:
+                db.session.add(AppSetting(key=name_key, value=display_name))
+            upserted_ids.add(discord_id)
+        else:  # remove
+            member_key = f'STAFF_MEMBER_{discord_id}'
+            name_key = f'STAFF_NAME_{discord_id}'
+            row = AppSetting.query.get(member_key)
+            if row:
+                db.session.delete(row)
+            name_row = AppSetting.query.get(name_key)
+            if name_row:
+                db.session.delete(name_row)
+
+    if full_sync:
+        # Remove any DB staff entries not present in this payload's upsert list
+        existing = AppSetting.query.filter(
+            AppSetting.key.like('STAFF_MEMBER_%')
+        ).all()
+        for row in existing:
+            existing_id = row.key[len('STAFF_MEMBER_'):]
+            if existing_id not in upserted_ids:
+                db.session.delete(row)
+                name_row = AppSetting.query.get(f'STAFF_NAME_{existing_id}')
+                if name_row:
+                    db.session.delete(name_row)
+
+    db.session.commit()
+    return jsonify({'ok': True, 'processed': len(operations)})


### PR DESCRIPTION
## Summary

- **Flask `POST /api/staff/sync`** (bot-write auth): accepts `{ operations, full_sync }`, upserts/removes `STAFF_MEMBER_*` and `STAFF_NAME_*` AppSettings. `full_sync: true` removes any DB staff entries not in the payload.
- **`StaffRoleSyncService`**: on bot startup does a full guild member fetch and syncs all current Discord staff role holders (replacing DB state). Listens for `guildMemberUpdate` to handle incremental adds/removes.
- **Priority**: when a member holds multiple staff roles, highest-priority wins (`administrator > moderator > storyteller > system_helper`).
- **`GuildMembers` privileged intent** added to the client (required for `guild.members.fetch()` and `guildMemberUpdate`).
- **`STAFF_ROLE_SYNC_ENABLED=false`** by default — existing bots are unaffected until opted in. Role IDs default to the MCbN production values but can be overridden via env.

## Config

```
STAFF_ROLE_SYNC_ENABLED=true          # opt in
# Override only if role IDs differ from MCbN defaults:
# STAFF_ROLE_SYSTEM_HELPER_ID=...
# STAFF_ROLE_STORYTELLER_ID=...
# STAFF_ROLE_MODERATOR_ID=...
# STAFF_ROLE_ADMINISTRATOR_ID=...
```

**Note:** the Discord bot application must have "Server Members Intent" enabled on its application page (discord.com/developers/applications).

## Test plan

- [ ] Enable `STAFF_ROLE_SYNC_ENABLED=true` on dev bot, restart — check Flask DB `STAFF_MEMBER_*` rows match current Discord staff roles
- [ ] Add/remove a staff role from a user in Discord — verify DB updates within seconds
- [ ] `full_sync=true` removes stale DB entries no longer holding a Discord role
- [ ] Disabling `STAFF_ROLE_SYNC_ENABLED` leaves the existing bot behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)