### PR TITLE
feat: coteries — creation, pool, blanking, wiki sync

### DIFF
--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -118,6 +118,17 @@ export const data = new SlashCommandBuilder()
   )
   .addSubcommand((s) =>
     s
+      .setName('coterie-create')
+      .setDescription('Create a coterie on the site and post the setup link here (staff only)')
+      .addStringOption((o) =>
+        o
+          .setName('name')
+          .setDescription('Exact coterie name as entered on the site')
+          .setRequired(true),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
       .setName('blank')
       .setDescription('Blank a tracked background for one night')
       .addStringOption((o) =>
@@ -461,6 +472,55 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
     } catch (err) {
       await interaction.editReply(`Scan failed: ${errorToMessage(err)}`);
     }
+    return;
+  }
+
+  if (sub === 'coterie-create') {
+    if (!config.testerDiscordIds.has(interaction.user.id)) {
+      await interaction.reply({ content: 'This command is restricted to staff.', ephemeral: true });
+      return;
+    }
+    const coterieName = interaction.options.getString('name', true).trim();
+    const channelId = interaction.channelId;
+    await interaction.deferReply();
+
+    let result: Awaited<ReturnType<typeof ctx.adapter.activateCoterie>>;
+    try {
+      result = await ctx.adapter.activateCoterie(coterieName, channelId);
+    } catch (err) {
+      await interaction.editReply({
+        content: `Failed to activate coterie: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    const { coterie } = result;
+    const baseUrl = config.webAppBaseUrl.replace(/\/+$/, '');
+    const coterieUrl = `${baseUrl}/coteries/${coterie.slug}`;
+    const memberMentions = coterie.members
+      .filter((m) => m.player_discord_id)
+      .map((m) => `<@${m.player_discord_id}>`)
+      .join(' ');
+    const totalDots = coterie.free_pool_total;
+    const memberCount = coterie.members.length;
+
+    await interaction.editReply({
+      embeds: [
+        {
+          title: `🏰 ${coterie.name}`,
+          description: [
+            `**${memberCount} member${memberCount !== 1 ? 's' : ''}** · **${totalDots} free dot${totalDots !== 1 ? 's' : ''}** in the pool`,
+            '',
+            coterie.members.map((m) => `• ${m.character_name} (${m.free_dots} free dot${m.free_dots !== 1 ? 's' : ''})`).join('\n'),
+            '',
+            `[View & set up your coterie](${coterieUrl})`,
+          ].join('\n'),
+          color: 0x8b0000,
+          url: coterieUrl,
+        },
+      ],
+      content: memberMentions ? `${memberMentions} — your coterie is ready!` : undefined,
+    });
     return;
   }
 

--- a/apps/bot/src/scripts/discord-wiki-sync.ts
+++ b/apps/bot/src/scripts/discord-wiki-sync.ts
@@ -43,8 +43,6 @@ import {
   fetchPins,
 } from './notionSync/discordIngest';
 import {
-  CHAR_TO_COTERIE,
-  COTERIE_MEMBERS,
   FACTIONS,
   inferSpcType,
   mapDomain,
@@ -208,6 +206,30 @@ async function fetchActiveRoster(webBase: string, webReadToken: string): Promise
   }
 }
 
+interface ApiCoterie {
+  id: number;
+  name: string;
+  slug: string;
+  description: string;
+  members: Array<{ character_name: string; clan: string; player_discord_id: string }>;
+}
+
+async function fetchCoteries(webBase: string, webReadToken: string): Promise<ApiCoterie[]> {
+  if (!webReadToken) return [];
+  try {
+    const res = await fetch(`${webBase}/api/coteries`, {
+      headers: { Authorization: `Bearer ${webReadToken}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) { console.log(`  [warn] Coteries API returned ${res.status}`); return []; }
+    const body = await res.json() as { coteries: ApiCoterie[] };
+    return body.coteries ?? [];
+  } catch (err) {
+    console.log(`  [warn] Could not reach coteries API: ${err}`);
+    return [];
+  }
+}
+
 function firstImage(messages: DiscordMessage[]): string | null {
   for (const msg of messages) {
     for (const a of msg.attachments ?? []) {
@@ -266,11 +288,22 @@ async function main(opts: WikiSyncOptions) {
   }
 
   // ------------------------------------------------------------------
-  // 2. Active PC roster
+  // 2. Active PC roster + coteries from web API
   // ------------------------------------------------------------------
-  console.log('\n[2/7] Fetching active roster from web API…');
+  console.log('\n[2/7] Fetching active roster and coteries from web API…');
   const activeRoster = await fetchActiveRoster(WEB_BASE, WEB_READ_TOKEN);
   console.log(`  Active characters: ${activeRoster.length}`);
+
+  const dbCoteries = await fetchCoteries(WEB_BASE, WEB_READ_TOKEN);
+  console.log(`  Active coteries: ${dbCoteries.length}`);
+
+  // Build char→coterie lookup from DB data
+  const CHAR_TO_COTERIE = new Map<string, string>();
+  for (const c of dbCoteries) {
+    for (const m of c.members) {
+      CHAR_TO_COTERIE.set(m.character_name.toLowerCase(), c.name);
+    }
+  }
 
   // ------------------------------------------------------------------
   // 3. Location Database
@@ -453,24 +486,31 @@ async function main(opts: WikiSyncOptions) {
   }
 
   // ------------------------------------------------------------------
-  // 6.5 Coteries wiki pages (built from static COTERIE_MEMBERS map)
+  // 6.5 Coteries wiki pages (sourced from DB via web API)
   // ------------------------------------------------------------------
-  console.log('\n[6.5/7] Populating Coteries wiki pages…');
+  console.log('\n[6.5/7] Populating Coteries wiki pages from DB…');
   let coterieCreatedCount = 0;
-  for (const [coterieName, members] of Object.entries(COTERIE_MEMBERS)) {
-    const memberList = members.map((m) => `- [${toTitleCase(m)}](/wiki/${wikiSlug('characters', m)})`).join('\n');
-    const body = `## Members\n\n${memberList}`;
-    console.log(`  → ${coterieName} (${members.length} members)`);
+  for (const coterie of dbCoteries) {
+    const memberList = coterie.members
+      .map((m) => `- [${m.character_name}](/wiki/${wikiSlug('characters', m.character_name)})${m.clan ? ` — ${m.clan}` : ''}`)
+      .join('\n');
+    const body = [
+      coterie.description ? `${coterie.description}\n` : '',
+      '## Members',
+      '',
+      memberList || '_(none)_',
+    ].join('\n');
+    console.log(`  → ${coterie.name} (${coterie.members.length} members)`);
     await wikiClient.upsertPage({
-      slug: wikiSlug('coteries', coterieName),
-      title: coterieName,
+      slug: wikiSlug('coteries', coterie.name),
+      title: coterie.name,
       category: 'coteries',
       body_markdown: body,
       published: true,
     });
     coterieCreatedCount++;
   }
-  console.log(`  Created ${coterieCreatedCount} coterie pages.`);
+  console.log(`  Synced ${coterieCreatedCount} coterie pages from DB.`);
 
   // ------------------------------------------------------------------
   // 6.6 Factions wiki pages (built from active roster sect field)

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -127,6 +127,27 @@ export interface TrackerAdapter {
     operations: Array<{ action: 'upsert' | 'remove'; discord_id: string; display_name: string; role: string }>,
     fullSync?: boolean,
   ): Promise<{ ok: boolean; processed: number }>;
+  activateCoterie(
+    name: string,
+    discordChannelId: string,
+  ): Promise<{
+    ok: boolean;
+    coterie: {
+      id: number;
+      name: string;
+      slug: string;
+      members: Array<{ character_name: string; player_discord_id: string; free_dots: number }>;
+      free_pool_total: number;
+    };
+  }>;
+  listCoteries(): Promise<Array<{
+    id: number;
+    name: string;
+    slug: string;
+    description: string;
+    discord_channel_id: string | null;
+    members: Array<{ character_name: string; clan: string; player_discord_id: string }>;
+  }>>;
 }
 
 export type CharacterDetails = {
@@ -1286,6 +1307,29 @@ export class WebAppAdapter implements TrackerAdapter {
     });
     if (!res.ok) throw new Error(`staff/sync POST failed: ${res.status}`);
     return res.json() as Promise<{ ok: boolean; processed: number }>;
+  }
+
+  async activateCoterie(name: string, discordChannelId: string) {
+    const res = await this.fetchWithTimeout(`${this.baseUrl}/api/coteries/activate`, {
+      method: 'POST',
+      headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, discord_channel_id: discordChannelId }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+      throw new Error((body.error as string | undefined) ?? `coteries/activate POST failed: ${res.status}`);
+    }
+    return res.json() as ReturnType<TrackerAdapter['activateCoterie']>;
+  }
+
+  async listCoteries() {
+    const res = await this.fetchWithTimeout(`${this.baseUrl}/api/coteries`, {
+      method: 'GET',
+      headers: this.readAuthHeaders(),
+    });
+    if (!res.ok) throw new Error(`coteries GET failed: ${res.status}`);
+    const data = await res.json() as { coteries: ReturnType<TrackerAdapter['listCoteries']> extends Promise<infer T> ? T : never };
+    return data.coteries;
   }
 
   private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {

--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -146,6 +146,7 @@ def create_app():
     from .blueprints.character_creator import bp as character_creator_bp
     from .blueprints.cc_admin import bp as cc_admin_bp
     from .blueprints.reports import bp as reports_bp
+    from .blueprints.coteries import bp as coteries_bp
 
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(claims_bp, url_prefix='/claims')
@@ -161,6 +162,7 @@ def create_app():
     app.register_blueprint(character_creator_bp)
     app.register_blueprint(cc_admin_bp)
     app.register_blueprint(reports_bp)
+    app.register_blueprint(coteries_bp, url_prefix='/coteries')
     csrf.exempt(api_bp)
     csrf.exempt(character_creator_bp)
 

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1959,7 +1959,7 @@ def staff_sync():
 @require_bot_scope('read')
 def list_coteries():
     """Return all active coteries with members. Used by wiki sync and bot."""
-    from app.db import Coterie, CoterieMember, DbCharacter
+    from app.db import Coterie
     coteries = Coterie.query.filter_by(status='active').order_by(Coterie.name).all()
     result = []
     for c in coteries:

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1940,3 +1940,84 @@ def staff_sync():
 
     db.session.commit()
     return jsonify({'ok': True, 'processed': len(operations)})
+
+
+# ---------------------------------------------------------------------------
+# Coterie API — for bot and wiki sync
+# ---------------------------------------------------------------------------
+
+@bp.route('/coteries', methods=['GET'])
+@require_bot_scope('read')
+def list_coteries():
+    """Return all active coteries with members. Used by wiki sync and bot."""
+    from app.db import Coterie, CoterieMember, DbCharacter
+    coteries = Coterie.query.filter_by(status='active').order_by(Coterie.name).all()
+    result = []
+    for c in coteries:
+        members = []
+        for m in c.members:
+            char = m.character
+            members.append({
+                'character_name': char.character_name,
+                'clan': char.clan or '',
+                'player_discord_id': char.player_discord or '',
+            })
+        result.append({
+            'id': c.id,
+            'name': c.name,
+            'slug': c.slug,
+            'description': c.description or '',
+            'discord_channel_id': c.discord_channel_id,
+            'members': members,
+        })
+    return jsonify({'coteries': result})
+
+
+@bp.route('/coteries/activate', methods=['POST'])
+@require_bot_scope('write')
+def activate_coterie():
+    """Bot: find a pending coterie by name, set its Discord channel, return data.
+
+    Body: { name: str, discord_channel_id: str }
+    """
+    from app.db import Coterie, db
+    data = request.get_json(silent=True) or {}
+    name = (data.get('name') or '').strip()
+    channel_id = (data.get('discord_channel_id') or '').strip()
+
+    if not name:
+        return jsonify({'error': 'name is required'}), 400
+
+    coterie = Coterie.query.filter(
+        Coterie.name.ilike(name)
+    ).first()
+    if not coterie:
+        return jsonify({'error': f'No coterie found with name "{name}"'}), 404
+    if coterie.status == 'active':
+        return jsonify({'error': f'"{name}" is already active'}), 409
+
+    from datetime import datetime, timezone
+    coterie.status = 'active'
+    if channel_id:
+        coterie.discord_channel_id = channel_id
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    members = [
+        {
+            'character_name': m.character.character_name,
+            'player_discord_id': m.character.player_discord or '',
+            'free_dots': m.free_dots_remaining,
+        }
+        for m in coterie.members
+    ]
+    return jsonify({
+        'ok': True,
+        'coterie': {
+            'id': coterie.id,
+            'name': coterie.name,
+            'slug': coterie.slug,
+            'members': members,
+            'free_pool_total': sum(m.free_dots_remaining for m in coterie.members),
+        },
+    })

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -426,6 +426,15 @@ def blank_background():
     if not _requester_can_access_character(char, effective_discord_id):
         return _forbidden()
 
+    # Donated backgrounds can only be blanked through coterie routes
+    from app.db import DbCharacterBackground as _BgModel
+    _bg_row = _BgModel.query.filter_by(
+        character_name=char.character_name,
+        background_name=background_name,
+    ).first()
+    if _bg_row and _bg_row.donated_coterie_id:
+        return jsonify({'error': 'This background is donated to a coterie — use the coterie blanking route.'}), 409
+
     current_night = _current_open_night()
     if not current_night:
         return jsonify({'error': 'No active open night found'}), 409

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -14,7 +14,6 @@ from app.db import (
     DbCharacter, DbCharacterBackground,
 )
 from app.db_service import DBService
-from app.game_calendar import next_night_after_downtime
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +171,7 @@ def manage(slug: str):
     # All active characters not yet in this coterie
     existing_ids = [m.roster_character_id for m in coterie.members]
     available_chars = DbCharacter.query.filter(
-        DbCharacter.active == True,
+        DbCharacter.active,
         ~DbCharacter.id.in_(existing_ids) if existing_ids else True,
     ).order_by(DbCharacter.character_name).all()
 

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -82,13 +82,20 @@ def view(slug: str):
     ).all()
 
     # Determine if the current player is a member (for blanking controls)
+    from flask import session as _session
     is_member = False
     player_char = None
-    if 'discord_id' in __import__('flask').session:
+    my_backgrounds = []
+    if _session.get('authenticated'):
         discord_id = get_player_discord_id()
         player_char = _get_player_character(discord_id)
         if player_char:
             is_member = bool(_get_coterie_member(coterie, player_char))
+            # Backgrounds the player can donate (not already donated anywhere)
+            my_backgrounds = DbCharacterBackground.query.filter_by(
+                character_name=player_char.character_name,
+                donated_coterie_id=None,
+            ).filter(DbCharacterBackground.dots_total > 0).all()
 
     pool_backgrounds = [a for a in coterie.advantages if a.advantage_type == 'background']
     pool_merits = [a for a in coterie.advantages if a.advantage_type == 'merit']
@@ -103,6 +110,7 @@ def view(slug: str):
         pool_flaws=pool_flaws,
         is_member=is_member,
         player_char=player_char,
+        my_backgrounds=my_backgrounds,
         is_staff_user=is_staff(),
     )
 

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -281,6 +281,10 @@ def add_advantage(slug: str):
         flash('Advantage name is required.', 'danger')
         return redirect(url_for('coteries.view', slug=slug))
 
+    if dots < 1:
+        flash('Dots must be at least 1.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
     if advantage_type not in ('background', 'merit', 'flaw'):
         advantage_type = 'background'
 

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -1,0 +1,433 @@
+"""Coterie management routes — creation, setup, public view, and blanking."""
+
+import logging
+import re
+from datetime import datetime, timezone
+
+from flask import (
+    Blueprint, render_template, request, redirect, url_for, flash, abort,
+)
+
+from app.auth import require_staff, require_login, get_player_discord_id, is_staff
+from app.db import (
+    db, Coterie, CoterieMember, CoterieAdvantage,
+    DbCharacter, DbCharacterBackground,
+)
+from app.db_service import DBService
+from app.game_calendar import next_night_after_downtime
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint('coteries', __name__)
+db_service = DBService()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _slugify(name: str) -> str:
+    slug = name.lower().strip()
+    slug = re.sub(r'[^\w\s-]', '', slug)
+    slug = re.sub(r'[\s_]+', '-', slug)
+    slug = re.sub(r'-+', '-', slug).strip('-')
+    return slug or 'coterie'
+
+
+def _get_coterie_or_404(slug: str) -> Coterie:
+    coterie = Coterie.query.filter_by(slug=slug).first()
+    if not coterie:
+        abort(404)
+    return coterie
+
+
+def _get_player_character(discord_id: str) -> DbCharacter | None:
+    """Return the active approved character for this Discord user, if any."""
+    return DbCharacter.query.filter_by(
+        player_discord=discord_id,
+        active=True,
+    ).first()
+
+
+def _get_coterie_member(coterie: Coterie, char: DbCharacter) -> CoterieMember | None:
+    return CoterieMember.query.filter_by(
+        coterie_id=coterie.id,
+        roster_character_id=char.id,
+    ).first()
+
+
+# ---------------------------------------------------------------------------
+# Public: coterie index
+# ---------------------------------------------------------------------------
+
+@bp.route('/')
+def index():
+    coteries = Coterie.query.filter(
+        Coterie.status.in_(['active', 'pending'])
+    ).order_by(Coterie.name).all()
+    return render_template('coteries/index.html', coteries=coteries)
+
+
+# ---------------------------------------------------------------------------
+# Public: coterie page
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>')
+def view(slug: str):
+    coterie = _get_coterie_or_404(slug)
+
+    # Donated backgrounds: from member PCs, grouped by character
+    donated_bgs = DbCharacterBackground.query.filter_by(
+        donated_coterie_id=coterie.id
+    ).all()
+
+    # Determine if the current player is a member (for blanking controls)
+    is_member = False
+    player_char = None
+    if 'discord_id' in __import__('flask').session:
+        discord_id = get_player_discord_id()
+        player_char = _get_player_character(discord_id)
+        if player_char:
+            is_member = bool(_get_coterie_member(coterie, player_char))
+
+    pool_backgrounds = [a for a in coterie.advantages if a.advantage_type == 'background']
+    pool_merits = [a for a in coterie.advantages if a.advantage_type == 'merit']
+    pool_flaws = [a for a in coterie.advantages if a.advantage_type == 'flaw']
+
+    return render_template(
+        'coteries/view.html',
+        coterie=coterie,
+        donated_bgs=donated_bgs,
+        pool_backgrounds=pool_backgrounds,
+        pool_merits=pool_merits,
+        pool_flaws=pool_flaws,
+        is_member=is_member,
+        player_char=player_char,
+        is_staff_user=is_staff(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Staff: create coterie
+# ---------------------------------------------------------------------------
+
+@bp.route('/new', methods=['GET', 'POST'])
+@require_staff
+def new():
+    if request.method == 'POST':
+        name = request.form.get('name', '').strip()
+        description = request.form.get('description', '').strip()
+        channel_id = request.form.get('discord_channel_id', '').strip() or None
+
+        if not name:
+            flash('Coterie name is required.', 'danger')
+            return render_template('coteries/new.html')
+
+        slug = _slugify(name)
+        # Ensure slug uniqueness
+        base_slug = slug
+        counter = 1
+        while Coterie.query.filter_by(slug=slug).first():
+            slug = f'{base_slug}-{counter}'
+            counter += 1
+
+        if Coterie.query.filter_by(name=name).first():
+            flash(f'A coterie named "{name}" already exists.', 'danger')
+            return render_template('coteries/new.html')
+
+        now = datetime.now(timezone.utc)
+        coterie = Coterie(
+            name=name,
+            slug=slug,
+            description=description,
+            discord_channel_id=channel_id,
+            status='pending',
+            created_at=now,
+            updated_at=now,
+        )
+        db.session.add(coterie)
+        db.session.commit()
+        flash(f'Coterie "{name}" created.', 'success')
+        return redirect(url_for('coteries.manage', slug=coterie.slug))
+
+    return render_template('coteries/new.html')
+
+
+# ---------------------------------------------------------------------------
+# Staff: manage coterie (members + advantages)
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/manage')
+@require_staff
+def manage(slug: str):
+    coterie = _get_coterie_or_404(slug)
+    # All active characters not yet in this coterie
+    existing_ids = [m.roster_character_id for m in coterie.members]
+    available_chars = DbCharacter.query.filter(
+        DbCharacter.active == True,
+        ~DbCharacter.id.in_(existing_ids) if existing_ids else True,
+    ).order_by(DbCharacter.character_name).all()
+
+    return render_template(
+        'coteries/manage.html',
+        coterie=coterie,
+        available_chars=available_chars,
+    )
+
+
+@bp.route('/<slug>/members', methods=['POST'])
+@require_staff
+def add_member(slug: str):
+    coterie = _get_coterie_or_404(slug)
+    char_id = request.form.get('character_id', type=int)
+    char = DbCharacter.query.get(char_id)
+    if not char:
+        flash('Character not found.', 'danger')
+        return redirect(url_for('coteries.manage', slug=slug))
+
+    # One character per coterie per player enforced by DB unique constraint
+    if CoterieMember.query.filter_by(coterie_id=coterie.id, roster_character_id=char.id).first():
+        flash(f'{char.character_name} is already a member.', 'warning')
+        return redirect(url_for('coteries.manage', slug=slug))
+
+    member = CoterieMember(
+        coterie_id=coterie.id,
+        roster_character_id=char.id,
+        free_dots_remaining=2,
+        setup_complete=False,
+        joined_at=datetime.now(timezone.utc),
+    )
+    db.session.add(member)
+    db.session.commit()
+    flash(f'{char.character_name} added to {coterie.name}.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
+@bp.route('/<slug>/members/<int:member_id>/remove', methods=['POST'])
+@require_staff
+def remove_member(slug: str, member_id: int):
+    coterie = _get_coterie_or_404(slug)
+    member = CoterieMember.query.filter_by(id=member_id, coterie_id=coterie.id).first_or_404()
+    char_name = member.character.character_name
+
+    # Un-donate any backgrounds donated by this character to this coterie
+    DbCharacterBackground.query.filter_by(
+        character_name=char_name,
+        donated_coterie_id=coterie.id,
+    ).update({'donated_coterie_id': None})
+
+    db.session.delete(member)
+    db.session.commit()
+    flash(f'{char_name} removed from {coterie.name}.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
+@bp.route('/<slug>/activate', methods=['POST'])
+@require_staff
+def activate(slug: str):
+    coterie = _get_coterie_or_404(slug)
+    coterie.status = 'active'
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'{coterie.name} is now active.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
+@bp.route('/<slug>/edit', methods=['POST'])
+@require_staff
+def edit(slug: str):
+    coterie = _get_coterie_or_404(slug)
+    coterie.description = request.form.get('description', '').strip()
+    channel_id = request.form.get('discord_channel_id', '').strip()
+    if channel_id:
+        coterie.discord_channel_id = channel_id
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash('Coterie updated.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
+# ---------------------------------------------------------------------------
+# Staff/member: add pool advantage
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/advantages', methods=['POST'])
+@require_login
+def add_advantage(slug: str):
+    coterie = _get_coterie_or_404(slug)
+
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+
+    # Must be a member or staff
+    is_member_flag = player_char and bool(_get_coterie_member(coterie, player_char))
+    if not is_member_flag and not is_staff():
+        abort(403)
+
+    name = request.form.get('name', '').strip()
+    dots = request.form.get('dots', 1, type=int)
+    advantage_type = request.form.get('advantage_type', 'background')
+    notes = request.form.get('notes', '').strip()
+
+    if not name:
+        flash('Advantage name is required.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    if advantage_type not in ('background', 'merit', 'flaw'):
+        advantage_type = 'background'
+
+    # Spending from member's free dot allocation (flaws add dots, don't spend them)
+    if advantage_type != 'flaw' and is_member_flag and not is_staff():
+        member = _get_coterie_member(coterie, player_char)
+        if member.free_dots_remaining < dots:
+            flash(
+                f'You only have {member.free_dots_remaining} free dot(s) remaining.',
+                'danger',
+            )
+            return redirect(url_for('coteries.view', slug=slug))
+        member.free_dots_remaining -= dots
+
+    adv = CoterieAdvantage(
+        coterie_id=coterie.id,
+        name=name,
+        dots=dots,
+        advantage_type=advantage_type,
+        notes=notes,
+        added_by=player_char.character_name if player_char else 'staff',
+        created_at=datetime.now(timezone.utc),
+    )
+    db.session.add(adv)
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'Added {name} ({dots} dot{"s" if dots != 1 else ""}) to {coterie.name}.', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+@bp.route('/<slug>/advantages/<int:adv_id>/remove', methods=['POST'])
+@require_staff
+def remove_advantage(slug: str, adv_id: int):
+    coterie = _get_coterie_or_404(slug)
+    adv = CoterieAdvantage.query.filter_by(id=adv_id, coterie_id=coterie.id).first_or_404()
+    db.session.delete(adv)
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'Removed {adv.name} from pool.', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+# ---------------------------------------------------------------------------
+# Member: donate / un-donate background
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/donate/<int:bg_id>', methods=['POST'])
+@require_login
+def donate_background(slug: str, bg_id: int):
+    coterie = _get_coterie_or_404(slug)
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    bg = DbCharacterBackground.query.filter_by(
+        id=bg_id,
+        character_name=player_char.character_name,
+    ).first_or_404()
+
+    if bg.donated_coterie_id:
+        flash(f'{bg.background_name} is already donated to a coterie.', 'warning')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    notes = request.form.get('flaw_notes', '').strip()
+    bg.donated_coterie_id = coterie.id
+    if notes:
+        # Append flaw note to any existing notes via advantage entry
+        flaw_adv = CoterieAdvantage(
+            coterie_id=coterie.id,
+            name=f'{bg.background_name} flaw(s)',
+            dots=0,
+            advantage_type='flaw',
+            notes=notes,
+            added_by=player_char.character_name,
+            created_at=datetime.now(timezone.utc),
+        )
+        db.session.add(flaw_adv)
+
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'{bg.background_name} donated to {coterie.name}.', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+@bp.route('/<slug>/undonate/<int:bg_id>', methods=['POST'])
+@require_login
+def undonate_background(slug: str, bg_id: int):
+    coterie = _get_coterie_or_404(slug)
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    bg = DbCharacterBackground.query.filter_by(
+        id=bg_id,
+        character_name=player_char.character_name,
+        donated_coterie_id=coterie.id,
+    ).first_or_404()
+
+    bg.donated_coterie_id = None
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'{bg.background_name} removed from coterie pool.', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+# ---------------------------------------------------------------------------
+# Member: blank a donated background
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/blank/<int:bg_id>', methods=['POST'])
+@require_login
+def blank_donated_background(slug: str, bg_id: int):
+    coterie = _get_coterie_or_404(slug)
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    bg = DbCharacterBackground.query.filter_by(
+        id=bg_id,
+        donated_coterie_id=coterie.id,
+    ).first_or_404()
+
+    dots = request.form.get('dots', 1, type=int)
+
+    # Find current night
+    from app.db import DbPlayPeriod
+    open_periods = DbPlayPeriod.query.filter_by(submissions_open=True, active=True).all()
+    open_periods.sort(key=lambda p: p.night_number, reverse=True)
+    current_night = open_periods[0] if open_periods else None
+
+    if not current_night:
+        flash('Cannot blank without an active night.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    try:
+        result = db_service.blank_character_background(
+            bg.character_name,
+            bg.background_name,
+            dots,
+            current_night.night_number,
+            updated_by=player_char.character_name,
+        )
+        release = result['release_night_number']
+        flash(
+            f'Blanked {result["dots_blanked_now"]} dot(s) of {result["background_name"]} '
+            f'(owned by {bg.character_name}). Releases at Night {release}.',
+            'success',
+        )
+    except ValueError as exc:
+        flash(str(exc), 'danger')
+
+    return redirect(url_for('coteries.view', slug=slug))

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -309,6 +309,19 @@ def blank_background(name):
         dots = 1
     dots = max(1, min(dots, 10))
 
+    # Donated backgrounds can only be blanked through the coterie page
+    from app.db import DbCharacterBackground as _BgModel
+    _bg_row = _BgModel.query.filter_by(
+        character_name=name,
+        background_name=background_name,
+    ).first()
+    if _bg_row and _bg_row.donated_coterie_id:
+        flash(
+            'This background is donated to a coterie — blank it from the coterie page.',
+            'warning',
+        )
+        return redirect(url_for('player.character', name=name))
+
     all_periods = db_service.get_all_periods()
     open_periods = [p for p in all_periods if p.submissions_open and p.active]
     open_periods.sort(key=lambda p: p.night_number, reverse=True)

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -277,3 +277,67 @@ class DbCharacterBackground(db.Model):
     release_night_number = db.Column(Integer, nullable=True)
     updated_at = db.Column(String(20), nullable=False, default='')
     updated_by = db.Column(String(100), nullable=False, default='')
+    # Set when this background has been donated to a coterie pool.
+    # While donated, only coterie members may blank it (not the PC owner independently).
+    donated_coterie_id = db.Column(Integer, db.ForeignKey('coteries.id'), nullable=True, index=True)
+
+
+class Coterie(db.Model):
+    __tablename__ = 'coteries'
+    __table_args__ = (
+        db.Index('ix_coteries_slug', 'slug'),
+        db.Index('ix_coteries_status', 'status'),
+    )
+    id = db.Column(Integer, primary_key=True)
+    name = db.Column(String(200), nullable=False, unique=True)
+    slug = db.Column(String(200), nullable=False, unique=True)
+    description = db.Column(Text, default='')
+    discord_channel_id = db.Column(String(50), nullable=True)
+    status = db.Column(String(20), nullable=False, default='pending')  # pending | active
+    created_at = db.Column(DateTime, nullable=False,
+                           default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(DateTime, nullable=False,
+                           default=lambda: datetime.now(timezone.utc),
+                           onupdate=lambda: datetime.now(timezone.utc))
+
+    members = db.relationship('CoterieMember', back_populates='coterie',
+                              cascade='all, delete-orphan')
+    advantages = db.relationship('CoterieAdvantage', back_populates='coterie',
+                                 cascade='all, delete-orphan')
+    donated_backgrounds = db.relationship('DbCharacterBackground',
+                                          foreign_keys='DbCharacterBackground.donated_coterie_id',
+                                          backref='coterie')
+
+
+class CoterieMember(db.Model):
+    __tablename__ = 'coterie_members'
+    __table_args__ = (
+        db.UniqueConstraint('coterie_id', 'roster_character_id', name='uq_coterie_member'),
+    )
+    id = db.Column(Integer, primary_key=True)
+    coterie_id = db.Column(Integer, db.ForeignKey('coteries.id'), nullable=False, index=True)
+    roster_character_id = db.Column(Integer, db.ForeignKey('characters.id'), nullable=False)
+    free_dots_remaining = db.Column(Integer, nullable=False, default=2)
+    setup_complete = db.Column(Boolean, nullable=False, default=False)
+    joined_at = db.Column(DateTime, nullable=False,
+                          default=lambda: datetime.now(timezone.utc))
+
+    coterie = db.relationship('Coterie', back_populates='members')
+    character = db.relationship('DbCharacter', backref='coterie_memberships')
+
+
+class CoterieAdvantage(db.Model):
+    """An item in the coterie pool funded by free dots or flaw compensation."""
+    __tablename__ = 'coterie_advantages'
+    id = db.Column(Integer, primary_key=True)
+    coterie_id = db.Column(Integer, db.ForeignKey('coteries.id'), nullable=False, index=True)
+    name = db.Column(String(200), nullable=False)
+    dots = db.Column(Integer, nullable=False, default=1)
+    # background | merit | flaw
+    advantage_type = db.Column(String(20), nullable=False, default='background')
+    notes = db.Column(Text, default='')
+    added_by = db.Column(String(200), nullable=False, default='')
+    created_at = db.Column(DateTime, nullable=False,
+                           default=lambda: datetime.now(timezone.utc))
+
+    coterie = db.relationship('Coterie', back_populates='advantages')

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -281,6 +281,10 @@ class DbCharacterBackground(db.Model):
     # While donated, only coterie members may blank it (not the PC owner independently).
     donated_coterie_id = db.Column(Integer, db.ForeignKey('coteries.id'), nullable=True, index=True)
 
+    @property
+    def dots_available(self) -> int:
+        return max(0, (self.dots_total or 0) - (self.dots_blanked or 0))
+
 
 class Coterie(db.Model):
     __tablename__ = 'coteries'

--- a/apps/web/app/templates/coteries/index.html
+++ b/apps/web/app/templates/coteries/index.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Coteries — MCbN{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <h2 class="mb-0"><i class="bi bi-people-fill text-danger"></i> Coteries</h2>
+    {% if session.get('is_staff') %}
+    <a href="{{ url_for('coteries.new') }}" class="btn btn-sm btn-outline-danger ms-auto">
+        <i class="bi bi-plus-lg"></i> New Coterie
+    </a>
+    {% endif %}
+</div>
+
+{% if coteries %}
+<div class="row g-3">
+    {% for c in coteries %}
+    <div class="col-md-4">
+        <div class="card h-100 {% if c.status == 'pending' %}border-secondary opacity-75{% endif %}">
+            <div class="card-body">
+                <div class="d-flex align-items-start justify-content-between mb-1">
+                    <h5 class="card-title mb-0">
+                        <a href="{{ url_for('coteries.view', slug=c.slug) }}" class="text-decoration-none">{{ c.name }}</a>
+                    </h5>
+                    {% if c.status == 'pending' %}
+                    <span class="badge bg-secondary ms-2">pending</span>
+                    {% endif %}
+                </div>
+                <p class="text-muted small mb-2">{{ c.members | length }} member{{ 's' if c.members | length != 1 }}</p>
+                {% if c.description %}
+                <p class="card-text small text-muted">{{ c.description | truncate(120) }}</p>
+                {% endif %}
+            </div>
+            {% if session.get('is_staff') %}
+            <div class="card-footer">
+                <a href="{{ url_for('coteries.manage', slug=c.slug) }}" class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-gear"></i> Manage
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p class="text-muted">No coteries yet.</p>
+{% endif %}
+{% endblock %}

--- a/apps/web/app/templates/coteries/manage.html
+++ b/apps/web/app/templates/coteries/manage.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% block title %}Manage {{ coterie.name }}{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <a href="{{ url_for('coteries.view', slug=coterie.slug) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-arrow-left"></i></a>
+    <h2 class="mb-0">{{ coterie.name }} <span class="badge {% if coterie.status == 'active' %}bg-success{% else %}bg-secondary{% endif %} fs-6">{{ coterie.status }}</span></h2>
+    {% if coterie.status == 'pending' %}
+    <form method="POST" action="{{ url_for('coteries.activate', slug=coterie.slug) }}" class="ms-auto">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button class="btn btn-sm btn-success">Activate Coterie</button>
+    </form>
+    {% endif %}
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% for cat, msg in messages %}<div class="alert alert-{{ cat }} py-2">{{ msg }}</div>{% endfor %}
+{% endwith %}
+
+<div class="row g-4">
+    <!-- Members -->
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header fw-bold"><i class="bi bi-people"></i> Members ({{ coterie.members | length }})</div>
+            <div class="card-body">
+                {% if coterie.members %}
+                <table class="table table-dark table-sm align-middle mb-3">
+                    <thead><tr><th>Character</th><th>Free Dots</th><th>Setup</th><th></th></tr></thead>
+                    <tbody>
+                    {% for m in coterie.members %}
+                    <tr>
+                        <td>{{ m.character.character_name }}<br>
+                            <small class="text-muted">{{ m.character.clan or '—' }}</small></td>
+                        <td>{{ m.free_dots_remaining }}</td>
+                        <td>{% if m.setup_complete %}<span class="text-success">✓</span>{% else %}<span class="text-muted">—</span>{% endif %}</td>
+                        <td>
+                            <form method="POST" action="{{ url_for('coteries.remove_member', slug=coterie.slug, member_id=m.id) }}"
+                                  onsubmit="return confirm('Remove {{ m.character.character_name }}? Their donated backgrounds will be un-donated.')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button class="btn btn-sm btn-outline-danger">Remove</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+                {% else %}
+                <p class="text-muted small">No members yet.</p>
+                {% endif %}
+
+                <form method="POST" action="{{ url_for('coteries.add_member', slug=coterie.slug) }}" class="d-flex gap-2">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <select name="character_id" class="form-select form-select-sm" required>
+                        <option value="">Add character…</option>
+                        {% for c in available_chars %}
+                        <option value="{{ c.id }}">{{ c.character_name }} ({{ c.clan or '?' }})</option>
+                        {% endfor %}
+                    </select>
+                    <button class="btn btn-sm btn-outline-primary">Add</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit details -->
+    <div class="col-md-6">
+        <div class="card mb-3">
+            <div class="card-header fw-bold"><i class="bi bi-pencil"></i> Edit Details</div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('coteries.edit', slug=coterie.slug) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-2">
+                        <label class="form-label fw-bold small mb-1">Description</label>
+                        <textarea name="description" class="form-control form-control-sm" rows="3">{{ coterie.description or '' }}</textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold small mb-1">Discord Channel ID</label>
+                        <input type="text" name="discord_channel_id" class="form-control form-control-sm font-monospace"
+                               value="{{ coterie.discord_channel_id or '' }}" placeholder="Set by /lasombra coterie create">
+                    </div>
+                    <button class="btn btn-sm btn-outline-secondary">Save</button>
+                </form>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header fw-bold small text-muted">Pool Summary</div>
+            <div class="card-body small text-muted">
+                <div>Free pool: {{ coterie.members | sum(attribute='free_dots_remaining') }} dot(s) remaining across {{ coterie.members | length }} member(s)</div>
+                <div>Pool items: {{ coterie.advantages | length }}</div>
+                <a href="{{ url_for('coteries.view', slug=coterie.slug) }}" class="btn btn-sm btn-outline-secondary mt-2">View Public Page</a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/apps/web/app/templates/coteries/new.html
+++ b/apps/web/app/templates/coteries/new.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}New Coterie{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-4">
+    <a href="{{ url_for('coteries.index') }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-arrow-left"></i></a>
+    <h2 class="mb-0">New Coterie</h2>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% for cat, msg in messages %}<div class="alert alert-{{ cat }} py-2">{{ msg }}</div>{% endfor %}
+{% endwith %}
+
+<div class="card" style="max-width:540px;">
+    <div class="card-body">
+        <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="mb-3">
+                <label class="form-label fw-bold">Coterie Name</label>
+                <input type="text" name="name" class="form-control" required placeholder="e.g. The Brood">
+            </div>
+            <div class="mb-3">
+                <label class="form-label fw-bold">Description <span class="text-muted fw-normal">(optional)</span></label>
+                <textarea name="description" class="form-control" rows="3"></textarea>
+            </div>
+            <div class="mb-4">
+                <label class="form-label fw-bold">Discord Channel ID <span class="text-muted fw-normal">(optional — set by bot)</span></label>
+                <input type="text" name="discord_channel_id" class="form-control font-monospace" placeholder="e.g. 1194085845653786654">
+            </div>
+            <button class="btn btn-danger">Create Coterie</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/apps/web/app/templates/coteries/view.html
+++ b/apps/web/app/templates/coteries/view.html
@@ -1,0 +1,226 @@
+{% extends "base.html" %}
+{% block title %}{{ coterie.name }} — Coterie{% endblock %}
+{% block content %}
+
+<div class="d-flex align-items-center gap-3 mb-1 flex-wrap">
+    <a href="{{ url_for('coteries.index') }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-arrow-left"></i></a>
+    <h2 class="mb-0">{{ coterie.name }}</h2>
+    {% if is_staff_user %}
+    <a href="{{ url_for('coteries.manage', slug=coterie.slug) }}" class="btn btn-sm btn-outline-secondary ms-auto">
+        <i class="bi bi-gear"></i> Manage
+    </a>
+    {% endif %}
+</div>
+
+{% if coterie.status == 'pending' %}
+<div class="alert alert-secondary py-2 mb-3">This coterie is pending setup.</div>
+{% endif %}
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% for cat, msg in messages %}<div class="alert alert-{{ cat }} py-2">{{ msg }}</div>{% endfor %}
+{% endwith %}
+
+{% if coterie.description %}
+<p class="text-muted mb-4">{{ coterie.description }}</p>
+{% endif %}
+
+<div class="row g-4">
+
+    <!-- Members -->
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header fw-bold"><i class="bi bi-people"></i> Members</div>
+            <ul class="list-group list-group-flush">
+                {% for m in coterie.members %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <div>
+                        <a href="{{ url_for('player.character', name=m.character.character_name) }}"
+                           class="text-decoration-none">{{ m.character.character_name }}</a>
+                        <br><small class="text-muted">{{ m.character.clan or '—' }}</small>
+                    </div>
+                    {% if is_member and player_char and player_char.id == m.roster_character_id %}
+                    <span class="badge bg-secondary">you</span>
+                    {% endif %}
+                </li>
+                {% else %}
+                <li class="list-group-item text-muted">No members yet.</li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+
+    <!-- Pool advantages -->
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header fw-bold"><i class="bi bi-gem"></i> Coterie Pool</div>
+            <div class="card-body">
+                {% if pool_backgrounds %}
+                <div class="sheet-group-label">Backgrounds</div>
+                {% for a in pool_backgrounds %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ a.name }}</span>
+                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= a.dots %}filled{% endif %}"></span>{% endfor %}</span>
+                    {% if is_staff_user %}
+                    <form method="POST" action="{{ url_for('coteries.remove_advantage', slug=coterie.slug, adv_id=a.id) }}" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button class="btn btn-link btn-sm p-0 text-danger ms-1" title="Remove">×</button>
+                    </form>
+                    {% endif %}
+                </div>
+                {% if a.notes %}<div class="sheet-specialty-row">{{ a.notes }}</div>{% endif %}
+                {% endfor %}
+                {% endif %}
+
+                {% if pool_merits %}
+                <div class="sheet-group-label {% if pool_backgrounds %}mt-3{% endif %}">Merits</div>
+                {% for a in pool_merits %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ a.name }}</span>
+                    <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= a.dots %}filled{% endif %}"></span>{% endfor %}</span>
+                    {% if is_staff_user %}
+                    <form method="POST" action="{{ url_for('coteries.remove_advantage', slug=coterie.slug, adv_id=a.id) }}" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button class="btn btn-link btn-sm p-0 text-danger ms-1" title="Remove">×</button>
+                    </form>
+                    {% endif %}
+                </div>
+                {% if a.notes %}<div class="sheet-specialty-row">{{ a.notes }}</div>{% endif %}
+                {% endfor %}
+                {% endif %}
+
+                {% if pool_flaws %}
+                <div class="sheet-group-label {% if pool_backgrounds or pool_merits %}mt-3{% endif %}">Flaws</div>
+                {% for a in pool_flaws %}
+                <div class="sheet-trait-row">
+                    <span class="sheet-trait-name">{{ a.name }}</span>
+                    {% if a.dots %}<span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= a.dots %}filled{% endif %}"></span>{% endfor %}</span>{% endif %}
+                    {% if is_staff_user %}
+                    <form method="POST" action="{{ url_for('coteries.remove_advantage', slug=coterie.slug, adv_id=a.id) }}" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button class="btn btn-link btn-sm p-0 text-danger ms-1" title="Remove">×</button>
+                    </form>
+                    {% endif %}
+                </div>
+                {% if a.notes %}<div class="sheet-specialty-row">{{ a.notes }}</div>{% endif %}
+                {% endfor %}
+                {% endif %}
+
+                {% if not pool_backgrounds and not pool_merits and not pool_flaws %}
+                <p class="text-muted small mb-0">No pool items yet.</p>
+                {% endif %}
+
+                <!-- Add advantage (members + staff) -->
+                {% if is_member or is_staff_user %}
+                {% set my_member = coterie.members | selectattr('roster_character_id', 'equalto', player_char.id if player_char else -1) | list %}
+                {% set dots_left = (my_member[0].free_dots_remaining if my_member else 0) if not is_staff_user else 99 %}
+                <hr class="my-3">
+                <p class="small text-muted mb-2">
+                    {% if not is_staff_user %}Your free dots remaining: <strong>{{ dots_left }}</strong>{% else %}Staff: add pool item{% endif %}
+                </p>
+                <form method="POST" action="{{ url_for('coteries.add_advantage', slug=coterie.slug) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-2">
+                        <input type="text" name="name" class="form-control form-control-sm" placeholder="Name (e.g. Haven)" required>
+                    </div>
+                    <div class="d-flex gap-2 mb-2">
+                        <input type="number" name="dots" class="form-control form-control-sm" style="width:80px" value="1" min="1" max="5">
+                        <select name="advantage_type" class="form-select form-select-sm">
+                            <option value="background">Background</option>
+                            <option value="merit">Merit</option>
+                            <option value="flaw">Flaw</option>
+                        </select>
+                    </div>
+                    <div class="mb-2">
+                        <input type="text" name="notes" class="form-control form-control-sm" placeholder="Notes (optional)">
+                    </div>
+                    <button class="btn btn-sm btn-outline-primary w-100">Add to Pool</button>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <!-- Donated backgrounds -->
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header fw-bold"><i class="bi bi-share"></i> Donated Backgrounds</div>
+            <div class="card-body">
+                {% if donated_bgs %}
+                {% for bg in donated_bgs %}
+                <div class="sheet-trait-row">
+                    <span>
+                        <span class="sheet-trait-name">{{ bg.background_name }}</span>
+                        <br><small class="text-muted">{{ bg.character_name }}</small>
+                    </span>
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="dot-pips">{% for i in range(1,6) %}<span class="dot-pip {% if i <= bg.dots_total %}filled{% endif %}"></span>{% endfor %}</span>
+                        {% if bg.dots_blanked > 0 %}
+                        <span class="badge bg-warning text-dark" title="Blanked until Night {{ bg.release_night_number }}">
+                            {{ bg.dots_blanked }} blanked
+                        </span>
+                        {% endif %}
+                    </div>
+                </div>
+                <!-- Blank control (any member) -->
+                {% if is_member and bg.dots_available > 0 %}
+                <form method="POST" action="{{ url_for('coteries.blank_donated_background', slug=coterie.slug, bg_id=bg.id) }}"
+                      class="d-flex gap-2 mt-1 mb-2">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="number" name="dots" class="form-control form-control-sm" style="width:70px"
+                           value="1" min="1" max="{{ bg.dots_available }}">
+                    <button class="btn btn-sm btn-outline-warning">Blank</button>
+                </form>
+                {% endif %}
+                <!-- Un-donate control (owner only) -->
+                {% if player_char and player_char.character_name == bg.character_name %}
+                <form method="POST" action="{{ url_for('coteries.undonate_background', slug=coterie.slug, bg_id=bg.id) }}"
+                      class="mb-2" onsubmit="return confirm('Remove {{ bg.background_name }} from the coterie pool?')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button class="btn btn-sm btn-outline-secondary">Un-donate</button>
+                </form>
+                {% endif %}
+                {% endfor %}
+                {% else %}
+                <p class="text-muted small mb-3">No donated backgrounds yet.</p>
+                {% endif %}
+
+                <!-- Donate form (own backgrounds) -->
+                {% if is_member and player_char %}
+                {% set my_bgs = player_char | attr('character_name') %}
+                <hr class="my-3">
+                <p class="small text-muted mb-2">Donate one of your backgrounds:</p>
+                {% set available_bgs = [] %}
+                {% for bg in donated_bgs %}{% endfor %}{# loop used below #}
+                {# fetch player bgs via context — rendered from blueprint #}
+                {% if my_backgrounds %}
+                <form method="POST" action="{{ url_for('coteries.donate_background', slug=coterie.slug, bg_id=0) }}"
+                      id="donate-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <select name="_bg_id" class="form-select form-select-sm mb-2" id="donate-bg-select" required>
+                        <option value="">Select background…</option>
+                        {% for bg in my_backgrounds %}
+                        <option value="{{ bg.id }}">{{ bg.background_name }} ({{ bg.dots_total }}●{% if bg.dots_blanked %}, {{ bg.dots_blanked }} blanked{% endif %})</option>
+                        {% endfor %}
+                    </select>
+                    <input type="text" name="flaw_notes" class="form-control form-control-sm mb-2"
+                           placeholder="Flaw notes (e.g. Haven - Creepy, •)">
+                    <button class="btn btn-sm btn-outline-secondary w-100">Donate to Coterie</button>
+                </form>
+                <script>
+                document.getElementById('donate-form').addEventListener('submit', function(e) {
+                    const sel = document.getElementById('donate-bg-select');
+                    const bgId = sel.value;
+                    if (!bgId) { e.preventDefault(); return; }
+                    this.action = this.action.replace('/0', '/' + bgId);
+                });
+                </script>
+                {% else %}
+                <p class="text-muted small">No undated backgrounds to donate.</p>
+                {% endif %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/apps/web/migrations/versions/1c45d20d519a_add_coterie_tables_and_donated_coterie_.py
+++ b/apps/web/migrations/versions/1c45d20d519a_add_coterie_tables_and_donated_coterie_.py
@@ -1,0 +1,80 @@
+"""add coterie tables and donated_coterie_id to character_backgrounds
+
+Revision ID: 1c45d20d519a
+Revises: a4d1e8f2b7c3
+Create Date: 2026-06-04 12:21:08.236943
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1c45d20d519a'
+down_revision = 'a4d1e8f2b7c3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'coteries',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(200), nullable=False, unique=True),
+        sa.Column('slug', sa.String(200), nullable=False, unique=True),
+        sa.Column('description', sa.Text(), nullable=True, default=''),
+        sa.Column('discord_channel_id', sa.String(50), nullable=True),
+        sa.Column('status', sa.String(20), nullable=False, server_default='pending'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('ix_coteries_slug', 'coteries', ['slug'])
+    op.create_index('ix_coteries_status', 'coteries', ['status'])
+
+    op.create_table(
+        'coterie_members',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('coterie_id', sa.Integer(), sa.ForeignKey('coteries.id'), nullable=False),
+        sa.Column('roster_character_id', sa.Integer(), sa.ForeignKey('characters.id'), nullable=False),
+        sa.Column('free_dots_remaining', sa.Integer(), nullable=False, server_default='2'),
+        sa.Column('setup_complete', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('joined_at', sa.DateTime(), nullable=False),
+        sa.UniqueConstraint('coterie_id', 'roster_character_id', name='uq_coterie_member'),
+    )
+    op.create_index('ix_coterie_members_coterie_id', 'coterie_members', ['coterie_id'])
+
+    op.create_table(
+        'coterie_advantages',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('coterie_id', sa.Integer(), sa.ForeignKey('coteries.id'), nullable=False),
+        sa.Column('name', sa.String(200), nullable=False),
+        sa.Column('dots', sa.Integer(), nullable=False, server_default='1'),
+        sa.Column('advantage_type', sa.String(20), nullable=False, server_default='background'),
+        sa.Column('notes', sa.Text(), nullable=True, default=''),
+        sa.Column('added_by', sa.String(200), nullable=False, server_default=''),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('ix_coterie_advantages_coterie_id', 'coterie_advantages', ['coterie_id'])
+
+    with op.batch_alter_table('character_backgrounds', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('donated_coterie_id', sa.Integer(), nullable=True))
+        batch_op.create_index('ix_character_backgrounds_donated_coterie_id', ['donated_coterie_id'], unique=False)
+        batch_op.create_foreign_key(
+            'fk_character_backgrounds_donated_coterie_id',
+            'coteries', ['donated_coterie_id'], ['id'],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('character_backgrounds', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_character_backgrounds_donated_coterie_id', type_='foreignkey')
+        batch_op.drop_index('ix_character_backgrounds_donated_coterie_id')
+        batch_op.drop_column('donated_coterie_id')
+
+    op.drop_index('ix_coterie_advantages_coterie_id', table_name='coterie_advantages')
+    op.drop_table('coterie_advantages')
+    op.drop_index('ix_coterie_members_coterie_id', table_name='coterie_members')
+    op.drop_table('coterie_members')
+    op.drop_index('ix_coteries_status', table_name='coteries')
+    op.drop_index('ix_coteries_slug', table_name='coteries')
+    op.drop_table('coteries')


### PR DESCRIPTION
Closes #222

## What's in this PR

### Web
- **DB**: 3 new tables (`coteries`, `coterie_members`, `coterie_advantages`) + `donated_coterie_id` on `character_backgrounds`; migration `1c45d20d519a`
- **`/coteries/`** — public index of all active/pending coteries
- **`/coteries/<slug>`** — public coterie page: members, pool advantages (backgrounds/merits/flaws), donated backgrounds with blanking controls
- **`/coteries/new`** — staff: create pending coterie (name, description, optional channel ID)
- **`/coteries/<slug>/manage`** — staff: add/remove members, edit description, activate
- **API `GET /api/coteries`** — returns all active coteries with members (for wiki sync + bot)
- **API `POST /api/coteries/activate`** — bot activates a pending coterie by name, sets Discord channel ID

### Bot
- **`/lasombra coterie-create [name]`** (staff only): looks up pending coterie by name, activates it with the ticket channel ID, posts embed with member list, pool size, setup link, and pings all members
- `adapter.ts`: `activateCoterie()`, `listCoteries()` methods

### Wiki sync
- `discord-wiki-sync.ts`: replaces hardcoded `COTERIE_MEMBERS` static map with live `GET /api/coteries` call — coterie wiki pages now sourced from DB
- `CHAR_TO_COTERIE` lookup built from DB data at sync time
- Coterie pages include description + clan per member

## Workflow

1. Player creates coterie ticket → Ticket Tool creates channel in Character Projects
2. Staff creates pending coterie on `/coteries/new`, adds members via `/coteries/<slug>/manage`
3. Staff runs `/lasombra coterie-create [coterie name]` in the ticket channel → bot activates coterie, posts embed with link
4. Players visit `/coteries/<slug>`, spend free dots (2 per member), donate backgrounds
5. Any coterie member can blank donated backgrounds from the coterie page

## Notes
- Background flaw linking tracked in #264 (players manually add flaw notes during donation for now)
- Specialties management tracked in #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)