### PR TITLE
feat: living character sheet (RoD import, sheet view, spend auto-fill)

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -62,6 +62,26 @@ def my_characters():
         .all()
     )
 
+    # Which roster characters have an approved living sheet
+    chars_with_sheet: set[str] = set()
+    if my_chars:
+        char_ids = [
+            row.id for row in DbCharacter.query.filter(
+                DbCharacter.character_name.in_([c.character_name for c in my_chars])
+            ).all()
+        ]
+        approved_drafts = CharacterDraft.query.filter(
+            CharacterDraft.roster_character_id.in_(char_ids),
+            CharacterDraft.status == 'approved',
+        ).all()
+        sheet_id_set = {d.roster_character_id for d in approved_drafts}
+        name_map = {
+            row.id: row.character_name for row in DbCharacter.query.filter(
+                DbCharacter.id.in_(char_ids)
+            ).all()
+        }
+        chars_with_sheet = {name_map[i] for i in sheet_id_set if i in name_map}
+
     # Staff also see a full character search
     if check_is_staff():
         all_characters = db_service.get_active_characters()
@@ -74,6 +94,7 @@ def my_characters():
             open_periods=open_periods,
             calendar=calendar,
             pending_drafts=pending_drafts,
+            chars_with_sheet=chars_with_sheet,
         )
 
     if not my_chars and not pending_drafts:
@@ -89,6 +110,7 @@ def my_characters():
         open_periods=open_periods,
         calendar=calendar,
         pending_drafts=pending_drafts,
+        chars_with_sheet=chars_with_sheet,
     )
 
 
@@ -194,16 +216,24 @@ def character(name):
     backgrounds = db_service.get_character_backgrounds(name)
     current_night = open_periods[0] if open_periods else None
 
-    # Check whether this character has an approved living sheet draft
+    # Check whether this character has an approved living sheet draft; load data for spend form
     char_row = DbCharacter.query.filter(
         DbCharacter.character_name.ilike(name)
     ).first()
     has_approved_draft = False
+    sheet_data = None
     if char_row:
-        has_approved_draft = CharacterDraft.query.filter_by(
+        approved_draft = CharacterDraft.query.filter_by(
             roster_character_id=char_row.id,
             status='approved',
-        ).first() is not None
+        ).first()
+        if approved_draft:
+            has_approved_draft = True
+            if approved_draft.character_data:
+                try:
+                    sheet_data = json.loads(approved_draft.character_data)
+                except (json.JSONDecodeError, TypeError):
+                    sheet_data = None
 
     return render_template(
         'player/character.html',
@@ -226,6 +256,7 @@ def character(name):
         backgrounds=backgrounds,
         current_night=current_night,
         has_approved_draft=has_approved_draft,
+        sheet_data=sheet_data,
     )
 
 
@@ -810,3 +841,28 @@ def import_sheet(name):
         'success',
     )
     return redirect(url_for('player.character', name=name))
+
+
+@bp.route('/<name>/sheet')
+@require_character_owner
+def view_sheet(name):
+    """Display the player's living character sheet."""
+    char = db_service.get_character(name)
+    if not char:
+        abort(404)
+
+    char_row = DbCharacter.query.filter(DbCharacter.character_name.ilike(name)).first()
+    sheet_data = None
+    draft = None
+    if char_row:
+        draft = CharacterDraft.query.filter_by(
+            roster_character_id=char_row.id,
+            status='approved',
+        ).first()
+        if draft and draft.character_data:
+            try:
+                sheet_data = json.loads(draft.character_data)
+            except (json.JSONDecodeError, TypeError):
+                sheet_data = None
+
+    return render_template('player/sheet.html', char=char, sheet_data=sheet_data, draft=draft)

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -695,7 +695,11 @@ def _map_rod_to_cc(rod: dict) -> dict:
         'humanity': rod.get('humanity', 7),
         'ambition': rod.get('ambition', ''),
         'desire': rod.get('desire', ''),
-        'touchstones': rod.get('touchstones', []),
+        'touchstones': (
+            [t.strip() for t in rod['touchstones'].split(',') if t.strip()]
+            if isinstance(rod.get('touchstones'), str)
+            else (rod.get('touchstones') or [])
+        ),
         'age_category': 'ancilla',  # existing characters are treated as ancilla
     }
 
@@ -779,17 +783,13 @@ def import_sheet(name):
     if not char_row:
         abort(404)
 
-    # Block if an approved draft already exists
     existing = CharacterDraft.query.filter_by(
         roster_character_id=char_row.id,
         status='approved',
     ).first()
-    if existing:
-        flash('This character already has a linked living sheet.', 'warning')
-        return redirect(url_for('player.character', name=name))
 
     if request.method == 'GET':
-        return render_template('player/import_sheet.html', char=char)
+        return render_template('player/import_sheet.html', char=char, has_sheet=existing is not None)
 
     json_text = request.form.get('sheet_json', '').strip()
     if not json_text:
@@ -817,29 +817,38 @@ def import_sheet(name):
     discord_name = session.get('discord_name', 'unknown')
     now = datetime.now(timezone.utc)
 
-    draft = CharacterDraft(
-        player_discord_id=discord_id,
-        character_name=char_row.character_name,
-        status='approved',
-        roster_character_id=char_row.id,
-        character_data=json.dumps(cc_data),
-        approved_at=now,
-        approved_by=f'player:{discord_name} (RoD import)',
-    )
-    db.session.add(draft)
+    if existing:
+        existing.character_data = json.dumps(cc_data)
+        existing.updated_at = now
+        existing.approved_by = f'player:{discord_name} (RoD re-import)'
+        action_details = 'Re-imported character sheet from Realm of Darkness export'
+        flash_msg = 'Character sheet updated from your new RoD export.'
+    else:
+        draft = CharacterDraft(
+            player_discord_id=discord_id,
+            character_name=char_row.character_name,
+            status='approved',
+            roster_character_id=char_row.id,
+            character_data=json.dumps(cc_data),
+            approved_at=now,
+            approved_by=f'player:{discord_name} (RoD import)',
+        )
+        db.session.add(draft)
+        action_details = 'Imported character sheet from Realm of Darkness export'
+        flash_msg = (
+            'Character sheet imported! Your living sheet is now active — '
+            'approved spends will update it automatically.'
+        )
+
     db_service.log_action(
         staff_user=f'player:{discord_name}',
         action_type='player_sheet_import',
         target=name,
-        details='Imported character sheet from Realm of Darkness export',
+        details=action_details,
     )
     db.session.commit()
 
-    flash(
-        'Character sheet imported! Your living sheet is now active — '
-        'approved spends will update it automatically.',
-        'success',
-    )
+    flash(flash_msg, 'success')
     return redirect(url_for('player.character', name=name))
 
 

--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -2,6 +2,9 @@
 
 import csv
 import io
+import json
+import logging
+from datetime import datetime, timezone
 from flask import (
     Blueprint, render_template, request, redirect, url_for, flash, abort,
     Response,
@@ -9,6 +12,9 @@ from flask import (
 from app import db_service, sheets_sync
 from app.auth import require_staff, get_staff_user
 from app.models import Character, CLANS, AGE_CATEGORIES, SECTS
+from app.db import CharacterDraft, DbCharacter, db
+
+logger = logging.getLogger(__name__)
 
 bp = Blueprint('roster', __name__)
 
@@ -873,3 +879,88 @@ def export_xp_csv(name):
         mimetype='text/csv',
         headers={'Content-Disposition': f'attachment; filename="{safe_name}_xp_history.csv"'},
     )
+
+
+@bp.route('/<name>/edit-sheet', methods=['GET', 'POST'])
+@require_staff
+def edit_sheet(name):
+    """Staff: view and edit a character's living sheet JSON."""
+    char = db_service.get_character(name)
+    if not char:
+        abort(404)
+
+    char_row = DbCharacter.query.filter(DbCharacter.character_name.ilike(name)).first()
+    if not char_row:
+        abort(404)
+
+    draft = CharacterDraft.query.filter_by(
+        roster_character_id=char_row.id,
+        status='approved',
+    ).first()
+
+    if request.method == 'GET':
+        sheet_json = json.dumps(json.loads(draft.character_data), indent=2) if draft else ''
+        return render_template(
+            'roster/edit_sheet.html',
+            char=char,
+            draft=draft,
+            sheet_json=sheet_json,
+        )
+
+    action = request.form.get('action', 'save')
+
+    if action == 'delete':
+        if draft:
+            db.session.delete(draft)
+            staff = get_staff_user()
+            db_service.log_action(
+                staff_user=staff,
+                action_type='staff_sheet_delete',
+                target=name,
+                details='Staff deleted living character sheet',
+            )
+            db.session.commit()
+            flash('Living sheet deleted. The player can re-import a new one.', 'success')
+        return redirect(url_for('roster.detail', name=name))
+
+    json_text = request.form.get('sheet_json', '').strip()
+    if not json_text:
+        flash('Sheet JSON cannot be empty.', 'danger')
+        return render_template('roster/edit_sheet.html', char=char, draft=draft, sheet_json='')
+
+    try:
+        new_data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        flash(f'Invalid JSON: {exc}', 'danger')
+        return render_template('roster/edit_sheet.html', char=char, draft=draft, sheet_json=json_text)
+
+    staff = get_staff_user()
+    now = datetime.now(timezone.utc)
+
+    if draft:
+        draft.character_data = json.dumps(new_data)
+        draft.updated_at = now
+        draft.approved_by = f'staff:{staff} (manual edit)'
+        action_details = 'Staff manually edited living character sheet'
+    else:
+        draft = CharacterDraft(
+            player_discord_id=None,
+            character_name=char_row.character_name,
+            status='approved',
+            roster_character_id=char_row.id,
+            character_data=json.dumps(new_data),
+            approved_at=now,
+            approved_by=f'staff:{staff} (manual create)',
+        )
+        db.session.add(draft)
+        action_details = 'Staff manually created living character sheet'
+
+    db_service.log_action(
+        staff_user=staff,
+        action_type='staff_sheet_edit',
+        target=name,
+        details=action_details,
+    )
+    db.session.commit()
+    flash('Character sheet saved.', 'success')
+    return redirect(url_for('roster.detail', name=name))

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1883,3 +1883,53 @@ a.wiki-featured-card h4 {
     margin-top: 0.3rem;
     line-height: 1.5;
 }
+
+/* ── Character sheet layout (inline + full sheet view) ────────────────────── */
+.sheet-section-label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--vtm-gold);
+    border-bottom: 1px solid rgba(197, 165, 90, 0.25);
+    padding-bottom: 0.3rem;
+    margin-bottom: 0.6rem;
+}
+
+.sheet-group-label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #8888a8;
+    margin-bottom: 0.35rem;
+}
+
+.sheet-trait-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.1rem 0.5rem 0.1rem 0;
+    min-height: 1.5rem;
+}
+
+.sheet-trait-name {
+    font-size: 0.82rem;
+    color: #ccc;
+}
+
+.sheet-disc-name {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #aaa;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.2rem;
+}
+
+.dot-pip.square {
+    border-radius: 2px;
+}
+
+.dot-pips-lg .dot-pip {
+    width: 13px;
+    height: 13px;
+}

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -88,17 +88,7 @@
 {% endfor %}
 {% endif %}
 
