### PR TITLE
feat: add convictions and Chronicle Tenets to character sheet

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -736,6 +736,15 @@ def _map_rod_to_cc(rod: dict) -> dict:
             if isinstance(rod.get('touchstones'), str)
             else (rod.get('touchstones') or [])
         ),
+        'convictions': (
+            [c.strip() for c in rod['convictions'].split(',') if c.strip()]
+            if isinstance(rod.get('convictions'), str)
+            else [
+                (c if isinstance(c, str) else c.get('description', c.get('name', '')))
+                for c in (rod.get('convictions') or [])
+                if c
+            ]
+        ),
         'age_category': 'ancilla',  # existing characters are treated as ancilla
     }
 

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -703,7 +703,12 @@ def _normalize_sheet_data(data: dict) -> dict:
     - CC format: skillSpecialties: [{skill, name}, ...]
     - RoD import: skill_specialties: {skill: [name, ...]}
 
-    Always produces skill_specialties in dict form so templates have one format to handle.
+    Unifies the two conviction formats:
+    - CC format: convictions embedded on each touchstone as t.conviction
+    - RoD import: top-level convictions array
+
+    Always produces skill_specialties (dict) and convictions (list) so
+    templates have one format to handle.
     """
     if 'skill_specialties' not in data:
         cc_specs = data.get('skillSpecialties') or []
@@ -716,6 +721,16 @@ def _normalize_sheet_data(data: dict) -> dict:
                     merged.setdefault(skill, []).append(name)
         if merged:
             data['skill_specialties'] = merged
+
+    if 'convictions' not in data:
+        conv_from_ts = [
+            t['conviction']
+            for t in (data.get('touchstones') or [])
+            if isinstance(t, dict) and t.get('conviction')
+        ]
+        if conv_from_ts:
+            data['convictions'] = conv_from_ts
+
     return data
 
 

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -275,14 +275,29 @@
             {% endif %}
         </div>
         {% set _touch = sheet_data.get('touchstones', []) %}
+        {% set _conv = sheet_data.get('convictions', []) %}
         {% if _touch %}
         <div>
-            <div class="sheet-group-label">Touchstones &amp; Convictions</div>
+            <div class="sheet-group-label">Touchstones</div>
             {% for t in _touch %}
             <div class="sheet-trait-name">{{ t if t is string else t.get('description', t.get('name','')) }}</div>
             {% endfor %}
         </div>
         {% endif %}
+        {% if _conv %}
+        <div class="mt-2">
+            <div class="sheet-group-label">Convictions</div>
+            {% for c in _conv %}
+            {% if c %}<div class="sheet-trait-name">{{ c }}</div>{% endif %}
+            {% endfor %}
+        </div>
+        {% endif %}
+        <div class="mt-2">
+            <div class="sheet-group-label">Chronicle Tenets</div>
+            <div class="sheet-trait-name">Thou shalt not kill.</div>
+            <div class="sheet-trait-name">Thou shall not harm children.</div>
+            <div class="sheet-trait-name">Thou shall not engage in excessive cruelty.</div>
+        </div>
 
     </div>
     </div><!-- /#inline-sheet -->

--- a/apps/web/app/templates/player/sheet.html
+++ b/apps/web/app/templates/player/sheet.html
@@ -38,6 +38,7 @@
 {% set _hp  = sheet_data.get('maxHealth', 0) %}
 {% set _gen = sheet_data.get('generation', 0) %}
 {% set _touch = sheet_data.get('touchstones', []) %}
+{% set _conv = sheet_data.get('convictions', []) %}
 {% set _ls  = sheet_data.get('loresheet_purchases', []) %}
 {% set _spec = sheet_data.get('skill_specialties', {}) %}
 
@@ -252,21 +253,36 @@
 
 </div>
 
-{% if _touch %}
+{% if _touch or _conv %}
 <div class="mt-3">
-    <div class="sheet-group-label">Touchstones &amp; Convictions</div>
-    <div class="row g-2">
-        {% for t in _touch %}
-        {% set txt = t if t is string else t.get('description', t.get('name', '')) %}
-        {% if txt %}
-        <div class="col-md-4 col-lg-3">
-            <div class="sheet-trait-name">{{ txt }}</div>
+    <div class="row g-4">
+        {% if _touch %}
+        <div class="col-md-6">
+            <div class="sheet-group-label">Touchstones</div>
+            {% for t in _touch %}
+            {% set txt = t if t is string else t.get('description', t.get('name', '')) %}
+            {% if txt %}<div class="sheet-trait-name">{{ txt }}</div>{% endif %}
+            {% endfor %}
         </div>
         {% endif %}
-        {% endfor %}
+        {% if _conv %}
+        <div class="col-md-6">
+            <div class="sheet-group-label">Convictions</div>
+            {% for c in _conv %}
+            {% if c %}<div class="sheet-trait-name">{{ c }}</div>{% endif %}
+            {% endfor %}
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endif %}
+
+<div class="mt-4">
+    <div class="sheet-group-label">Chronicle Tenets</div>
+    <div class="sheet-trait-name">Thou shalt not kill.</div>
+    <div class="sheet-trait-name">Thou shall not harm children.</div>
+    <div class="sheet-trait-name">Thou shall not engage in excessive cruelty.</div>
+</div>
 
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Convictions**: mapped from RoD export (`convictions` field, handles string or array format) and displayed in a separate column alongside Touchstones on both the full sheet and inline sheet views
- **Chronicle Tenets**: static section added to the bottom of every sheet (full and inline): _Thou shalt not kill / Thou shall not harm children / Thou shall not engage in excessive cruelty_
- Splits the old "Touchstones & Convictions" label into two distinct labeled sections

## Test plan
- [ ] Import a RoD sheet with convictions — verify they appear under Convictions, touchstones under Touchstones
- [ ] Sheet with no convictions — Touchstones still shows, no empty Convictions section
- [ ] Chronicle Tenets appear on every sheet regardless of data
- [ ] Inline sheet (XP Tracker page) shows same sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)