### PR TITLE
feat: staff delete for character drafts

### DIFF
--- a/apps/web/app/blueprints/cc_admin.py
+++ b/apps/web/app/blueprints/cc_admin.py
@@ -277,6 +277,36 @@ def draft_request_revision(draft_id):
     return redirect(url_for('cc_admin.draft_list'))
 
 
+@bp.route('/cc-admin/drafts/<draft_id>/delete', methods=['POST'])
+@require_staff
+def draft_delete(draft_id):
+    """Permanently delete a character draft and optionally its roster entry."""
+    draft = db.session.get(CharacterDraft, draft_id)
+    if draft is None:
+        abort(404)
+
+    char_name = draft.character_name or str(draft_id)
+    also_delete_roster = request.form.get('delete_roster') == '1'
+
+    if also_delete_roster and draft.roster_character_id:
+        roster_row = db.session.get(DbCharacter, draft.roster_character_id)
+        if roster_row:
+            db.session.delete(roster_row)
+
+    db.session.delete(draft)
+    db.session.commit()
+
+    actor = session.get('discord_name') or 'staff'
+    db_service.log_action(
+        staff_user=actor,
+        action_type='draft_deleted',
+        target=char_name,
+        details=f'Draft {draft_id} deleted' + (' + roster entry' if also_delete_roster else ''),
+    )
+    flash(f'Draft for "{char_name}" deleted.', 'success')
+    return redirect(url_for('cc_admin.draft_list'))
+
+
 @bp.route('/cc-admin/loresheets/<loresheet_id>/unban', methods=['POST'])
 @require_staff
 def loresheet_unban(loresheet_id):

--- a/apps/web/app/blueprints/cc_admin.py
+++ b/apps/web/app/blueprints/cc_admin.py
@@ -291,6 +291,13 @@ def draft_delete(draft_id):
     if also_delete_roster and draft.roster_character_id:
         roster_row = db.session.get(DbCharacter, draft.roster_character_id)
         if roster_row:
+            if roster_row.active:
+                flash('Deactivate the character on the roster before deleting.', 'danger')
+                return redirect(url_for('cc_admin.draft_review', draft_id=draft_id))
+            confirm = request.form.get('confirm_name', '').strip()
+            if confirm.lower() != (roster_row.character_name or '').lower():
+                flash('Confirmation name did not match — roster entry was NOT deleted.', 'danger')
+                return redirect(url_for('cc_admin.draft_review', draft_id=draft_id))
             db.session.delete(roster_row)
 
     db.session.delete(draft)

--- a/apps/web/app/templates/cc_admin/draft_review.html
+++ b/apps/web/app/templates/cc_admin/draft_review.html
@@ -317,11 +317,17 @@
             onsubmit="return confirm('Permanently delete this draft? This cannot be undone.')">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         {% if draft.roster_character_id %}
-        <div class="form-check mb-3">
-          <input class="form-check-input" type="checkbox" name="delete_roster" value="1" id="delete_roster">
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" name="delete_roster" value="1" id="delete_roster"
+                 onchange="document.getElementById('roster-confirm').classList.toggle('d-none', !this.checked)">
           <label class="form-check-label text-danger" for="delete_roster">
             Also delete linked roster entry ({{ draft.character_name }})
           </label>
+        </div>
+        <div id="roster-confirm" class="d-none mb-3 ms-4">
+          <div class="text-muted small mb-1">Character must be inactive. Type the character name to confirm:</div>
+          <input type="text" name="confirm_name" class="form-control form-control-sm" style="max-width:260px"
+                 placeholder="{{ draft.character_name }}">
         </div>
         {% endif %}
         <button type="submit" class="btn btn-outline-danger btn-sm">

--- a/apps/web/app/templates/cc_admin/draft_review.html
+++ b/apps/web/app/templates/cc_admin/draft_review.html
@@ -309,5 +309,27 @@
   </div>
   {% endif %}
 
+  {# ── Danger zone ── #}
+  <div class="card mb-4 border-danger">
+    <div class="card-header py-2 fw-semibold text-danger">Danger Zone</div>
+    <div class="card-body">
+      <form method="post" action="{{ url_for('cc_admin.draft_delete', draft_id=draft.id) }}"
+            onsubmit="return confirm('Permanently delete this draft? This cannot be undone.')">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% if draft.roster_character_id %}
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" name="delete_roster" value="1" id="delete_roster">
+          <label class="form-check-label text-danger" for="delete_roster">
+            Also delete linked roster entry ({{ draft.character_name }})
+          </label>
+        </div>
+        {% endif %}
+        <button type="submit" class="btn btn-outline-danger btn-sm">
+          <i class="bi bi-trash me-1"></i> Delete Draft
+        </button>
+      </form>
+    </div>
+  </div>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Adds a **Danger Zone** section to the draft review page (`/cc-admin/drafts/<id>`) with a **Delete Draft** button, visible for all draft statuses.

- Permanently deletes the `CharacterDraft` record
- Optional checkbox to also delete the linked `DbCharacter` roster entry
- Logs the deletion to the audit trail
- Redirects to the draft list after deletion

## Test plan
- [ ] Open any draft in cc-admin, confirm Danger Zone section appears at bottom
- [ ] Delete a draft without the roster checkbox — draft gone, roster entry intact
- [ ] Delete a draft with the roster checkbox — both gone
- [ ] Confirm audit log entry created

🤖 Generated with [Claude Code](https://claude.com/claude-code)