-<!-- Living sheet banner -->
-{% if has_approved_draft %}
-<div class="alert alert-dark d-flex align-items-center gap-3 mb-3 border">
-    <i class="bi bi-file-earmark-person fs-4 text-muted"></i>
-    <div class="flex-grow-1 text-muted small">Living sheet active — approved spends update your sheet automatically.</div>
-    <a href="{{ url_for('player.view_sheet', name=char.character_name) }}"
-       class="btn btn-sm btn-outline-secondary text-nowrap">
-        <i class="bi bi-person-lines-fill"></i> View Sheet
-    </a>
-</div>
-{% else %}
+{% if not has_approved_draft %}
 <div class="alert alert-secondary d-flex align-items-center gap-3 mb-3">
     <i class="bi bi-file-earmark-person fs-4 text-muted"></i>
     <div class="flex-grow-1">
@@ -114,73 +104,169 @@
 
 <!-- Collapsible character sheet (shown only when sheet exists) -->
 {% if has_approved_draft and sheet_data %}
-{% set _attrs = sheet_data.get('attributes', {}) %}
-{% set _skills = sheet_data.get('skills', {}) %}
-{% set _discs = sheet_data.get('disciplines', []) %}
-{% set _merits = sheet_data.get('merits', []) %}
-{% set _flaws = sheet_data.get('flaws', []) %}
+{% set _a = sheet_data.get('attributes', {}) %}
+{% set _s = sheet_data.get('skills', {}) %}
+{% set _d = sheet_data.get('disciplines', []) %}
+{% set _m = sheet_data.get('merits', []) %}
+{% set _f = sheet_data.get('flaws', []) %}
+{% set _r = sheet_data.get('rituals', []) %}
+{% set _bp = sheet_data.get('bloodPotency', 0) %}
+{% set _hum = sheet_data.get('humanity', 0) %}
+{% set _wil = sheet_data.get('willpower', 0) %}
+{% set _hp = sheet_data.get('maxHealth', 0) %}
 <div class="card mb-4">
     <div class="card-header" data-bs-toggle="collapse" data-bs-target="#inline-sheet" role="button" style="cursor:pointer;">
         <div class="d-flex justify-content-between align-items-center">
             <h5 class="mb-0"><i class="bi bi-person-lines-fill"></i> Character Sheet <i class="bi bi-chevron-down float-end small"></i></h5>
             <div class="d-flex gap-2 align-items-center">
-                {% if sheet_data.get('bloodPotency') %}<span class="badge bg-dark border text-muted">BP {{ sheet_data.bloodPotency }}</span>{% endif %}
-                {% if sheet_data.get('humanity') %}<span class="badge bg-dark border text-muted">Humanity {{ sheet_data.humanity }}</span>{% endif %}
+                {% if _bp %}<span class="badge bg-dark border text-muted">BP {{ _bp }}</span>{% endif %}
+                {% if _hum %}<span class="badge bg-dark border text-muted">Humanity {{ _hum }}</span>{% endif %}
                 <a href="{{ url_for('player.view_sheet', name=char.character_name) }}" class="btn btn-sm btn-outline-secondary" onclick="event.stopPropagation()">Full Sheet</a>
             </div>
         </div>
     </div>
     <div class="collapse" id="inline-sheet">
-    <div class="card-body">
-        <div class="row g-3">
-            {% if _attrs %}
-            <div class="col-lg-4">
-                <div class="text-muted small mb-2" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Attributes</div>
-                {% for k in ['strength','dexterity','stamina','charisma','manipulation','composure','intelligence','wits','resolve'] %}
-                {% set v = _attrs.get(k, 0) %}
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span style="font-size:0.85rem;">{{ k | title }}</span>
-                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}</span>
+    <div class="card-body pb-2">
+
+        {# ── Attributes ── #}
+        <div class="sheet-section-label">Attributes</div>
+        <div class="row g-0 mb-3">
+            {% for group, keys in [('Physical',['strength','dexterity','stamina']),('Social',['charisma','manipulation','composure']),('Mental',['intelligence','wits','resolve'])] %}
+            <div class="col-4">
+                <div class="sheet-group-label">{{ group }}</div>
+                {% for k in keys %}{% set v = _a.get(k,0) %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ k|title }}</span>
+                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i<=v %}filled{% endif %}"></span>{% endfor %}</span>
                 </div>
                 {% endfor %}
             </div>
-            {% endif %}
-            {% if _skills %}
-            <div class="col-lg-4">
-                <div class="text-muted small mb-2" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Skills (rated)</div>
-                {% for k, v in _skills | dictsort %}
-                {% if v > 0 %}
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span style="font-size:0.85rem;">{{ k | replace('_',' ') | title }}</span>
-                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}</span>
+            {% endfor %}
+        </div>
+
+        {# ── Skills ── #}
+        <div class="sheet-section-label">Skills</div>
+        <div class="row g-0 mb-3">
+            {% set phys_skills = ['athletics','brawl','craft','drive','firearms','larceny','melee','stealth','survival'] %}
+            {% set soc_skills  = ['animal_ken','etiquette','insight','intimidation','leadership','performance','persuasion','streetwise','subterfuge'] %}
+            {% set ment_skills = ['academics','awareness','finance','investigation','medicine','occult','politics','science','technology'] %}
+            {% for group, keys in [('Physical',phys_skills),('Social',soc_skills),('Mental',ment_skills)] %}
+            <div class="col-4">
+                <div class="sheet-group-label">{{ group }}</div>
+                {% for k in keys %}{% set v = _s.get(k,0) %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ k|replace('_',' ')|title }}</span>
+                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i<=v %}filled{% endif %}"></span>{% endfor %}</span>
                 </div>
-                {% endif %}
                 {% endfor %}
             </div>
-            {% endif %}
-            {% if _discs or _merits or _flaws %}
-            <div class="col-lg-4">
-                {% if _discs %}
-                <div class="text-muted small mb-2" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Disciplines</div>
+            {% endfor %}
+        </div>
+
+        {# ── Advantages / Disciplines / Rituals ── #}
+        <div class="sheet-section-label">Advantages &amp; Disciplines</div>
+        <div class="row g-3 mb-3">
+            {# Disciplines #}
+            {% if _d %}
+            <div class="col-md-4">
+                <div class="sheet-group-label">Disciplines</div>
                 {% set disc_groups = {} %}
-                {% for p in _discs %}{% set d = p.get('discipline','Unknown')|title %}{% if d not in disc_groups %}{% set _ = disc_groups.update({d:[]}) %}{% endif %}{% set _ = disc_groups[d].append(p) %}{% endfor %}
-                {% for disc_name, powers in disc_groups | dictsort %}
-                <div class="mb-1"><span class="text-muted small">{{ disc_name }}:</span>
-                {% for p in powers | sort(attribute='level') %}<span class="badge bg-dark border text-muted ms-1">{{ p.get('name','?') }} L{{ p.get('level','?') }}</span>{% endfor %}
+                {% for p in _d %}{% set dn = p.get('discipline','?')|title %}{% if dn not in disc_groups %}{% set _ = disc_groups.update({dn:[]}) %}{% endif %}{% set _ = disc_groups[dn].append(p) %}{% endfor %}
+                {% for dn, powers in disc_groups|dictsort %}
+                <div class="mb-2">
+                    <div class="sheet-disc-name">{{ dn }}</div>
+                    {% for p in powers|sort(attribute='level') %}
+                    <div class="sheet-trait-row">
+                        <span class="sheet-trait-name">{{ p.get('name','?') }}</span>
+                        <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ p.get('level','?') }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {# Merits & Flaws #}
+            {% if _m or _f %}
+            <div class="col-md-4">
+                {% if _m %}
+                <div class="sheet-group-label">Merits &amp; Backgrounds</div>
+                {% for m in _m %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ m.get('name','?') }}</span>
+                    <span class="dot-pips">{% set lv=m.get('level',0) %}{% for i in range(1,6) %}<span class="dot-pip {% if i<=lv %}filled{% endif %}"></span>{% endfor %}</span>
                 </div>
                 {% endfor %}
                 {% endif %}
-                {% if _merits %}
-                <div class="text-muted small mt-2 mb-1" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Merits &amp; Backgrounds</div>
-                {% for m in _merits %}<span class="badge bg-dark border text-muted me-1 mb-1">{{ m.get('name','?') }} {{ m.get('level',0) }}</span>{% endfor %}
+                {% if _f %}
+                <div class="sheet-group-label mt-2">Flaws</div>
+                {% for f in _f %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ f.get('name','?') }}</span>
+                    <span class="dot-pips">{% set lv=f.get('level',0) %}{% for i in range(1,6) %}<span class="dot-pip {% if i<=lv %}filled{% endif %}"></span>{% endfor %}</span>
+                </div>
+                {% endfor %}
                 {% endif %}
