### PR TITLE
Allow mortals and Duskborn to claim XP for daytime activity

### DIFF
--- a/apps/bot/src/commands/xp.ts
+++ b/apps/bot/src/commands/xp.ts
@@ -21,7 +21,7 @@ import { calculateXpCost } from '../xpRules';
 
 const CLAIM_CATEGORY_CHOICES = [
   { name: 'Posted at least once', value: 'posted_once' },
-  { name: 'Hunting / Awakening scene', value: 'hunting_awakening' },
+  { name: 'Hunting / Awakening scene or Daytime post', value: 'hunting_awakening' },
   { name: 'Scene with another character', value: 'scene_with_another' },
   { name: 'Conflict with another character', value: 'conflict' },
   { name: 'Combat with another character', value: 'combat' },

--- a/apps/bot/src/interactiveClaimWizard.ts
+++ b/apps/bot/src/interactiveClaimWizard.ts
@@ -18,7 +18,7 @@ import { parseMessageLink } from './utils/linkValidator';
 
 const CATEGORY_OPTIONS = [
   { key: 'posted_once', label: 'Posted at least once' },
-  { key: 'hunting_awakening', label: 'Hunting / Awakening scene' },
+  { key: 'hunting_awakening', label: 'Hunting / Awakening scene or Daytime post' },
   { key: 'scene_with_another', label: 'Scene with another character' },
   { key: 'conflict', label: 'Conflict with another character' },
   { key: 'combat', label: 'Combat with another character' },

--- a/apps/web/app/models.py
+++ b/apps/web/app/models.py
@@ -79,7 +79,7 @@ class XPClaim:
                 'link': self.posted_once_link,
             },
             {
-                'name': 'Hunting / Awakening scene',
+                'name': 'Hunting / Awakening scene or Daytime post',
                 'claimed': self.hunting_awakening,
                 'link': self.hunting_awakening_link,
             },

--- a/apps/web/app/templates/player/amend_claim.html
+++ b/apps/web/app/templates/player/amend_claim.html
@@ -41,7 +41,7 @@
 
                 {% set cats = [
                     ('posted_once', 'Posted at least once during this play period', claim.posted_once, claim.posted_once_link),
-                    ('hunting_awakening', 'Posted a Hunting and/or Awakening scene', claim.hunting_awakening, claim.hunting_awakening_link),
+                    ('hunting_awakening', 'Posted a Hunting and/or Awakening scene or posted during Daytime', claim.hunting_awakening, claim.hunting_awakening_link),
                     ('scene_with_another', 'Participated in a scene with another character', claim.scene_with_another, claim.scene_with_another_link),
                     ('conflict', 'Engaged in conflict with another character', claim.conflict, claim.conflict_link),
                     ('combat', 'Engaged in combat with another character', claim.combat, claim.combat_link),

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -457,7 +457,7 @@
 
                             {% set cats = [
                                 ('posted_once', 'Posted at least once during this play period'),
-                                ('hunting_awakening', 'Posted a Hunting and/or Awakening scene'),
+                                ('hunting_awakening', 'Posted a Hunting and/or Awakening scene or posted during Daytime'),
                                 ('scene_with_another', 'Participated in a scene with another character'),
                                 ('conflict', 'Engaged in conflict with another character'),
                                 ('combat', 'Engaged in combat with another character'),


### PR DESCRIPTION
## Summary

- Expands the **Hunting / Awakening scene** XP claim category to include daytime posts
- Mortals and Duskborn (Thin-Bloods) can now tick this box when they post during the day — they can't hunt or have an awakening scene, so this was the only category they had no way to fulfill
- Label-only change; the underlying field key `hunting_awakening` is unchanged, no DB migration needed

## Updated labels

| Surface | New label |
|---|---|
| Character page XP claim form | *Posted a Hunting and/or Awakening scene or posted during Daytime* |
| Amend claim form | *Posted a Hunting and/or Awakening scene or posted during Daytime* |
| models.py (approval history) | *Hunting / Awakening scene or Daytime post* |
| Bot interactive claim wizard | *Hunting / Awakening scene or Daytime post* |
| `/xp` command dropdown | *Hunting / Awakening scene or Daytime post* |

## Test plan
- [ ] Submit an XP claim as a mortal/Duskborn character and confirm the updated label appears on the claim form
- [ ] Check `/xp claim` in Discord — confirm updated dropdown label
- [ ] Approve a claim and verify the history entry shows the updated name

🤖 Generated with [Claude Code](https://claude.com/claude-code)