### PR TITLE
fix: migration guard, date normalization, scan-activity date range

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1820,12 +1820,12 @@ def discord_activity_record():
 def periods_recent():
     """Return the most recent N play periods with their date ranges.
 
-    Query param: count (default 2, max 10).
+    Query param: count (default 2, max 50).
     Response: { periods: [{ label, nightNumber, startDate, endDate }] }
     """
     from app.db import DbPlayPeriod
     try:
-        count = min(10, max(1, int(request.args.get('count', 2))))
+        count = min(50, max(1, int(request.args.get('count', 2))))
     except (ValueError, TypeError):
         count = 2
     rows = (

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -14,6 +14,14 @@ from app.db import DbCharacter, DbPlayPeriod, DbSpendRequest, DbXPClaim, Discord
 bp = Blueprint('reports', __name__)
 
 
+def _iso_date(d: str) -> str:
+    """Normalize YYYYMMDD or YYYY-MM-DD to YYYY-MM-DD."""
+    d = d.strip()
+    if len(d) == 8 and d.isdigit():
+        return f'{d[:4]}-{d[4:6]}-{d[6:]}'
+    return d
+
+
 @bp.route('/reports')
 @require_staff
 def index():
@@ -103,8 +111,8 @@ def index():
     discord_activity = []
     if recent_periods:
         end_dates = [p.end_date for p in recent_periods if p.end_date]
-        act_since = min(start_dates) if start_dates else ''
-        act_until = max(end_dates) if end_dates else ''
+        act_since = _iso_date(min(start_dates)) if start_dates else ''
+        act_until = _iso_date(max(end_dates)) if end_dates else ''
 
         act_q = DiscordPostCount.query
         if act_since:


### PR DESCRIPTION
## Summary
- Guards the `discord_post_counts` migration against already-stamped DBs (create_table / add_column idempotency)
- Normalizes dates in the activity backfill scanner to prevent format mismatches
- Adds date-range support to the scan-activity command

## Test plan
- [ ] Run migration on a DB that already has the table — no error
- [ ] Scan activity with a date range via `/lasombra scan-activity` — results scoped correctly
- [ ] Backfill dates stored and displayed in consistent format

🤖 Generated with [Claude Code](https://claude.com/claude-code)