-                {% if _flaws %}
-                <div class="text-muted small mt-2 mb-1" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Flaws</div>
-                {% for f in _flaws %}<span class="badge bg-dark border text-muted me-1 mb-1">{{ f.get('name','?') }} {{ f.get('level',0) }}</span>{% endfor %}
+            </div>
+            {% endif %}
+            {# Rituals #}
+            {% if _r %}
+            <div class="col-md-4">
+                {% set bs_r = _r|selectattr('discipline','equalto','blood sorcery')|list %}
+                {% set tb_r = _r|selectattr('discipline','equalto','thin-blood alchemy')|list %}
+                {% if bs_r %}
+                <div class="sheet-group-label">Blood Sorcery Rituals</div>
+                {% for r in bs_r|sort(attribute='level') %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ r.get('name','?') }}</span>
+                    <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ r.get('level','?') }}</span>
+                </div>
+                {% endfor %}
+                {% endif %}
+                {% if tb_r %}
+                <div class="sheet-group-label mt-2">Thin-Blood Alchemy</div>
+                {% for r in tb_r|sort(attribute='level') %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ r.get('name','?') }}</span>
+                    <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ r.get('level','?') }}</span>
+                </div>
+                {% endfor %}
                 {% endif %}
             </div>
             {% endif %}
         </div>
