### PR TITLE
fix: normalize CC skillSpecialties format for sheet rendering

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -711,7 +711,9 @@ def _normalize_sheet_data(data: dict) -> dict:
     templates have one format to handle.
     """
     if 'skill_specialties' not in data:
-        cc_specs = data.get('skillSpecialties') or []
+        cc_specs = list(data.get('skillSpecialties') or [])
+        predator_specs = (data.get('predatorType') or {}).get('pickedSpecialties') or []
+        cc_specs = cc_specs + list(predator_specs)
         merged: dict[str, list[str]] = {}
         for item in cc_specs:
             if isinstance(item, dict):

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -712,12 +712,13 @@ def _normalize_sheet_data(data: dict) -> dict:
     """
     if 'skill_specialties' not in data:
         cc_specs = list(data.get('skillSpecialties') or [])
-        predator_specs = (data.get('predatorType') or {}).get('pickedSpecialties') or []
-        cc_specs = cc_specs + list(predator_specs)
+        predator = data.get('predatorType')
+        if isinstance(predator, dict):
+            cc_specs = cc_specs + list(predator.get('pickedSpecialties') or [])
         merged: dict[str, list[str]] = {}
         for item in cc_specs:
             if isinstance(item, dict):
-                skill = item.get('skill', '')
+                skill = item.get('skill', '').replace(' ', '_')
                 name = item.get('name', '').strip()
                 if skill and name:
                     merged.setdefault(skill, []).append(name)


### PR DESCRIPTION
## Summary
- Normalizes the `skillSpecialties` format coming from the character creator before rendering on the player sheet, fixing a display bug introduced with the CC specialty data shape.

## Test plan
- [ ] Submit a character with skill specialties via CC
- [ ] Approve and view character sheet — specialties render correctly
- [ ] Existing characters with specialties still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)