### PR TITLE
Fix: background blanks release after next downtime

### DIFF
--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -29,6 +29,7 @@ from app.db import (
     DbCharacterBackground,
 )
 from app.models import Character, PlayPeriod, XPClaim, SpendRequest, LedgerEntry, AuditEntry
+from app.game_calendar import next_night_after_downtime
 
 
 def _now_str() -> str:
@@ -1278,7 +1279,10 @@ class DBService:
 
         row.dots_blanked = blanked + dots
         row.blanked_at_night_number = current_night_number
-        row.release_night_number = current_night_number + 1
+        row.release_night_number = (
+            next_night_after_downtime(current_night_number)
+            or current_night_number + 1
+        )
         row.updated_at = _now_str()
         row.updated_by = updated_by[:100]
         db.session.commit()

--- a/apps/web/app/game_calendar.py
+++ b/apps/web/app/game_calendar.py
@@ -45,6 +45,43 @@ _RAW = [
 ]
 
 
+def _night_number_from_label(label: str) -> int | None:
+    """Parse the night number from a label like 'Night 62'. Returns None if not a night label."""
+    parts = label.split()
+    if len(parts) == 2 and parts[0].lower() == 'night':
+        try:
+            return int(parts[1])
+        except ValueError:
+            pass
+    return None
+
+
+def next_night_after_downtime(current_night_number: int) -> int | None:
+    """Return the night_number of the first IC night after the next downtime.
+
+    This is the standard blank release point: a background blanked on any night
+    stays blanked until the opening of the first night after the subsequent downtime.
+    Returns None if no future downtime exists in the calendar (caller should fall back).
+    """
+    found_current = False
+    past_downtime = False
+    for kind, label, _start, _end, _note in _RAW:
+        if not found_current:
+            if kind == 'night' and _night_number_from_label(label) == current_night_number:
+                found_current = True
+            continue
+        if not past_downtime:
+            if kind == 'downtime':
+                past_downtime = True
+            continue
+        # Past the next downtime — first night entry is our target
+        if kind == 'night':
+            n = _night_number_from_label(label)
+            if n is not None:
+                return n
+    return None
+
+
 def get_calendar():
     """Return all calendar entries with status computed for today."""
     today = date.today()


### PR DESCRIPTION
## Summary

Background blanks were releasing one night too soon (`+1`). The correct rule is: a blank persists until the start of the first IC night after the next downtime.

**Example**: blank on Night 62 → stays blanked through Nights 63, 64, and the July 12–14 Downtime → releases when Night 65 opens.

## Changes

- `game_calendar.py`: added `next_night_after_downtime(night_number)` — walks the static calendar to find the correct release night
- `db_service.py`: `blank_character_background` now uses this instead of `current_night_number + 1`
- Falls back to `+1` if the current night is past the end of the calendar (keeps existing tests passing, handles edge cases)

## Verified

| Blank on | Next downtime | Releases at |
|----------|--------------|-------------|
| Night 59 | May 17 | Night 61 ✓ |
| Night 62 | Jul 12 | Night 65 ✓ |
| Night 64 | Jul 12 | Night 65 ✓ |
| Night 65 | Sep 6 | Night 69 ✓ |

121 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)