+
+        {# ── Vitals ── #}
+        <div class="sheet-section-label">Vitals</div>
+        <div class="row g-3 pb-1">
+            <div class="col-auto">
+                <div class="sheet-group-label">Humanity</div>
+                <div class="dot-pips">{% for i in range(1,11) %}<span class="dot-pip {% if i<=_hum %}filled{% endif %}"></span>{% endfor %}</div>
+            </div>
+            <div class="col-auto">
+                <div class="sheet-group-label">Blood Potency</div>
+                <div class="dot-pips">{% for i in range(1,11) %}<span class="dot-pip {% if i<=_bp %}filled{% endif %}"></span>{% endfor %}</div>
+            </div>
+            {% if _hp %}
+            <div class="col-auto">
+                <div class="sheet-group-label">Health</div>
+                <div class="dot-pips">{% for i in range(1,_hp+1) %}<span class="dot-pip square"></span>{% endfor %}</div>
+            </div>
+            {% endif %}
+            {% if _wil %}
+            <div class="col-auto">
+                <div class="sheet-group-label">Willpower</div>
+                <div class="dot-pips">{% for i in range(1,_wil+1) %}<span class="dot-pip square"></span>{% endfor %}</div>
+            </div>
+            {% endif %}
+            {% set _touch = sheet_data.get('touchstones', []) %}
+            {% if _touch %}
+            <div class="col-12 col-md">
+                <div class="sheet-group-label">Touchstones &amp; Convictions</div>
+                {% for t in _touch %}<div class="sheet-trait-name">{{ t if t is string else t.get('description', t.get('name','')) }}</div>{% endfor %}
+            </div>
+            {% endif %}
+        </div>
+
     </div>
     </div><!-- /#inline-sheet -->
 </div>

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -88,8 +88,17 @@
 {% endfor %}
 {% endif %}
 
-<!-- Living sheet import prompt -->
-{% if not has_approved_draft %}
+<!-- Living sheet banner -->
+{% if has_approved_draft %}
+<div class="alert alert-dark d-flex align-items-center gap-3 mb-3 border">
+    <i class="bi bi-file-earmark-person fs-4 text-muted"></i>
+    <div class="flex-grow-1 text-muted small">Living sheet active — approved spends update your sheet automatically.</div>
+    <a href="{{ url_for('player.view_sheet', name=char.character_name) }}"
+       class="btn btn-sm btn-outline-secondary text-nowrap">
+        <i class="bi bi-person-lines-fill"></i> View Sheet
+    </a>
+</div>
+{% else %}
 <div class="alert alert-secondary d-flex align-items-center gap-3 mb-3">
     <i class="bi bi-file-earmark-person fs-4 text-muted"></i>
     <div class="flex-grow-1">
@@ -950,8 +959,53 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // ═══ Living Sheet — pre-fill current dots from imported sheet data ═══
+    const SHEET_DATA = {{ sheet_data | tojson if sheet_data else 'null' }};
+
+    function lookupCurrentDots(cat, traitName) {
+        if (!SHEET_DATA || !traitName) return null;
+        const key = traitName.trim().toLowerCase().replace(/\s+/g, '_');
+        if (cat === 'Attribute') {
+            const v = SHEET_DATA.attributes && SHEET_DATA.attributes[key];
+            return (v != null) ? v : null;
+        }
+        if (cat === 'Skill' || cat === 'New Skill') {
+            const v = SHEET_DATA.skills && SHEET_DATA.skills[key];
+            return (v != null) ? v : null;
+        }
+        if (cat === 'Discipline (In-Clan)' || cat === 'Discipline (Out-of-Clan)' || cat === 'Caitiff Discipline' || cat === 'Ghoul Discipline') {
+            // Look for the highest level power in this discipline
+            const discs = SHEET_DATA.disciplines || [];
+            const disc = discs.filter(p => (p.discipline || '').toLowerCase() === key);
+            if (disc.length) return Math.max(...disc.map(p => p.level || 0));
+            return null;
+        }
+        if (cat === 'Advantage (Merit/Background)') {
+            const merits = SHEET_DATA.merits || [];
+            const m = merits.find(m => m.name && m.name.toLowerCase() === traitName.trim().toLowerCase());
+            return m ? (m.level || 0) : null;
+        }
+        return null;
+    }
+
+    const traitNameInput = document.getElementById('trait_name');
+    function autofillCurrentDots() {
+        const cat = spendCategory.value;
+        const trait = traitNameInput ? traitNameInput.value : '';
+        const dots = lookupCurrentDots(cat, trait);
+        if (dots != null) {
+            currentDots.value = dots;
+            calcCost();
+        }
+    }
+    if (traitNameInput) {
+        traitNameInput.addEventListener('change', autofillCurrentDots);
+        traitNameInput.addEventListener('blur', autofillCurrentDots);
+    }
+
     spendCategory.addEventListener('change', function() {
         updateDotConstraints();
+        autofillCurrentDots();
         calcCost();
     });
     currentDots.addEventListener('input', calcCost);

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -237,35 +237,37 @@
 
         {# ── Vitals ── #}
         <div class="sheet-section-label">Vitals</div>
-        <div class="row g-3 pb-1">
-            <div class="col-auto">
+        <div class="d-flex flex-wrap gap-4 mb-3">
+            <div>
                 <div class="sheet-group-label">Humanity</div>
                 <div class="dot-pips">{% for i in range(1,11) %}<span class="dot-pip {% if i<=_hum %}filled{% endif %}"></span>{% endfor %}</div>
             </div>
-            <div class="col-auto">
+            <div>
                 <div class="sheet-group-label">Blood Potency</div>
                 <div class="dot-pips">{% for i in range(1,11) %}<span class="dot-pip {% if i<=_bp %}filled{% endif %}"></span>{% endfor %}</div>
             </div>
             {% if _hp %}
-            <div class="col-auto">
+            <div>
                 <div class="sheet-group-label">Health</div>
                 <div class="dot-pips">{% for i in range(1,_hp+1) %}<span class="dot-pip square"></span>{% endfor %}</div>
             </div>
             {% endif %}
             {% if _wil %}
-            <div class="col-auto">
+            <div>
                 <div class="sheet-group-label">Willpower</div>
                 <div class="dot-pips">{% for i in range(1,_wil+1) %}<span class="dot-pip square"></span>{% endfor %}</div>
             </div>
             {% endif %}
-            {% set _touch = sheet_data.get('touchstones', []) %}
-            {% if _touch %}
-            <div class="col-12 col-md">
-                <div class="sheet-group-label">Touchstones &amp; Convictions</div>
-                {% for t in _touch %}<div class="sheet-trait-name">{{ t if t is string else t.get('description', t.get('name','')) }}</div>{% endfor %}
-            </div>
-            {% endif %}
         </div>
+        {% set _touch = sheet_data.get('touchstones', []) %}
+        {% if _touch %}
+        <div>
+            <div class="sheet-group-label">Touchstones &amp; Convictions</div>
+            {% for t in _touch %}
+            <div class="sheet-trait-name">{{ t if t is string else t.get('description', t.get('name','')) }}</div>
+            {% endfor %}
+        </div>
+        {% endif %}
 
     </div>
     </div><!-- /#inline-sheet -->

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -109,6 +109,7 @@
 {% set _d = sheet_data.get('disciplines', []) %}
 {% set _m = sheet_data.get('merits', []) %}
 {% set _f = sheet_data.get('flaws', []) %}
+{% set _ls = sheet_data.get('loresheet_purchases', []) %}
 {% set _r = sheet_data.get('rituals', []) %}
 {% set _bp = sheet_data.get('bloodPotency', 0) %}
 {% set _hum = sheet_data.get('humanity', 0) %}
@@ -186,8 +187,8 @@
                 {% endfor %}
             </div>
             {% endif %}
-            {# Merits & Flaws #}
-            {% if _m or _f %}
+            {# Merits, Loresheets & Flaws #}
+            {% if _m or _f or _ls %}
             <div class="col-md-4">
                 {% if _m %}
                 <div class="sheet-group-label">Merits &amp; Backgrounds</div>
@@ -195,6 +196,15 @@
                 <div class="sheet-trait-row">
                     <span class="sheet-trait-name">{{ m.get('name','?') }}</span>
                     <span class="dot-pips">{% set lv=m.get('level',0) %}{% for i in range(1,6) %}<span class="dot-pip {% if i<=lv %}filled{% endif %}"></span>{% endfor %}</span>
+                </div>
+                {% endfor %}
+                {% endif %}
+                {% if _ls %}
+                <div class="sheet-group-label {% if _m %}mt-2{% endif %}">Loresheets</div>
+                {% for ls in _ls %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ ls.get('name','?') }}</span>
+                    <span class="dot-pips">{% set lv=ls.get('dot',0) %}{% for i in range(1,6) %}<span class="dot-pip {% if i<=lv %}filled{% endif %}"></span>{% endfor %}</span>
                 </div>
                 {% endfor %}
                 {% endif %}

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -112,6 +112,80 @@
 </div>
 {% endif %}
 
+<!-- Collapsible character sheet (shown only when sheet exists) -->
+{% if has_approved_draft and sheet_data %}
+{% set _attrs = sheet_data.get('attributes', {}) %}
+{% set _skills = sheet_data.get('skills', {}) %}
+{% set _discs = sheet_data.get('disciplines', []) %}
+{% set _merits = sheet_data.get('merits', []) %}
+{% set _flaws = sheet_data.get('flaws', []) %}
+<div class="card mb-4">
+    <div class="card-header" data-bs-toggle="collapse" data-bs-target="#inline-sheet" role="button" style="cursor:pointer;">
+        <div class="d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="bi bi-person-lines-fill"></i> Character Sheet <i class="bi bi-chevron-down float-end small"></i></h5>
+            <div class="d-flex gap-2 align-items-center">
+                {% if sheet_data.get('bloodPotency') %}<span class="badge bg-dark border text-muted">BP {{ sheet_data.bloodPotency }}</span>{% endif %}
+                {% if sheet_data.get('humanity') %}<span class="badge bg-dark border text-muted">Humanity {{ sheet_data.humanity }}</span>{% endif %}
+                <a href="{{ url_for('player.view_sheet', name=char.character_name) }}" class="btn btn-sm btn-outline-secondary" onclick="event.stopPropagation()">Full Sheet</a>
+            </div>
+        </div>
+    </div>
+    <div class="collapse" id="inline-sheet">
+    <div class="card-body">
+        <div class="row g-3">
+            {% if _attrs %}
+            <div class="col-lg-4">
+                <div class="text-muted small mb-2" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Attributes</div>
+                {% for k in ['strength','dexterity','stamina','charisma','manipulation','composure','intelligence','wits','resolve'] %}
+                {% set v = _attrs.get(k, 0) %}
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span style="font-size:0.85rem;">{{ k | title }}</span>
+                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}</span>
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% if _skills %}
+            <div class="col-lg-4">
+                <div class="text-muted small mb-2" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Skills (rated)</div>
+                {% for k, v in _skills | dictsort %}
+                {% if v > 0 %}
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span style="font-size:0.85rem;">{{ k | replace('_',' ') | title }}</span>
+                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}</span>
+                </div>
+                {% endif %}
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% if _discs or _merits or _flaws %}
+            <div class="col-lg-4">
+                {% if _discs %}
+                <div class="text-muted small mb-2" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Disciplines</div>
+                {% set disc_groups = {} %}
+                {% for p in _discs %}{% set d = p.get('discipline','Unknown')|title %}{% if d not in disc_groups %}{% set _ = disc_groups.update({d:[]}) %}{% endif %}{% set _ = disc_groups[d].append(p) %}{% endfor %}
+                {% for disc_name, powers in disc_groups | dictsort %}
+                <div class="mb-1"><span class="text-muted small">{{ disc_name }}:</span>
+                {% for p in powers | sort(attribute='level') %}<span class="badge bg-dark border text-muted ms-1">{{ p.get('name','?') }} L{{ p.get('level','?') }}</span>{% endfor %}
+                </div>
+                {% endfor %}
+                {% endif %}
+                {% if _merits %}
+                <div class="text-muted small mt-2 mb-1" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Merits &amp; Backgrounds</div>
+                {% for m in _merits %}<span class="badge bg-dark border text-muted me-1 mb-1">{{ m.get('name','?') }} {{ m.get('level',0) }}</span>{% endfor %}
+                {% endif %}
+                {% if _flaws %}
+                <div class="text-muted small mt-2 mb-1" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Flaws</div>
+                {% for f in _flaws %}<span class="badge bg-dark border text-muted me-1 mb-1">{{ f.get('name','?') }} {{ f.get('level',0) }}</span>{% endfor %}
+                {% endif %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    </div><!-- /#inline-sheet -->
+</div>
+{% endif %}
+
 <!-- Pending notifications -->
 {% if pending_claims_count > 0 or pending_spends_count > 0 %}
 <div class="alert alert-info">
@@ -127,12 +201,13 @@
 
 <!-- Backgrounds -->
 <div class="card mb-4">
-    <div class="card-header d-flex justify-content-between align-items-center">
-        <h5 class="mb-0"><i class="bi bi-check2-square"></i> Background Blanking</h5>
+    <div class="card-header d-flex justify-content-between align-items-center" data-bs-toggle="collapse" data-bs-target="#background-blanking" role="button" style="cursor:pointer;">
+        <h5 class="mb-0"><i class="bi bi-check2-square"></i> Background Blanking <i class="bi bi-chevron-down float-end ms-2 small"></i></h5>
         {% if current_night %}
         <span class="badge bg-secondary">Current: {{ current_night.period_label }}</span>
         {% endif %}
     </div>
+    <div class="collapse show" id="background-blanking">
     <div class="card-body">
         {% if backgrounds %}
         <div class="table-responsive mb-3">
@@ -206,6 +281,7 @@
             </div>
         </form>
     </div>
+    </div><!-- /#background-blanking -->
 </div>
 
 <!-- ═══ Submission Forms ═══ -->
@@ -449,9 +525,10 @@
 
 <!-- Approved Claims History -->
 <div class="card mb-4" id="xp-claims-history">
-    <div class="card-header">
-        <h5 class="mb-0"><i class="bi bi-journal-check"></i> XP Claims History</h5>
+    <div class="card-header" data-bs-toggle="collapse" data-bs-target="#claims-history-body" role="button" style="cursor:pointer;">
+        <h5 class="mb-0"><i class="bi bi-journal-check"></i> XP Claims History <i class="bi bi-chevron-down float-end small"></i></h5>
     </div>
+    <div class="collapse" id="claims-history-body">
     <div class="card-body">
         {% if approved_claims or ledger %}
         <div class="table-responsive">
@@ -501,10 +578,11 @@
         <p class="text-muted mb-0">No approved XP claims yet.</p>
         {% endif %}
     </div>
+    </div><!-- /#claims-history-body -->
 </div>
 
-<!-- Pending / Denied Spends -->
-{% if pending_spends_list or denied_spends %}
+<!-- Pending Spends -->
+{% if pending_spends_list %}
 <div class="card mb-4">
     <div class="card-header" data-bs-toggle="collapse" data-bs-target="#spends-in-progress" role="button" style="cursor:pointer;">
         <div class="d-flex justify-content-between align-items-center">
@@ -512,14 +590,7 @@
                 <i class="bi bi-hourglass-split"></i> Spend Requests In Progress
                 <i class="bi bi-chevron-down float-end"></i>
             </h5>
-            <div class="d-flex gap-2">
-                {% if pending_spends_list %}
-                <span class="badge bg-warning text-dark">{{ pending_spends_list|length }} pending</span>
-                {% endif %}
-                {% if denied_spends %}
-                <span class="badge bg-danger">{{ denied_spends|length }} denied</span>
-                {% endif %}
-            </div>
+            <span class="badge bg-warning text-dark">{{ pending_spends_list|length }} pending</span>
         </div>
     </div>
     <div class="collapse show" id="spends-in-progress">
@@ -532,7 +603,6 @@
                             <th class="d-none d-sm-table-cell">Category</th>
                             <th>Dots</th>
                             <th>XP</th>
-                            <th>Status</th>
                             <th class="d-none d-sm-table-cell">Notes</th>
                         </tr>
                     </thead>
@@ -543,18 +613,7 @@
                             <td class="d-none d-sm-table-cell"><small class="text-muted">{{ s.spend_category }}</small></td>
                             <td><span class="text-muted">{{ s.current_dots }}→{{ s.new_dots }}</span></td>
                             <td><span class="badge bg-secondary">{{ s.xp_cost }} XP</span></td>
-                            <td><span class="badge bg-warning text-dark">Pending</span></td>
                             <td class="d-none d-sm-table-cell"></td>
-                        </tr>
-                        {% endfor %}
-                        {% for s in denied_spends %}
-                        <tr>
-                            <td>{{ s.trait_name }}</td>
-                            <td class="d-none d-sm-table-cell"><small class="text-muted">{{ s.spend_category }}</small></td>
-                            <td><span class="text-muted">{{ s.current_dots }}→{{ s.new_dots }}</span></td>
-                            <td><span class="badge bg-secondary">{{ s.xp_cost }} XP</span></td>
-                            <td><span class="badge bg-danger">Denied</span></td>
-                            <td class="d-none d-sm-table-cell"><small class="text-muted">{{ s.st_notes or '' }}</small></td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -565,11 +624,12 @@
 </div>
 {% endif %}
 
-<!-- Approved Spends History — Character Sheet View -->
+<!-- Approved Spends History -->
 <div class="card mb-4">
-    <div class="card-header d-flex justify-content-between align-items-center">
-        <h5 class="mb-0"><i class="bi bi-cart-check"></i> Approved Spends</h5>
+    <div class="card-header" data-bs-toggle="collapse" data-bs-target="#approved-spends-body" role="button" style="cursor:pointer;">
+        <h5 class="mb-0"><i class="bi bi-cart-check"></i> Approved Spends <i class="bi bi-chevron-down float-end small"></i></h5>
     </div>
+    <div class="collapse" id="approved-spends-body">
     <div class="card-body">
         {% if approved_spends %}
         {% for category, spends in approved_spends | groupby('spend_category') %}
@@ -593,6 +653,7 @@
         <p class="text-muted mb-0">No approved spends yet.</p>
         {% endif %}
     </div>
+    </div><!-- /#approved-spends-body -->
 </div>
 
 <!-- Wish List -->

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -122,6 +122,7 @@
                 {% if _bp %}<span class="badge bg-dark border text-muted">BP {{ _bp }}</span>{% endif %}
                 {% if _hum %}<span class="badge bg-dark border text-muted">Humanity {{ _hum }}</span>{% endif %}
                 <a href="{{ url_for('player.view_sheet', name=char.character_name) }}" class="btn btn-sm btn-outline-secondary" onclick="event.stopPropagation()">Full Sheet</a>
+                <a href="{{ url_for('player.import_sheet', name=char.character_name) }}" class="btn btn-sm btn-outline-secondary" onclick="event.stopPropagation()" title="Re-import from Realm of Darkness"><i class="bi bi-arrow-clockwise"></i></a>
             </div>
         </div>
     </div>

--- a/apps/web/app/templates/player/import_sheet.html
+++ b/apps/web/app/templates/player/import_sheet.html
@@ -51,10 +51,10 @@
             </div>
             <div class="card-body">
                 <ol class="mb-3 ps-3" style="font-size:0.9rem;">
-                    <li class="mb-2">In Discord, use <code>/sheet</code> to pull up your character on the Realm of Darkness bot.</li>
-                    <li class="mb-2">Click the <strong>Export JSON</strong> button (download icon, bottom of the sheet).</li>
-                    <li class="mb-2">Copy the full JSON text that appears.</li>
-                    <li>Paste it in the box to the left and click <strong>Import Sheet</strong>.</li>
+                    <li class="mb-2">Go to <a href="https://realmofdarkness.app" target="_blank" rel="noopener noreferrer">realmofdarkness.app</a> and open your character sheet. <em>You must have created your character on the website — not just in Discord — for this to work.</em></li>
+                    <li class="mb-2">On your sheet, click the <strong>purple down-arrow button</strong>. It says <strong>Export JSON</strong> when you hover over it.</li>
+                    <li class="mb-2">Copy the full contents of the file that downloads.</li>
+                    <li>Paste it into the box on the left and click <strong>Import Sheet</strong>.</li>
                 </ol>
                 <p class="text-muted small mb-0">
                     Your attributes, skills, disciplines, merits, and flaws will be imported.

--- a/apps/web/app/templates/player/import_sheet.html
+++ b/apps/web/app/templates/player/import_sheet.html
@@ -67,8 +67,12 @@
             <div class="card-body py-2 px-3">
                 <p class="small mb-0 text-warning-emphasis">
                     <i class="bi bi-exclamation-triangle"></i>
-                    <strong>One-time import.</strong> Once imported, your sheet is locked and updated only through approved XP spends.
-                    If your RoD sheet has errors, contact staff to fix them.
+                    {% if has_sheet %}
+                    <strong>Re-import will overwrite your current sheet.</strong> Once active, your sheet is updated through approved XP spends.
+                    {% else %}
+                    <strong>After import, your sheet is updated only through approved XP spends.</strong>
+                    {% endif %}
+                    If you have trouble, contact staff.
                 </p>
             </div>
         </div>

--- a/apps/web/app/templates/player/my_characters.html
+++ b/apps/web/app/templates/player/my_characters.html
@@ -58,9 +58,9 @@
         <h6 class="text-muted mb-2">Your Characters</h6>
         <div class="list-group mb-4">
             {% for char in my_characters %}
-            <a href="{{ url_for('player.character', name=char.character_name) }}"
-               class="list-group-item list-group-item-action d-flex justify-content-between align-items-center has-clan-color clan-{{ char.clan | lower | replace(' ', '-') }}">
-                <div class="d-flex align-items-center gap-2">
+            <div class="list-group-item d-flex justify-content-between align-items-center has-clan-color clan-{{ char.clan | lower | replace(' ', '-') }}">
+                <a href="{{ url_for('player.character', name=char.character_name) }}"
+                   class="d-flex align-items-center gap-2 flex-grow-1 text-decoration-none">
                     {% if char.clan %}
                     <img src="{{ url_for('static', filename='images/symbols/' + char.clan | lower | replace(' ', '-') + '.png') }}"
                          class="char-list-clan-symbol" aria-hidden="true"
@@ -72,9 +72,18 @@
                         <span class="clan-badge clan-{{ char.clan | lower | replace(' ', '-') }} ms-2">{{ char.clan }}</span>
                         {% endif %}
                     </div>
+                </a>
+                <div class="d-flex align-items-center gap-2 ms-2">
+                    {% if char.character_name in chars_with_sheet %}
+                    <a href="{{ url_for('player.view_sheet', name=char.character_name) }}"
+                       class="btn btn-sm btn-outline-secondary" title="View character sheet">
+                        <i class="bi bi-person-lines-fill"></i>
+                    </a>
+                    {% endif %}
+                    <a href="{{ url_for('player.character', name=char.character_name) }}"
+                       class="text-muted"><i class="bi bi-chevron-right"></i></a>
                 </div>
-                <i class="bi bi-chevron-right text-muted"></i>
-            </a>
+            </div>
             {% endfor %}
         </div>
         <div class="text-center mb-4">

--- a/apps/web/app/templates/player/sheet.html
+++ b/apps/web/app/templates/player/sheet.html
@@ -11,227 +11,238 @@
         <h2 class="mb-0 d-inline">{{ char.character_name }}</h2>
         {% if char.clan %}<span class="badge bg-secondary ms-2">{{ char.clan }}</span>{% endif %}
         {% if char.age_category %}<span class="badge bg-dark border ms-1">{{ char.age_category }}</span>{% endif %}
+        {% if sheet_data and sheet_data.get('predatorType') %}<span class="text-muted small ms-2">· {{ sheet_data.predatorType }}</span>{% endif %}
     </div>
+    {% if draft %}
+    <span class="ms-auto text-muted small">Updated {{ draft.updated_at.strftime('%Y-%m-%d') if draft.updated_at else draft.approved_at.strftime('%Y-%m-%d') if draft.approved_at else '—' }}</span>
+    {% endif %}
 </div>
 
 {% if not sheet_data %}
 <div class="alert alert-secondary">
-    <i class="bi bi-file-earmark-person"></i>
     No living sheet linked yet.
     <a href="{{ url_for('player.import_sheet', name=char.character_name) }}" class="alert-link">Import your sheet</a>
-    to enable automatic updates from approved XP spends.
+    from Realm of Darkness to enable automatic updates from approved spends.
 </div>
 {% else %}
 
-{% set attrs = sheet_data.get('attributes', {}) %}
-{% set skills = sheet_data.get('skills', {}) %}
-{% set disciplines = sheet_data.get('disciplines', []) %}
-{% set rituals = sheet_data.get('rituals', []) %}
-{% set merits = sheet_data.get('merits', []) %}
-{% set flaws = sheet_data.get('flaws', []) %}
-{% set bp = sheet_data.get('bloodPotency', 0) %}
-{% set humanity = sheet_data.get('humanity', 0) %}
+{% set _a   = sheet_data.get('attributes', {}) %}
+{% set _s   = sheet_data.get('skills', {}) %}
+{% set _d   = sheet_data.get('disciplines', []) %}
+{% set _m   = sheet_data.get('merits', []) %}
+{% set _f   = sheet_data.get('flaws', []) %}
+{% set _r   = sheet_data.get('rituals', []) %}
+{% set _bp  = sheet_data.get('bloodPotency', 0) %}
+{% set _hum = sheet_data.get('humanity', 7) %}
+{% set _wil = sheet_data.get('willpower', 0) %}
+{% set _hp  = sheet_data.get('maxHealth', 0) %}
+{% set _gen = sheet_data.get('generation', 0) %}
+{% set _touch = sheet_data.get('touchstones', []) %}
 
-<!-- Vitals bar -->
-<div class="card mb-4">
-    <div class="card-body py-2">
-        <div class="d-flex gap-4 flex-wrap align-items-center">
-            {% if bp %}
-            <div class="text-center">
-                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Blood Potency</div>
-                <div class="fw-bold fs-5">{{ bp }}</div>
-            </div>
-            {% endif %}
-            {% if humanity %}
-            <div class="text-center">
-                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Humanity</div>
-                <div class="fw-bold fs-5">{{ humanity }}</div>
-            </div>
-            {% endif %}
-            {% if sheet_data.get('generation') %}
-            <div class="text-center">
-                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Generation</div>
-                <div class="fw-bold fs-5">{{ sheet_data.generation }}th</div>
-            </div>
-            {% endif %}
-            {% if sheet_data.get('predatorType') %}
-            <div class="text-center">
-                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Predator Type</div>
-                <div class="fw-bold">{{ sheet_data.predatorType }}</div>
-            </div>
-            {% endif %}
-            {% if draft %}
-            <div class="ms-auto text-muted small">
-                Last updated {{ draft.updated_at.strftime('%Y-%m-%d') if draft.updated_at else draft.approved_at.strftime('%Y-%m-%d') if draft.approved_at else '—' }}
-            </div>
-            {% endif %}
+{# ══════════════════════════════════════════════════════════════ ATTRIBUTES #}
+<div class="sheet-section-label">Attributes</div>
+<div class="row g-0 mb-4">
+    {% for group, keys in [
+        ('Physical', ['strength','dexterity','stamina']),
+        ('Social',   ['charisma','manipulation','composure']),
+        ('Mental',   ['intelligence','wits','resolve'])
+    ] %}
+    <div class="col-4">
+        <div class="sheet-group-label">{{ group }}</div>
+        {% for k in keys %}{% set v = _a.get(k, 0) %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ k | title }}</span>
+            <span class="dot-pips">
+                {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
+            </span>
         </div>
+        {% endfor %}
     </div>
+    {% endfor %}
 </div>
 
-<div class="row g-4">
-
-    <!-- Attributes -->
-    {% if attrs %}
-    <div class="col-lg-4">
-        <div class="card h-100">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Attributes</small>
-            </div>
-            <div class="card-body">
-                {% for group_name, keys in [('Physical', ['strength','dexterity','stamina']), ('Social', ['charisma','manipulation','composure']), ('Mental', ['intelligence','wits','resolve'])] %}
-                <div class="mb-3">
-                    <div class="text-muted small mb-1" style="font-size:0.7rem;text-transform:uppercase;">{{ group_name }}</div>
-                    {% for k in keys %}
-                    {% set v = attrs.get(k, 0) %}
-                    <div class="d-flex justify-content-between align-items-center mb-1">
-                        <span style="font-size:0.9rem;">{{ k | title }}</span>
-                        <span class="dot-pips">
-                            {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
-                        </span>
-                    </div>
-                    {% endfor %}
-                </div>
-                {% endfor %}
-            </div>
+{# ══════════════════════════════════════════════════════════════════ SKILLS #}
+<div class="sheet-section-label">Skills</div>
+<div class="row g-0 mb-4">
+    {% set phys = ['athletics','brawl','craft','drive','firearms','larceny','melee','stealth','survival'] %}
+    {% set soc  = ['animal_ken','etiquette','insight','intimidation','leadership','performance','persuasion','streetwise','subterfuge'] %}
+    {% set ment = ['academics','awareness','finance','investigation','medicine','occult','politics','science','technology'] %}
+    {% for group, keys in [('Physical', phys), ('Social', soc), ('Mental', ment)] %}
+    <div class="col-4">
+        <div class="sheet-group-label">{{ group }}</div>
+        {% for k in keys %}{% set v = _s.get(k, 0) %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ k | replace('_',' ') | title }}</span>
+            <span class="dot-pips">
+                {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
+            </span>
         </div>
+        {% endfor %}
+    </div>
+    {% endfor %}
+</div>
+
+{# ══════════════════════════════════════════════ DISCIPLINES / ADVANTAGES #}
+<div class="sheet-section-label">Disciplines &amp; Advantages</div>
+<div class="row g-4 mb-4">
+
+    {% if _d %}
+    <div class="col-md-4">
+        <div class="sheet-group-label">Disciplines</div>
+        {% set disc_groups = {} %}
+        {% for p in _d %}
+            {% set dn = p.get('discipline', 'Unknown') | title %}
+            {% if dn not in disc_groups %}{% set _ = disc_groups.update({dn: []}) %}{% endif %}
+            {% set _ = disc_groups[dn].append(p) %}
+        {% endfor %}
+        {% for dn, powers in disc_groups | dictsort %}
+        <div class="mb-3">
+            <div class="sheet-disc-name">{{ dn }}</div>
+            {% for p in powers | sort(attribute='level') %}
+            <div class="sheet-trait-row">
+                <span class="sheet-trait-name">{{ p.get('name', '?') }}</span>
+                <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ p.get('level', '?') }}</span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endfor %}
     </div>
     {% endif %}
 
-    <!-- Skills -->
-    {% if skills %}
-    <div class="col-lg-4">
-        <div class="card h-100">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Skills</small>
-            </div>
-            <div class="card-body">
-                {% set physical_skills = ['athletics','brawl','craft','drive','firearms','larceny','melee','stealth','survival'] %}
-                {% set social_skills = ['animal_ken','etiquette','insight','intimidation','leadership','performance','persuasion','streetwise','subterfuge'] %}
-                {% set mental_skills = ['academics','awareness','finance','investigation','medicine','occult','politics','science','technology'] %}
-                {% for group_name, group_keys in [('Physical', physical_skills), ('Social', social_skills), ('Mental', mental_skills)] %}
-                <div class="mb-3">
-                    <div class="text-muted small mb-1" style="font-size:0.7rem;text-transform:uppercase;">{{ group_name }}</div>
-                    {% for k in group_keys %}
-                    {% set v = skills.get(k, 0) %}
-                    {% if v > 0 %}
-                    <div class="d-flex justify-content-between align-items-center mb-1">
-                        <span style="font-size:0.9rem;">{{ k | replace('_', ' ') | title }}</span>
-                        <span class="dot-pips">
-                            {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
-                        </span>
-                    </div>
-                    {% endif %}
-                    {% endfor %}
-                </div>
-                {% endfor %}
-            </div>
+    {% if _m or _f %}
+    <div class="col-md-4">
+        {% if _m %}
+        <div class="sheet-group-label">Merits &amp; Backgrounds</div>
+        {% for m in _m %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ m.get('name', '?') }}</span>
+            <span class="dot-pips">
+                {% set lv = m.get('level', 0) %}
+                {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
+            </span>
         </div>
+        {% endfor %}
+        {% endif %}
+        {% if _f %}
+        <div class="sheet-group-label mt-3">Flaws</div>
+        {% for f in _f %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ f.get('name', '?') }}</span>
+            <span class="dot-pips">
+                {% set lv = f.get('level', 0) %}
+                {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
+            </span>
+        </div>
+        {% endfor %}
+        {% endif %}
     </div>
     {% endif %}
 
-    <!-- Disciplines, Merits, Flaws -->
-    <div class="col-lg-4">
-
-        {% if disciplines %}
-        <div class="card mb-3">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Disciplines</small>
-            </div>
-            <div class="card-body pb-1">
-                {% set disc_groups = {} %}
-                {% for p in disciplines %}
-                    {% set disc = p.get('discipline', 'Unknown') | title %}
-                    {% if disc not in disc_groups %}{% set _ = disc_groups.update({disc: []}) %}{% endif %}
-                    {% set _ = disc_groups[disc].append(p) %}
-                {% endfor %}
-                {% for disc_name, powers in disc_groups | dictsort %}
-                <div class="mb-2">
-                    <div class="fw-500 small mb-1">{{ disc_name }}</div>
-                    {% for p in powers | sort(attribute='level') %}
-                    <div class="d-flex justify-content-between align-items-center mb-1">
-                        <span style="font-size:0.85rem;" class="text-muted">{{ p.get('name', '?') }}</span>
-                        <span class="badge bg-dark border text-muted">L{{ p.get('level', '?') }}</span>
-                    </div>
-                    {% endfor %}
-                </div>
-                {% endfor %}
-            </div>
+    {% if _r %}
+    <div class="col-md-4">
+        {% set bs_r = _r | selectattr('discipline', 'equalto', 'blood sorcery') | list %}
+        {% set tb_r = _r | selectattr('discipline', 'equalto', 'thin-blood alchemy') | list %}
+        {% set oth_r = _r | rejectattr('discipline', 'in', ['blood sorcery','thin-blood alchemy']) | list %}
+        {% if bs_r %}
+        <div class="sheet-group-label">Blood Sorcery Rituals</div>
+        {% for r in bs_r | sort(attribute='level') %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ r.get('name', '?') }}</span>
+            <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ r.get('level', '?') }}</span>
         </div>
