### PR TITLE
feat: IM ancilla specialties flagged as archaic, ST-editable on approval

### DIFF
--- a/apps/character-app/src/generator/components/SkillSpecialtyModal.tsx
+++ b/apps/character-app/src/generator/components/SkillSpecialtyModal.tsx
@@ -16,6 +16,7 @@ type SpecialtyModalProps = {
     skills: Skills
     setCharacter: (character: Character) => void
     nextStep: () => void
+    isImAncilla?: boolean
 }
 
 const BONUS_SPECIALTY_SKILLS = ["academics", "craft", "performance", "science"] as const
@@ -27,7 +28,8 @@ export const SpecialtyModal = ({
     nextStep,
     character,
     pickedSkillNames,
-    skills
+    skills,
+    isImAncilla = false,
 }: SpecialtyModalProps) => {
     const phoneScreen = globals.isPhoneScreen
 
@@ -130,16 +132,46 @@ export const SpecialtyModal = ({
                             lineHeight: 1.55
                         }}
                     >
-                        Specialties represent focused expertise within a skill —{" "}
-                        <span style={{ color: "rgba(244, 236, 232, 0.8)" }}>
-                            Performance: Dancing
-                        </span>{" "}
-                        or{" "}
-                        <span style={{ color: "rgba(244, 236, 232, 0.8)" }}>
-                            Academics: History
-                        </span>
-                        .
+                        {isImAncilla ? (
+                            <>
+                                Your specialties must reflect your character's era — choose
+                                period-appropriate skills, not modern ones.{" "}
+                                <span style={{ color: "rgba(244, 236, 232, 0.8)" }}>
+                                    Performance: Lute
+                                </span>{" "}
+                                rather than{" "}
+                                <span style={{ color: rgba(RAW_GREY, 0.4), textDecoration: "line-through" }}>
+                                    Performance: Guitar
+                                </span>
+                                . Your Storyteller will review and may adjust these before approval.
+                            </>
+                        ) : (
+                            <>
+                                Specialties represent focused expertise within a skill —{" "}
+                                <span style={{ color: "rgba(244, 236, 232, 0.8)" }}>
+                                    Performance: Dancing
+                                </span>{" "}
+                                or{" "}
+                                <span style={{ color: "rgba(244, 236, 232, 0.8)" }}>
+                                    Academics: History
+                                </span>
+                                .
+                            </>
+                        )}
                     </Text>
+                    {isImAncilla && (
+                        <Text
+                            mt={8}
+                            style={{
+                                fontFamily: "Inter, Segoe UI, sans-serif",
+                                fontSize: "0.78rem",
+                                color: rgba(RAW_GOLD, 0.7),
+                                lineHeight: 1.5,
+                            }}
+                        >
+                            ⚠ ST review required — your proposed specialties will be confirmed or edited during character approval.
+                        </Text>
+                    )}
                 </div>
 
                 <div

--- a/apps/character-app/src/generator/components/SkillsPicker.tsx
+++ b/apps/character-app/src/generator/components/SkillsPicker.tsx
@@ -437,6 +437,11 @@ const SkillsPicker = ({ character, setCharacter, nextStep }: SkillsPickerProps) 
                 character={character}
                 pickedSkillNames={getAll(pickedSkills)}
                 skills={skills}
+                isImAncilla={
+                    character.age_category === "ancilla" &&
+                    !!character.in_memoriam &&
+                    !character.in_memoriam.use_standard
+                }
             />
         </div>
     )

--- a/apps/web/app/blueprints/cc_admin.py
+++ b/apps/web/app/blueprints/cc_admin.py
@@ -228,6 +228,10 @@ def draft_approve(draft_id):
         name = (request.form.get(f'specialty_{i}_name') or '').strip()
         if skill is None:
             break
+        if skill and not name:
+            flash(f'Specialty name for "{skill}" cannot be blank — approval aborted.', 'danger')
+            db.session.rollback()
+            return redirect(url_for('cc_admin.draft_review', draft_id=draft_id))
         if skill and name:
             specialty_overrides.append({'skill': skill, 'name': name.lower()})
         i += 1

