### PR TITLE
fix: prevent duplicate notifications on bot restart

### DIFF
--- a/apps/bot/src/services/characterSubmissionNotifier.ts
+++ b/apps/bot/src/services/characterSubmissionNotifier.ts
@@ -6,7 +6,7 @@ import type { TrackerAdapter, CcSubmittedDraft } from './adapter';
 
 const STATE_PATH = path.resolve('./data/cc-submission-cursor.json');
 
-type CursorState = { cursorEpoch: number };
+type CursorState = { cursorEpoch: number; seenIds?: string[] };
 
 function loadCursorState(): CursorState | null {
   try {
@@ -106,8 +106,12 @@ export class CharacterSubmissionNotifier {
         const saved = loadCursorState();
         if (saved) {
           this.cursorEpoch = saved.cursorEpoch;
+          for (const id of saved.seenIds ?? []) this.seenIds.add(id);
           this.initialized = true;
-          logEvent('info', 'cc_submission_notifier_resumed', { cursorEpoch: this.cursorEpoch });
+          logEvent('info', 'cc_submission_notifier_resumed', {
+            cursorEpoch: this.cursorEpoch,
+            seenCount: this.seenIds.size,
+          });
           return;
         }
         // No saved state — bootstrap: mark existing submissions as seen without posting.
@@ -121,7 +125,7 @@ export class CharacterSubmissionNotifier {
           this.cursorEpoch = Math.max(this.cursorEpoch, draft.submitted_at_epoch);
         }
         this.initialized = true;
-        saveCursorState({ cursorEpoch: this.cursorEpoch });
+        saveCursorState({ cursorEpoch: this.cursorEpoch, seenIds: [...this.seenIds] });
         logEvent('info', 'cc_submission_notifier_bootstrap', { seenCount: this.seenIds.size });
         return;
       }
@@ -143,7 +147,7 @@ export class CharacterSubmissionNotifier {
             const first = this.seenIds.values().next().value;
             if (first) this.seenIds.delete(first);
           }
-          saveCursorState({ cursorEpoch: this.cursorEpoch });
+          saveCursorState({ cursorEpoch: this.cursorEpoch, seenIds: [...this.seenIds] });
 
           if (!draft.ticket_channel_id) {
             logEvent('warn', 'cc_submission_notifier_no_ticket_channel', {

--- a/apps/bot/src/services/submissionNotifier.ts
+++ b/apps/bot/src/services/submissionNotifier.ts
@@ -120,10 +120,32 @@ export class SubmissionNotifier {
         if (saved) {
           this.cursorEpoch = saved.cursorEpoch;
           this.cursorEventKey = saved.cursorEventKey;
+
+          // Re-seed seenEventKeys for the boundary epoch window to prevent
+          // duplicate notifications after restart.  Same fix as ReviewNotifier.
+          try {
+            const warmup = await this.adapter.getSubmissionEvents({
+              sinceEpoch: Math.max(0, this.cursorEpoch - 300),
+              limit: 250,
+            });
+            for (const event of warmup.events) {
+              if (
+                event.submittedAtEpoch < this.cursorEpoch ||
+                (event.submittedAtEpoch === this.cursorEpoch &&
+                  event.eventKey <= this.cursorEventKey)
+              ) {
+                this.seenEventKeys.add(event.eventKey);
+              }
+            }
+          } catch {
+            // Non-fatal: worst case is one duplicate notification on this restart cycle.
+          }
+
           this.initialized = true;
           logEvent('info', 'submission_notifier_resumed', {
             cursorEpoch: this.cursorEpoch,
             cursorEventKey: this.cursorEventKey,
+            seenOnResume: this.seenEventKeys.size,
           });
           return;
         }


### PR DESCRIPTION
## Summary

- **`CharacterSubmissionNotifier`**: persists `seenIds` to the cursor JSON file and restores them on resume — matching the pattern already used by `CharacterApprovalNotifier`
- **`SubmissionNotifier`**: adds a warmup fetch on resume that re-seeds `seenEventKeys` for the 5-minute boundary-epoch window — matching the pattern already used by `ReviewNotifier`

## Root cause

All four notifier services use a cursor file (`./data/*.json`) to track position across restarts. Two of them had incomplete dedup protection:

| Service | Cursor persisted | Dedup set persisted | Safe on restart? |
|---|---|---|---|
| `ReviewNotifier` | epoch + eventKey | warmup re-seeds on resume | ✅ |
| `CharacterApprovalNotifier` | epoch + seenIds | seenIds restored from file | ✅ |
| `SubmissionNotifier` | epoch + eventKey | ❌ empty on resume | fixed here |
| `CharacterSubmissionNotifier` | epoch only | ❌ empty on resume | fixed here |

On restart, the cursor epoch is inclusive (`>=` query), so any events at exactly the cursor boundary are returned again. With an empty dedup set, they all get re-posted.

## Notes

- Existing cursor files (already deployed on ursula) don't have `seenIds` in them — `CharacterSubmissionNotifier` will resume with an empty set on the first restart after deploy, then be fully protected thereafter. The field is `?` optional specifically for this backwards-compat reason.
- The `SubmissionNotifier` warmup is non-fatal (wrapped in try/catch) — a warmup failure causes at most one duplicate notification on that restart cycle.

## Test plan

- [ ] Deploy to ursula, restart bot container, confirm no duplicate notifications fire in cubby channels or ST channel
- [ ] Verify `cc_submission_notifier_resumed` log event includes `seenCount > 0` on second restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)