+        {% endfor %}
         {% endif %}
-
-        {% set bs_rituals = rituals | selectattr('discipline', 'equalto', 'blood sorcery') | list %}
-        {% set tba_rituals = rituals | selectattr('discipline', 'equalto', 'thin-blood alchemy') | list %}
-        {% if bs_rituals %}
-        <div class="card mb-3">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Blood Sorcery Rituals</small>
-            </div>
-            <div class="card-body pb-1">
-                {% for r in bs_rituals | sort(attribute='level') %}
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span style="font-size:0.85rem;" class="text-muted">{{ r.get('name', '?') }}</span>
-                    <span class="badge bg-dark border text-muted">L{{ r.get('level', '?') }}</span>
-                </div>
-                {% endfor %}
-            </div>
+        {% if tb_r %}
+        <div class="sheet-group-label {% if bs_r %}mt-3{% endif %}">Thin-Blood Alchemy</div>
+        {% for r in tb_r | sort(attribute='level') %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ r.get('name', '?') }}</span>
+            <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ r.get('level', '?') }}</span>
         </div>
+        {% endfor %}
         {% endif %}
-        {% if tba_rituals %}
-        <div class="card mb-3">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Thin-Blood Alchemy</small>
-            </div>
-            <div class="card-body pb-1">
-                {% for r in tba_rituals | sort(attribute='level') %}
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span style="font-size:0.85rem;" class="text-muted">{{ r.get('name', '?') }}</span>
-                    <span class="badge bg-dark border text-muted">L{{ r.get('level', '?') }}</span>
-                </div>
-                {% endfor %}
-            </div>
+        {% if oth_r %}
+        <div class="sheet-group-label {% if bs_r or tb_r %}mt-3{% endif %}">Ceremonies</div>
+        {% for r in oth_r | sort(attribute='level') %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ r.get('name', '?') }}</span>
+            <span class="badge bg-dark border text-muted" style="font-size:0.65rem;">L{{ r.get('level', '?') }}</span>
         </div>
