### PR TITLE
Fix: show skill specialties on character sheet

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -707,9 +707,15 @@ def _map_rod_to_cc(rod: dict) -> dict:
     data['attributes'] = dict(rod.get('attributes', {}))
 
     # Skills: RoD uses {skill: {value: n, spec: [...]}} — flatten to {skill: n}
+    # and preserve specialties as {skill: [spec, ...]}
     data['skills'] = {
         k: (v.get('value', 0) if isinstance(v, dict) else int(v or 0))
         for k, v in rod.get('skills', {}).items()
+    }
+    data['skill_specialties'] = {
+        k: v.get('spec') or []
+        for k, v in rod.get('skills', {}).items()
+        if isinstance(v, dict) and v.get('spec')
     }
 
     # Disciplines: RoD dict-of-disciplines → CC array of power objects

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1916,6 +1916,14 @@ a.wiki-featured-card h4 {
     color: #ccc;
 }
 
+.sheet-specialty-row {
+    font-size: 0.72rem;
+    color: #888;
+    font-style: italic;
+    padding: 0 0.5rem 0.25rem 0;
+    margin-top: -0.1rem;
+}
+
 .sheet-disc-name {
     font-size: 0.72rem;
     font-weight: 600;

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -106,6 +106,7 @@
 {% if has_approved_draft and sheet_data %}
 {% set _a = sheet_data.get('attributes', {}) %}
 {% set _s = sheet_data.get('skills', {}) %}
+{% set _spec = sheet_data.get('skill_specialties', {}) %}
 {% set _d = sheet_data.get('disciplines', []) %}
 {% set _m = sheet_data.get('merits', []) %}
 {% set _f = sheet_data.get('flaws', []) %}
@@ -160,6 +161,9 @@
                     <span class="sheet-trait-name">{{ k|replace('_',' ')|title }}</span>
                     <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i<=v %}filled{% endif %}"></span>{% endfor %}</span>
                 </div>
+                {% if _spec.get(k) %}
+                <div class="sheet-specialty-row">{{ _spec[k] | join(', ') }}</div>
+                {% endif %}
                 {% endfor %}
             </div>
             {% endfor %}

--- a/apps/web/app/templates/player/sheet.html
+++ b/apps/web/app/templates/player/sheet.html
@@ -39,6 +39,7 @@
 {% set _gen = sheet_data.get('generation', 0) %}
 {% set _touch = sheet_data.get('touchstones', []) %}
 {% set _ls  = sheet_data.get('loresheet_purchases', []) %}
+{% set _spec = sheet_data.get('skill_specialties', {}) %}
 
 {# ══════════════════════════════════════════════════════════════ ATTRIBUTES #}
 <div class="sheet-section-label">Attributes</div>
@@ -78,6 +79,9 @@
                 {% for i in range(1, 6) %}<span class="dot-pip {% if i <= v %}filled{% endif %}"></span>{% endfor %}
             </span>
         </div>
+        {% if _spec.get(k) %}
+        <div class="sheet-specialty-row">{{ _spec[k] | join(', ') }}</div>
+        {% endif %}
         {% endfor %}
     </div>
     {% endfor %}


### PR DESCRIPTION
## Summary

- RoD exports skills as `{skill: {value: n, spec: [...]}}` — the importer was dropping `spec`
- `_map_rod_to_cc` now preserves specialties as `skill_specialties: {skill: [...]}` in sheet data
- Both `sheet.html` and the inline sheet in `character.html` render specialties in italic below each skill row that has them
- Added `.sheet-specialty-row` CSS class (small, italic, muted)

Existing sheets without specialties are unaffected (field defaults to `{}`).

## Test plan

- [ ] Re-import a RoD JSON that has skill specialties — verify they appear on the full sheet under the relevant skill
- [ ] Verify the inline sheet on the character page also shows them
- [ ] Verify a sheet with no specialties renders identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)