### PR TITLE
Bot: sync DB staff roles into testerDiscordIds on config sync

### DIFF
--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -196,6 +196,8 @@ export const config = {
   testGuildId: env.TEST_GUILD_ID,
   testRequesterDiscordId: env.TEST_REQUESTER_DISCORD_ID,
   testerDiscordIds: parseCsvIds(env.BOT_TESTER_IDS),
+  /** Snapshot of IDs from BOT_TESTER_IDS env var; used to recompute testerDiscordIds on each config sync. */
+  envTesterDiscordIds: parseCsvIds(env.BOT_TESTER_IDS),
   webAppBaseUrl: env.WEB_APP_BASE_URL,
   webAppApiToken: env.WEB_APP_API_TOKEN,
   webAppApiReadToken: env.WEB_APP_API_READ_TOKEN,

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -33,6 +33,7 @@ export interface BotConfigResponse {
   claimReminderIntervalMs: number | null;
   announcementsChannelId: string | null;
   ccTicketCategoryIds: string | null;
+  staffDiscordIds: string[] | null;
 }
 
 export interface TrackerAdapter {

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -35,8 +35,10 @@ export class ConfigSyncWorker {
       liveConfig.ccTicketCategoryIds = cfg.ccTicketCategoryIds !== null
         ? new Set(cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.ccTicketCategoryIds);
-      // Merge DB-configured staff into testerDiscordIds so dashboard role assignments
-      // are respected by local bot auth checks (e.g. /lasombra approve)
+      // Rebuild testerDiscordIds each sync so removals are respected:
+      // start from the env-seeded snapshot, then union in current DB staff.
+      config.testerDiscordIds = new Set(config.envTesterDiscordIds);
+      if (config.testRequesterDiscordId) config.testerDiscordIds.add(config.testRequesterDiscordId);
       if (Array.isArray(cfg.staffDiscordIds)) {
         for (const id of cfg.staffDiscordIds) {
           if (id) config.testerDiscordIds.add(id);

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -35,6 +35,13 @@ export class ConfigSyncWorker {
       liveConfig.ccTicketCategoryIds = cfg.ccTicketCategoryIds !== null
         ? new Set(cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.ccTicketCategoryIds);
+      // Merge DB-configured staff into testerDiscordIds so dashboard role assignments
+      // are respected by local bot auth checks (e.g. /lasombra approve)
+      if (Array.isArray(cfg.staffDiscordIds)) {
+        for (const id of cfg.staffDiscordIds) {
+          if (id) config.testerDiscordIds.add(id);
+        }
+      }
       logEvent('debug', 'config_sync_done', { liveConfig });
 
       if (cfg.restartRequested) {

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -804,6 +804,9 @@ def bot_config():
     for db_key, api_key in STR_KEYS.items():
         record = records.get(db_key)
         result[api_key] = record.value.strip() if record else None
+    # Include all staff Discord IDs from the DB so the bot can use them for local auth checks
+    staff_rows = AppSetting.query.filter(AppSetting.key.like('STAFF_MEMBER_%')).all()
+    result['staffDiscordIds'] = [row.key[len('STAFF_MEMBER_'):] for row in staff_rows]
     return jsonify(result)
 
 


### PR DESCRIPTION
## Summary

- `/api/bot-config` now includes `staffDiscordIds` — all Discord IDs stored as `STAFF_MEMBER_*` AppSettings in the DB (set via the dashboard's Staff/Moderators panel)
- `configSyncWorker` merges these IDs into `config.testerDiscordIds` on each sync cycle (default every 60s)
- Fixes dashboard moderators (e.g. Connor) being denied `/lasombra approve` because the bot's local auth check only read `BOT_TESTER_IDS` env var, not DB staff

## Why this matters

The web app's `is_allowed_discord_user()` already checks the DB, so staff set via the dashboard could always use web-based actions. But the bot has a pre-flight auth check against `config.testerDiscordIds` that only came from the env var — this bridges that gap without requiring env var changes.

## Test plan

- [ ] Set a Discord user as moderator in the dashboard Settings → Staff panel
- [ ] Restart bot (or wait up to 60s for config sync)
- [ ] Confirm that user can now run `/lasombra approve` successfully
- [ ] Confirm existing `BOT_TESTER_IDS` env var entries are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)