+        {% endfor %}
         {% endif %}
-
-        {% if merits %}
-        <div class="card mb-3">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Merits &amp; Backgrounds</small>
-            </div>
-            <div class="card-body pb-1">
-                {% for m in merits %}
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span style="font-size:0.85rem;" class="text-muted">{{ m.get('name', '?') }}</span>
-                    <span class="dot-pips">
-                        {% set lv = m.get('level', 0) %}
-                        {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
-                    </span>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-        {% endif %}
-
-        {% if flaws %}
-        <div class="card mb-3">
-            <div class="card-header py-2">
-                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Flaws</small>
-            </div>
-            <div class="card-body pb-1">
-                {% for f in flaws %}
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span style="font-size:0.85rem;" class="text-muted">{{ f.get('name', '?') }}</span>
-                    <span class="dot-pips">
-                        {% set lv = f.get('level', 0) %}
-                        {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
-                    </span>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-        {% endif %}
-
     </div>
+    {% endif %}
+
 </div>
+
+{# ══════════════════════════════════════════════════════════════════ VITALS #}
+<div class="sheet-section-label">Humanity, Health &amp; Extras</div>
+<div class="row g-4 mb-2">
+
+    <div class="col-md-5">
+        <div class="mb-3">
+            <div class="sheet-group-label">Humanity</div>
+            <div class="dot-pips dot-pips-lg">
+                {% for i in range(1, 11) %}<span class="dot-pip {% if i <= _hum %}filled{% endif %}"></span>{% endfor %}
+            </div>
+        </div>
+        <div class="mb-3">
+            <div class="sheet-group-label">Blood Potency</div>
+            <div class="dot-pips dot-pips-lg">
+                {% for i in range(1, 11) %}<span class="dot-pip {% if i <= _bp %}filled{% endif %}"></span>{% endfor %}
+            </div>
+        </div>
+        {% if _hp %}
+        <div class="mb-3">
+            <div class="sheet-group-label">Health</div>
+            <div class="dot-pips dot-pips-lg">
+                {% for i in range(1, _hp + 1) %}<span class="dot-pip square"></span>{% endfor %}
+            </div>
+        </div>
+        {% endif %}
+        {% if _wil %}
+        <div class="mb-3">
+            <div class="sheet-group-label">Willpower</div>
+            <div class="dot-pips dot-pips-lg">
+                {% for i in range(1, _wil + 1) %}<span class="dot-pip square"></span>{% endfor %}
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="col-md-4">
+        {% if _gen %}
+        <div class="mb-3">
+            <div class="sheet-group-label">Generation</div>
+            <div class="sheet-trait-name">{{ _gen }}th</div>
+        </div>
+        {% endif %}
+        {% set _ambi = sheet_data.get('ambition','') %}
+        {% set _desi = sheet_data.get('desire','') %}
+        {% if _ambi %}
+        <div class="mb-2">
+            <div class="sheet-group-label">Ambition</div>
+            <div class="sheet-trait-name">{{ _ambi }}</div>
+        </div>
+        {% endif %}
+        {% if _desi %}
+        <div class="mb-2">
+            <div class="sheet-group-label">Desire</div>
+            <div class="sheet-trait-name">{{ _desi }}</div>
+        </div>
+        {% endif %}
+    </div>
+
+    {% if _touch %}
+    <div class="col-md-3">
+        <div class="sheet-group-label">Touchstones &amp; Convictions</div>
+        {% for t in _touch %}
+        <div class="sheet-trait-name mb-1">{{ t if t is string else t.get('description', t.get('name', '')) }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+
 {% endif %}
 {% endblock %}

--- a/apps/web/app/templates/player/sheet.html
+++ b/apps/web/app/templates/player/sheet.html
@@ -233,16 +233,23 @@
         {% endif %}
     </div>
 
-    {% if _touch %}
-    <div class="col-md-3">
-        <div class="sheet-group-label">Touchstones &amp; Convictions</div>
+</div>
+
+{% if _touch %}
+<div class="mt-3">
+    <div class="sheet-group-label">Touchstones &amp; Convictions</div>
+    <div class="row g-2">
         {% for t in _touch %}
-        <div class="sheet-trait-name mb-1">{{ t if t is string else t.get('description', t.get('name', '')) }}</div>
+        {% set txt = t if t is string else t.get('description', t.get('name', '')) %}
+        {% if txt %}
+        <div class="col-md-4 col-lg-3">
+            <div class="sheet-trait-name">{{ txt }}</div>
+        </div>
+        {% endif %}
         {% endfor %}
     </div>
-    {% endif %}
-
 </div>
+{% endif %}
 
 {% endif %}
 {% endblock %}

--- a/apps/web/app/templates/player/sheet.html
+++ b/apps/web/app/templates/player/sheet.html
@@ -1,0 +1,237 @@
+{% extends "player/base.html" %}
+
+{% block title %}{{ char.character_name }} — Character Sheet{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <a href="{{ url_for('player.character', name=char.character_name) }}" class="btn btn-sm btn-outline-secondary">
+        <i class="bi bi-arrow-left"></i> XP Tracker
+    </a>
+    <div>
+        <h2 class="mb-0 d-inline">{{ char.character_name }}</h2>
+        {% if char.clan %}<span class="badge bg-secondary ms-2">{{ char.clan }}</span>{% endif %}
+        {% if char.age_category %}<span class="badge bg-dark border ms-1">{{ char.age_category }}</span>{% endif %}
+    </div>
+</div>
+
+{% if not sheet_data %}
+<div class="alert alert-secondary">
+    <i class="bi bi-file-earmark-person"></i>
+    No living sheet linked yet.
+    <a href="{{ url_for('player.import_sheet', name=char.character_name) }}" class="alert-link">Import your sheet</a>
+    to enable automatic updates from approved XP spends.
+</div>
+{% else %}
+
+{% set attrs = sheet_data.get('attributes', {}) %}
+{% set skills = sheet_data.get('skills', {}) %}
+{% set disciplines = sheet_data.get('disciplines', []) %}
+{% set rituals = sheet_data.get('rituals', []) %}
+{% set merits = sheet_data.get('merits', []) %}
+{% set flaws = sheet_data.get('flaws', []) %}
+{% set bp = sheet_data.get('bloodPotency', 0) %}
+{% set humanity = sheet_data.get('humanity', 0) %}
+
+<!-- Vitals bar -->
+<div class="card mb-4">
+    <div class="card-body py-2">
+        <div class="d-flex gap-4 flex-wrap align-items-center">
+            {% if bp %}
+            <div class="text-center">
+                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Blood Potency</div>
+                <div class="fw-bold fs-5">{{ bp }}</div>
+            </div>
+            {% endif %}
+            {% if humanity %}
+            <div class="text-center">
+                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Humanity</div>
+                <div class="fw-bold fs-5">{{ humanity }}</div>
+            </div>
+            {% endif %}
+            {% if sheet_data.get('generation') %}
+            <div class="text-center">
+                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Generation</div>
+                <div class="fw-bold fs-5">{{ sheet_data.generation }}th</div>
+            </div>
+            {% endif %}
+            {% if sheet_data.get('predatorType') %}
+            <div class="text-center">
+                <div class="text-muted small" style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;">Predator Type</div>
+                <div class="fw-bold">{{ sheet_data.predatorType }}</div>
+            </div>
+            {% endif %}
+            {% if draft %}
+            <div class="ms-auto text-muted small">
+                Last updated {{ draft.updated_at.strftime('%Y-%m-%d') if draft.updated_at else draft.approved_at.strftime('%Y-%m-%d') if draft.approved_at else '—' }}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<div class="row g-4">
+
+    <!-- Attributes -->
+    {% if attrs %}
+    <div class="col-lg-4">
+        <div class="card h-100">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Attributes</small>
+            </div>
+            <div class="card-body">
+                {% for group_name, keys in [('Physical', ['strength','dexterity','stamina']), ('Social', ['charisma','manipulation','composure']), ('Mental', ['intelligence','wits','resolve'])] %}
+                <div class="mb-3">
+                    <div class="text-muted small mb-1" style="font-size:0.7rem;text-transform:uppercase;">{{ group_name }}</div>
+                    {% for k in keys %}
+                    {% set v = attrs.get(k, 0) %}
+                    <div class="d-flex justify-content-between align-items-center mb-1">
+                        <span style="font-size:0.9rem;">{{ k | title }}</span>
+                        <span class="dot-pips">
+                            {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
+                        </span>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Skills -->
+    {% if skills %}
+    <div class="col-lg-4">
+        <div class="card h-100">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Skills</small>
+            </div>
+            <div class="card-body">
+                {% set physical_skills = ['athletics','brawl','craft','drive','firearms','larceny','melee','stealth','survival'] %}
+                {% set social_skills = ['animal_ken','etiquette','insight','intimidation','leadership','performance','persuasion','streetwise','subterfuge'] %}
+                {% set mental_skills = ['academics','awareness','finance','investigation','medicine','occult','politics','science','technology'] %}
+                {% for group_name, group_keys in [('Physical', physical_skills), ('Social', social_skills), ('Mental', mental_skills)] %}
+                <div class="mb-3">
+                    <div class="text-muted small mb-1" style="font-size:0.7rem;text-transform:uppercase;">{{ group_name }}</div>
+                    {% for k in group_keys %}
+                    {% set v = skills.get(k, 0) %}
+                    {% if v > 0 %}
+                    <div class="d-flex justify-content-between align-items-center mb-1">
+                        <span style="font-size:0.9rem;">{{ k | replace('_', ' ') | title }}</span>
+                        <span class="dot-pips">
+                            {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
+                        </span>
+                    </div>
+                    {% endif %}
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Disciplines, Merits, Flaws -->
+    <div class="col-lg-4">
+
+        {% if disciplines %}
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Disciplines</small>
+            </div>
+            <div class="card-body pb-1">
+                {% set disc_groups = {} %}
+                {% for p in disciplines %}
+                    {% set disc = p.get('discipline', 'Unknown') | title %}
+                    {% if disc not in disc_groups %}{% set _ = disc_groups.update({disc: []}) %}{% endif %}
+                    {% set _ = disc_groups[disc].append(p) %}
+                {% endfor %}
+                {% for disc_name, powers in disc_groups | dictsort %}
+                <div class="mb-2">
+                    <div class="fw-500 small mb-1">{{ disc_name }}</div>
+                    {% for p in powers | sort(attribute='level') %}
+                    <div class="d-flex justify-content-between align-items-center mb-1">
+                        <span style="font-size:0.85rem;" class="text-muted">{{ p.get('name', '?') }}</span>
+                        <span class="badge bg-dark border text-muted">L{{ p.get('level', '?') }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+
+        {% set bs_rituals = rituals | selectattr('discipline', 'equalto', 'blood sorcery') | list %}
+        {% set tba_rituals = rituals | selectattr('discipline', 'equalto', 'thin-blood alchemy') | list %}
+        {% if bs_rituals %}
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Blood Sorcery Rituals</small>
+            </div>
+            <div class="card-body pb-1">
+                {% for r in bs_rituals | sort(attribute='level') %}
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span style="font-size:0.85rem;" class="text-muted">{{ r.get('name', '?') }}</span>
+                    <span class="badge bg-dark border text-muted">L{{ r.get('level', '?') }}</span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+        {% if tba_rituals %}
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Thin-Blood Alchemy</small>
+            </div>
+            <div class="card-body pb-1">
+                {% for r in tba_rituals | sort(attribute='level') %}
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span style="font-size:0.85rem;" class="text-muted">{{ r.get('name', '?') }}</span>
+                    <span class="badge bg-dark border text-muted">L{{ r.get('level', '?') }}</span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+
+        {% if merits %}
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Merits &amp; Backgrounds</small>
+            </div>
+            <div class="card-body pb-1">
+                {% for m in merits %}
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span style="font-size:0.85rem;" class="text-muted">{{ m.get('name', '?') }}</span>
+                    <span class="dot-pips">
+                        {% set lv = m.get('level', 0) %}
+                        {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
+                    </span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+
+        {% if flaws %}
+        <div class="card mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">Flaws</small>
+            </div>
+            <div class="card-body pb-1">
+                {% for f in flaws %}
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span style="font-size:0.85rem;" class="text-muted">{{ f.get('name', '?') }}</span>
+                    <span class="dot-pips">
+                        {% set lv = f.get('level', 0) %}
+                        {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
+                    </span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/apps/web/app/templates/player/sheet.html
+++ b/apps/web/app/templates/player/sheet.html
@@ -38,6 +38,7 @@
 {% set _hp  = sheet_data.get('maxHealth', 0) %}
 {% set _gen = sheet_data.get('generation', 0) %}
 {% set _touch = sheet_data.get('touchstones', []) %}
+{% set _ls  = sheet_data.get('loresheet_purchases', []) %}
 
 {# ══════════════════════════════════════════════════════════════ ATTRIBUTES #}
 <div class="sheet-section-label">Attributes</div>
@@ -109,7 +110,7 @@
     </div>
     {% endif %}
 
-    {% if _m or _f %}
+    {% if _m or _f or _ls %}
     <div class="col-md-4">
         {% if _m %}
         <div class="sheet-group-label">Merits &amp; Backgrounds</div>
@@ -118,6 +119,18 @@
             <span class="sheet-trait-name">{{ m.get('name', '?') }}</span>
             <span class="dot-pips">
                 {% set lv = m.get('level', 0) %}
+                {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
+            </span>
+        </div>
+        {% endfor %}
+        {% endif %}
+        {% if _ls %}
+        <div class="sheet-group-label {% if _m %}mt-3{% endif %}">Loresheets</div>
+        {% for ls in _ls %}
+        <div class="sheet-trait-row">
+            <span class="sheet-trait-name">{{ ls.get('name', '?') }}</span>
+            <span class="dot-pips">
+                {% set lv = ls.get('dot', 0) %}
                 {% for i in range(1, 6) %}<span class="dot-pip {% if i <= lv %}filled{% endif %}"></span>{% endfor %}
             </span>
         </div>

--- a/apps/web/app/templates/roster/detail.html
+++ b/apps/web/app/templates/roster/detail.html
@@ -85,6 +85,9 @@
       <a href="{{ url_for('roster.edit', name=char.character_name) }}" class="btn btn-sm btn-primary">
         <i class="bi bi-pencil"></i> Edit
       </a>
+      <a href="{{ url_for('roster.edit_sheet', name=char.character_name) }}" class="btn btn-sm btn-outline-primary">
+        <i class="bi bi-file-earmark-person"></i> Edit Sheet
+      </a>
       <form method="POST" action="{{ url_for('roster.set_status', name=char.character_name) }}" class="d-inline">
         {% set current_status = char.status or ('active' if char.active else 'retired') %}
         <select name="status" class="form-select form-select-sm d-inline-block w-auto"

--- a/apps/web/app/templates/roster/edit_sheet.html
+++ b/apps/web/app/templates/roster/edit_sheet.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+
+{% block title %}Edit Sheet — {{ char.character_name }}{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <a href="{{ url_for('roster.detail', name=char.character_name) }}" class="btn btn-sm btn-outline-secondary">
+        <i class="bi bi-arrow-left"></i> Back
+    </a>
+    <div>
+        <h2 class="mb-0 d-inline">Edit Living Sheet</h2>
+        <span class="badge bg-secondary ms-2">{{ char.character_name }}</span>
+        {% if char.clan %}<span class="badge bg-dark border ms-1">{{ char.clan }}</span>{% endif %}
+    </div>
+    {% if draft %}
+    <span class="ms-auto text-muted small">
+        Last updated {{ draft.updated_at.strftime('%Y-%m-%d') if draft.updated_at else draft.approved_at.strftime('%Y-%m-%d') if draft.approved_at else '—' }}
+        {% if draft.approved_by %}<span class="ms-1 text-muted">· {{ draft.approved_by }}</span>{% endif %}
+    </span>
+    {% endif %}
+</div>
+
+<div class="row g-4">
+    <div class="col-lg-8">
+        <div class="card">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">
+                    <i class="bi bi-file-earmark-code"></i> Sheet JSON
+                </small>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('roster.edit_sheet', name=char.character_name) }}">
+                    <input type="hidden" name="action" value="save">
+                    <div class="mb-3">
+                        <textarea class="form-control font-monospace"
+                                  id="sheet_json" name="sheet_json"
+                                  rows="28"
+                                  style="font-size:0.75rem;resize:vertical;">{{ sheet_json }}</textarea>
+                        <div class="form-text">
+                            Edit the JSON directly. This is the canonical living sheet data — be careful.
+                            Must be valid JSON starting with <code>{</code>.
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-floppy"></i> Save Sheet
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-4">
+        {% if draft %}
+        <div class="card border-secondary mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">
+                    Quick Actions
+                </small>
+            </div>
+            <div class="card-body d-flex flex-column gap-2">
+                <a href="{{ url_for('player.view_sheet', name=char.character_name) }}"
+                   class="btn btn-sm btn-outline-info" target="_blank">
+                    <i class="bi bi-eye"></i> View Sheet
+                </a>
+                <button class="btn btn-sm btn-outline-danger" type="button"
+                        data-bs-toggle="collapse" data-bs-target="#delete-confirm">
+                    <i class="bi bi-trash"></i> Delete Sheet
+                </button>
+                <div class="collapse" id="delete-confirm">
+                    <div class="alert alert-danger mt-2 mb-0 py-2 px-3" style="font-size:0.85rem;">
+                        <strong>Delete the living sheet?</strong> The player will need to re-import.
+                        <form method="POST" action="{{ url_for('roster.edit_sheet', name=char.character_name) }}" class="mt-2">
+                            <input type="hidden" name="action" value="delete">
+                            <button type="submit" class="btn btn-danger btn-sm">Yes, delete it</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% else %}
+        <div class="alert alert-secondary">
+            No living sheet exists for this character yet. Paste valid JSON above and save to create one.
+        </div>
+        {% endif %}
+
+        <div class="card border-info">
+            <div class="card-header bg-info bg-opacity-10 py-2">
+                <h6 class="mb-0"><i class="bi bi-info-circle"></i> Key Fields</h6>
+            </div>
+            <div class="card-body" style="font-size:0.82rem;">
+                <ul class="mb-0 ps-3">
+                    <li><code>attributes</code> — flat dict, e.g. <code>"strength": 3</code></li>
+                    <li><code>skills</code> — flat dict, e.g. <code>"athletics": 2</code></li>
+                    <li><code>disciplines</code> — array of power objects with <code>name</code>, <code>discipline</code>, <code>level</code></li>
+                    <li><code>merits</code> / <code>flaws</code> — arrays with <code>name</code>, <code>level</code></li>
+                    <li><code>bloodPotency</code>, <code>humanity</code>, <code>willpower</code>, <code>maxHealth</code></li>
+                    <li><code>touchstones</code> — array of strings</li>
+                    <li><code>generation</code>, <code>predatorType</code>, <code>ambition</code>, <code>desire</code></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Living sheet system**: players can import a Realm of Darkness V5 JSON export as their character's living sheet; approved XP spends automatically patch the sheet data
- **Sheet view**: full `/player/<name>/sheet` page in proper V5 layout (Attributes → Skills → Disciplines/Advantages/Rituals → Humanity/BP/Health/Willpower/Touchstones)
- **Inline sheet**: collapsible Character Sheet card at the top of the player character page, with BP/Humanity badges and links to full sheet and re-import
- **Re-import**: players can re-import from RoD at any time (overwrites existing); fixed touchstones bug where RoD string exports caused character-by-character vertical rendering
- **Staff sheet editor**: `/roster/<name>/edit-sheet` — full JSON editor with save/delete, accessible from the roster detail page
- **Spend form auto-fill**: pre-fills current dots from sheet data when a player selects an Attribute/Skill/Discipline to spend on
- **UX improvements**: collapsible Background Blanking, XP Claims History, and Approved Spends sections; Spend Requests In Progress only shows pending (no denied); sheet import link removed once sheet is active

## Test plan

- [ ] Import a Realm of Darkness JSON export on `/player/<name>/import-sheet` — sheet should appear inline on the character page
- [ ] Re-import with a corrected RoD export — should overwrite without error
- [ ] Touchstones render as a horizontal list, not character-by-character
- [ ] Full sheet at `/player/<name>/sheet` shows all sections in V5 order
- [ ] Approve an XP spend — verify the sheet dot updates automatically
- [ ] Staff: `/roster/<name>/edit-sheet` loads JSON, saves edits, delete button removes sheet
- [ ] Spend form pre-fills current dots when a trait is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)