--- a/apps/web/app/blueprints/cc_admin.py
+++ b/apps/web/app/blueprints/cc_admin.py
@@ -214,6 +214,27 @@ def draft_approve(draft_id):
     draft.approved_by = actor
     draft.approved_at = datetime.now(timezone.utc)
 
+    # Apply any ST-edited specialty overrides (IM ancilla archaic specialties)
+    char_data = {}
+    if draft.character_data:
+        try:
+            char_data = json.loads(draft.character_data)
+        except Exception:
+            pass
+    specialty_overrides = []
+    i = 0
+    while True:
+        skill = request.form.get(f'specialty_{i}_skill')
+        name = (request.form.get(f'specialty_{i}_name') or '').strip()
+        if skill is None:
+            break
+        if skill and name:
+            specialty_overrides.append({'skill': skill, 'name': name.lower()})
+        i += 1
+    if specialty_overrides:
+        char_data['skillSpecialties'] = specialty_overrides
+        draft.character_data = json.dumps(char_data)
+
     # Create or link roster entry (DbCharacter)
     char_name = draft.character_name or ''
     if char_name and not draft.roster_character_id:

--- a/apps/web/app/templates/cc_admin/draft_review.html
+++ b/apps/web/app/templates/cc_admin/draft_review.html
@@ -134,6 +134,27 @@
   </div>
   {% endif %}
 
+  {# ── Skill Specialties ── #}
+  {% set specialties = char_data.get('skillSpecialties', []) %}
+  {% set is_im_ancilla = char_data.get('age_category') == 'ancilla' and char_data.get('in_memoriam') and not char_data.get('in_memoriam', {}).get('use_standard', True) %}
+  {% if specialties %}
+  <div class="card mb-3{% if is_im_ancilla %} border-warning{% endif %}">
+    <div class="card-header py-2 fw-semibold d-flex align-items-center gap-2">
+      Skill Specialties
+      {% if is_im_ancilla %}
+        <span class="badge bg-warning text-dark ms-auto">ST Review Required — must be archaic</span>
+      {% endif %}
+    </div>
+    <div class="card-body">
+      <ul class="mb-0 ps-3">
+        {% for s in specialties %}
+          <li class="text-capitalize">{{ s.get('skill', '?') }}: {{ s.get('name', '?') }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
   {# ── Disciplines ── #}
   {% set disciplines = char_data.get('disciplines', []) %}
   {% if disciplines %}
@@ -338,6 +359,24 @@
       <form method="post" action="{{ url_for('cc_admin.draft_approve', draft_id=draft.id) }}"
             onsubmit="return confirm('Approve {{ draft.character_name or 'this character' }}?')">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% if is_im_ancilla and specialties %}
+        <div class="mb-3 p-3 border border-warning rounded">
+          <div class="fw-semibold small text-warning mb-2">
+            <i class="bi bi-pencil me-1"></i> Edit Archaic Specialties before approving
+          </div>
+          {% for s in specialties %}
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <input type="hidden" name="specialty_{{ loop.index0 }}_skill" value="{{ s.get('skill', '') }}">
+            <span class="text-capitalize text-muted small" style="min-width:100px;">{{ s.get('skill', '?') }}:</span>
+            <input type="text" name="specialty_{{ loop.index0 }}_name"
+                   value="{{ s.get('name', '') }}"
+                   class="form-control form-control-sm bg-dark text-light border-secondary"
+                   style="max-width:220px;"
+                   placeholder="archaic specialty">
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
         <button type="submit" class="btn btn-success">
           <i class="bi bi-check-circle me-1"></i> Approve Character
         </button>


### PR DESCRIPTION
## Summary
- Flags skill specialties entered during the In Memoriam (ancilla) step as archaic
- Allows STs to edit these specialties during the draft review / approval flow
- Updates the skill specialty modal and skills picker in the CC to support this state

## Test plan
- [ ] Create an IM ancilla draft with skill specialties — archaic flag set
- [ ] ST views draft review — IM specialties are editable
- [ ] Non-IM specialties behave as before (no archaic flag, not ST-editable pre-approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)