### PR TITLE
fix: CC freebie rules — PT merit credit, loresheet search, starting XP open spend

### DIFF
--- a/apps/character-app/src/generator/components/LoresheetPicker.tsx
+++ b/apps/character-app/src/generator/components/LoresheetPicker.tsx
@@ -1,7 +1,9 @@
-import { Button, ScrollArea, Stack, Text, Title } from "@mantine/core"
+import { Button, ScrollArea, Stack, Tabs, Text, TextInput, Title } from "@mantine/core"
 import { IconCheck } from "@tabler/icons-react"
 import { useEffect, useState } from "react"
 import { Character } from "~/data/Character"
+import { AttributesKey } from "~/data/Attributes"
+import { SkillsKey } from "~/data/Skills"
 import { Loresheet, LoresheetDot, LORESHEETS, loresheetDotCost } from "~/data/Loresheets"
 import { RAW_RED, rgba } from "~/theme/colors"
 import { cc } from "~/utils/api"
@@ -12,25 +14,40 @@ import {
 } from "./sharedGeneratorScrollableLayout"
 import { nightfallScrollAreaStyles, nightfallScrollbarSize } from "./sharedScrollAreaStyles"
 
-type LoresheetPickerProps = {
-    character: Character
-    setCharacter: (character: Character) => void
-    nextStep: () => void
+// ─── XP cost functions (V5 table) ───────────────────────────────────────────
+const attrLevelCost = (newLevel: number) => newLevel * 5
+const skillLevelCost = (newLevel: number) => newLevel * 3
+
+function cumulativeCost(from: number, to: number, costFn: (l: number) => number): number {
+    if (to <= from) return 0
+    let total = 0
+    for (let l = from + 1; l <= to; l++) total += costFn(l)
+    return total
 }
 
-const FONT_DISPLAY = "Cinzel, Georgia, serif"
-const FONT_BODY = "Crimson Text, Georgia, serif"
-const FONT_UI = "Inter, Segoe UI, sans-serif"
-const C_FG = "rgba(244, 236, 232, 0.95)"
-const C_MUTED = "rgba(220, 210, 205, 0.6)"
-const C_CARD = "rgba(26, 20, 24, 0.88)"
-const C_BORDER = "rgba(125, 91, 72, 0.35)"
-const C_RED = rgba(RAW_RED, 1)
-const C_RED_DIM = rgba(RAW_RED, 0.45)
-const C_RED_GLOW = `0 0 18px ${rgba(RAW_RED, 0.28)}`
-const C_GOLD = "rgba(195, 155, 90, 0.85)"
-const C_GOLD_DIM = "rgba(195, 155, 90, 0.4)"
+// ─── Stat groupings ──────────────────────────────────────────────────────────
+const ATTR_GROUPS: { label: string; attrs: AttributesKey[] }[] = [
+    { label: "Physical", attrs: ["strength", "dexterity", "stamina"] },
+    { label: "Social",   attrs: ["charisma", "manipulation", "composure"] },
+    { label: "Mental",   attrs: ["intelligence", "wits", "resolve"] },
+]
 
+const SKILL_GROUPS: { label: string; skills: SkillsKey[] }[] = [
+    {
+        label: "Physical",
+        skills: ["athletics", "brawl", "craft", "drive", "firearms", "melee", "larceny", "stealth", "survival"],
+    },
+    {
+        label: "Social",
+        skills: ["animal ken", "etiquette", "insight", "intimidation", "leadership", "performance", "persuasion", "streetwise", "subterfuge"],
+    },
+    {
+        label: "Mental",
+        skills: ["academics", "awareness", "finance", "investigation", "medicine", "occult", "politics", "science", "technology"],
+    },
+]
+
+// ─── Loresheet helpers ───────────────────────────────────────────────────────
 const SOURCE_LABELS: Record<string, string> = {
     core: "Core",
     camarilla: "Camarilla",
@@ -55,118 +72,206 @@ const SOURCE_LABELS: Record<string, string> = {
     custom: "Nashville",
 }
 
-function sourceLabel(source: string): string {
-    return SOURCE_LABELS[source] ?? source
+function isLoresheetAvailable(ls: Loresheet, clan: string) {
+    return !ls.clanRestriction?.length || ls.clanRestriction.includes(clan)
 }
-
-function isLoresheetAvailable(loresheet: Loresheet, clan: string): boolean {
-    if (!loresheet.clanRestriction || loresheet.clanRestriction.length === 0) return true
-    return loresheet.clanRestriction.includes(clan)
+function isDotAvailable(dot: LoresheetDot, clan: string) {
+    return !dot.clanRestriction?.length || dot.clanRestriction.includes(clan)
 }
-
-function isDotAvailable(dot: LoresheetDot, clan: string): boolean {
-    if (!dot.clanRestriction || dot.clanRestriction.length === 0) return true
-    return dot.clanRestriction.includes(clan)
+function isPurchased(character: Character, lsId: string, dot: number) {
+    return (character.loresheet_purchases ?? []).some(p => p.loresheet_id === lsId && p.dot === dot)
 }
-
-function isPurchased(character: Character, loresheetId: string, dot: number): boolean {
-    return (character.loresheet_purchases ?? []).some(
-        (p) => p.loresheet_id === loresheetId && p.dot === dot,
-    )
-}
-
-function togglePurchase(character: Character, loresheetId: string, dotEntry: LoresheetDot): Character {
+function togglePurchase(character: Character, lsId: string, dot: number): Character {
     const current = character.loresheet_purchases ?? []
-    const exists = current.some((p) => p.loresheet_id === loresheetId && p.dot === dotEntry.dot)
-    const updated = exists
-        ? current.filter((p) => !(p.loresheet_id === loresheetId && p.dot === dotEntry.dot))
-        : [...current, { loresheet_id: loresheetId, dot: dotEntry.dot, dot_name: dotEntry.name, description: dotEntry.description }]
-    return { ...character, loresheet_purchases: updated }
+    const exists = current.some(p => p.loresheet_id === lsId && p.dot === dot)
+    return {
+        ...character,
+        loresheet_purchases: exists
+            ? current.filter(p => !(p.loresheet_id === lsId && p.dot === dot))
+            : [...current, { loresheet_id: lsId, dot }],
+    }
 }
 
-function totalXpSpent(character: Character): number {
-    return (character.loresheet_purchases ?? []).reduce(
-        (sum, p) => sum + loresheetDotCost(p.dot),
-        0,
+// ─── Shared style constants ───────────────────────────────────────────────────
+const FONT_DISPLAY = "Cinzel, Georgia, serif"
+const FONT_BODY    = "Crimson Text, Georgia, serif"
+const FONT_UI      = "Inter, Segoe UI, sans-serif"
+const C_FG         = "rgba(244, 236, 232, 0.95)"
+const C_MUTED      = "rgba(220, 210, 205, 0.6)"
+const C_CARD       = "rgba(26, 20, 24, 0.88)"
+const C_BORDER     = "rgba(125, 91, 72, 0.35)"
+const C_RED        = rgba(RAW_RED, 1)
+const C_RED_DIM    = rgba(RAW_RED, 0.45)
+const C_RED_GLOW   = `0 0 18px ${rgba(RAW_RED, 0.28)}`
+const C_GOLD       = "rgba(195, 155, 90, 0.85)"
+const C_GOLD_DIM   = "rgba(195, 155, 90, 0.4)"
+
+const activeTabStyle = {
+    background: "rgba(255,255,255,0.07)",
+    borderColor: "rgba(255,255,255,0.18)",
+    color: C_FG,
+}
+
+// ─── Dot row component (attributes & skills) ──────────────────────────────────
+function StatRow({
+    name,
+    base,
+    current,
+    min,
+    max,
+    costFn,
+    remaining,
+    onSet,
+}: {
+    name: string
+    base: number
+    current: number
+    min: number
+    max: number
+    costFn: (l: number) => number
+    remaining: number
+    onSet: (level: number) => void
+}) {
+    const bought = cumulativeCost(base, current, costFn)
+    return (
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "6px 0", borderBottom: "1px solid rgba(125,91,72,0.1)" }}>
+            <div style={{ width: 130, fontFamily: FONT_BODY, fontSize: "0.9rem", color: C_FG, textTransform: "capitalize", flexShrink: 0 }}>
+                {name}
+            </div>
+            <div style={{ display: "flex", gap: 4 }}>
+                {Array.from({ length: max - min + 1 }, (_, i) => i + min).map(level => {
+                    const filled = level <= current
+                    const isBase = level <= base
+                    const costToReach = level > current
+                        ? cumulativeCost(current, level, costFn)
+                        : level < current && level >= base
+                            ? -(cumulativeCost(level, current, costFn))
+                            : 0
+                    const canAfford = costToReach <= remaining
+                    const disabled = isBase || (level > current && !canAfford)
+                    return (
+                        <button
+                            key={level}
+                            title={
+                                isBase ? "Set in earlier step"
+                                    : level > current ? `+${costToReach} XP to reach ${level}`
+                                        : level < current ? `Refund ${-costToReach} XP`
+                                            : "Current level"
+                            }
+                            onClick={() => { if (!disabled) onSet(level) }}
+                            style={{
+                                width: 22,
+                                height: 22,
+                                borderRadius: 4,
+                                border: `1.5px solid ${filled ? (isBase ? "rgba(125,91,72,0.4)" : rgba(RAW_RED, 0.7)) : "rgba(125,91,72,0.3)"}`,
+                                background: filled
+                                    ? isBase ? "rgba(125,91,72,0.2)" : rgba(RAW_RED, 0.18)
+                                    : "rgba(255,255,255,0.02)",
+                                cursor: disabled ? "default" : "pointer",
+                                opacity: disabled && !isBase ? 0.35 : 1,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                fontSize: "0.65rem",
+                                color: filled ? (isBase ? C_MUTED : C_RED) : "rgba(125,91,72,0.4)",
+                                transition: "all 120ms ease",
+                                fontFamily: "inherit",
+                                padding: 0,
+                            }}
+                        >
+                            {filled ? "●" : "○"}
+                        </button>
+                    )
+                })}
+            </div>
+            {bought > 0 && (
+                <span style={{ marginLeft: "auto", fontFamily: FONT_UI, fontSize: "0.65rem", color: C_RED_DIM, letterSpacing: "0.08em" }}>
+                    -{bought} XP
+                </span>
+            )}
+        </div>
     )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+type LoresheetPickerProps = {
+    character: Character
+    setCharacter: (character: Character) => void
+    nextStep: () => void
 }
 
 export default function LoresheetPicker({ character, setCharacter, nextStep }: LoresheetPickerProps) {
     const budget = character.cc_xp_budget ?? 0
-    const spent = totalXpSpent(character)
+
+    // Capture starting values so we can compute XP spent in this step
+    const [baseAttrs] = useState(() => ({ ...character.attributes }))
+    const [baseSkills] = useState(() => ({ ...character.skills }))
+
+    // Spent tallies
+    const attrSpent = ATTR_GROUPS.flatMap(g => g.attrs).reduce(
+        (sum, key) => sum + cumulativeCost(baseAttrs[key], character.attributes[key], attrLevelCost), 0
+    )
+    const skillSpent = SKILL_GROUPS.flatMap(g => g.skills).reduce(
+        (sum, key) => sum + cumulativeCost(baseSkills[key], character.skills[key], skillLevelCost), 0
+    )
+    const lsSpent = (character.loresheet_purchases ?? []).reduce((sum, p) => sum + loresheetDotCost(p.dot), 0)
+    const spent = attrSpent + skillSpent + lsSpent
     const remaining = budget - spent
     const overBudget = remaining < 0
-    const clan = character.clan ?? ""
 
+    // Loresheet state
     const [bannedIds, setBannedIds] = useState<Set<string>>(new Set())
     useEffect(() => {
-        cc.getRestrictions().then((r) => setBannedIds(new Set(r.loresheets))).catch(() => {})
+        cc.getRestrictions().then(r => setBannedIds(new Set(r.loresheets))).catch(() => {})
     }, [])
-
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
-    const toggleExpanded = (id: string) => {
-        setExpandedIds((prev) => {
+    const toggleExpanded = (id: string) =>
+        setExpandedIds(prev => {
             const next = new Set(prev)
-            if (next.has(id)) next.delete(id)
-            else next.add(id)
+            next.has(id) ? next.delete(id) : next.add(id)
             return next
         })
-    }
+    const [lsSearch, setLsSearch] = useState("")
+    const visibleLoresheets = LORESHEETS
+        .filter(ls => isLoresheetAvailable(ls, character.clan ?? "") && !bannedIds.has(ls.id))
+        .filter(ls => !lsSearch || ls.name.toLowerCase().includes(lsSearch.toLowerCase()))
+        .sort((a, b) => a.name.localeCompare(b.name))
 
-    const visibleLoresheets = LORESHEETS.filter(
-        (ls) => isLoresheetAvailable(ls, clan) && !bannedIds.has(ls.id),
-    )
+    const [activeTab, setActiveTab] = useState<string | null>("attributes")
 
+    // Stat setters
+    const setAttr = (key: AttributesKey, level: number) =>
+        setCharacter({ ...character, attributes: { ...character.attributes, [key]: level } })
+    const setSkill = (key: SkillsKey, level: number) =>
+        setCharacter({ ...character, skills: { ...character.skills, [key]: level } })
+
+    // ── Render ──────────────────────────────────────────────────────────────
     return (
         <div style={generatorScrollableShellStyle}>
-            <ScrollArea
-                style={generatorScrollableAreaStyle}
-                w="100%"
-                px={20}
-                pt={4}
-                pb={8}
-                scrollbarSize={nightfallScrollbarSize}
-                type="always"
-                styles={nightfallScrollAreaStyles}
-            >
+            {/* ── Header + XP bar (sticky) ── */}
+            <div style={{ flexShrink: 0, padding: "0 20px 12px" }}>
                 <div style={generatorScrollableContentStyle}>
-                    {/* Header */}
-                    <Stack gap={4} align="center" mb={26}>
+                    <Stack gap={4} align="center" mb={16}>
                         <Title
                             order={2}
                             ta="center"
-                            style={{
-                                fontFamily: FONT_DISPLAY,
-                                fontWeight: 600,
-                                letterSpacing: "0.05em",
-                                color: C_FG,
-                            }}
+                            style={{ fontFamily: FONT_DISPLAY, fontWeight: 600, letterSpacing: "0.05em", color: C_FG }}
                         >
-                            Choose your{" "}
-                            <Text
-                                component="strong"
-                                inherit
-                                c="red.5"
-                                style={{ textShadow: C_RED_GLOW }}
-                            >
-                                Loresheets
+                            Spend your{" "}
+                            <Text component="strong" inherit c="red.5" style={{ textShadow: C_RED_GLOW }}>
+                                Starting XP
                             </Text>
                         </Title>
-                        <Text
-                            ta="center"
-                            maw={560}
-                            style={{ fontFamily: FONT_BODY, fontSize: "1.1rem", color: C_MUTED }}
-                        >
-                            Purchase dots from loresheets using your XP budget.
-                            All loresheets require Storyteller approval.
+                        <Text ta="center" maw={560} style={{ fontFamily: FONT_BODY, fontSize: "1.05rem", color: C_MUTED }}>
+                            Use the XP table to raise attributes, skills, or purchase loresheets.
                         </Text>
                     </Stack>
 
-                    {/* XP tracker bar */}
+                    {/* Budget bar */}
                     <div
                         style={{
                             maxWidth: 700,
-                            margin: "0 auto 24px",
+                            margin: "0 auto",
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "space-between",
@@ -177,325 +282,263 @@ export default function LoresheetPicker({ character, setCharacter, nextStep }: L
                             background: overBudget ? rgba(RAW_RED, 0.06) : "rgba(26, 20, 24, 0.7)",
                         }}
                     >
-                        <span
-                            style={{
-                                fontFamily: FONT_UI,
-                                fontSize: "0.75rem",
-                                letterSpacing: "0.12em",
-                                textTransform: "uppercase",
-                                color: C_GOLD,
-                            }}
-                        >
+                        <span style={{ fontFamily: FONT_UI, fontSize: "0.75rem", letterSpacing: "0.12em", textTransform: "uppercase", color: C_GOLD }}>
                             XP Budget
                         </span>
                         <div style={{ display: "flex", gap: 24 }}>
                             {[
-                                { label: "Budget", value: budget, color: C_FG },
-                                { label: "Spent", value: -spent, color: spent === 0 ? C_MUTED : C_RED_DIM },
-                                {
-                                    label: "Remaining",
-                                    value: remaining,
-                                    color: overBudget ? C_RED : C_GOLD,
-                                },
+                                { label: "Budget",    value: budget,    color: C_FG },
+                                { label: "Spent",     value: -spent,    color: spent === 0 ? C_MUTED : C_RED_DIM },
+                                { label: "Remaining", value: remaining, color: overBudget ? C_RED : C_GOLD },
                             ].map(({ label, value, color }) => (
                                 <div key={label} style={{ textAlign: "center" }}>
-                                    <div
-                                        style={{
-                                            fontFamily: FONT_DISPLAY,
-                                            fontSize: "1rem",
-                                            fontWeight: 700,
-                                            color,
-                                        }}
-                                    >
+                                    <div style={{ fontFamily: FONT_DISPLAY, fontSize: "1rem", fontWeight: 700, color }}>
                                         {value > 0 ? `+${value}` : value === 0 ? "0" : String(value)} XP
                                     </div>
-                                    <div
-                                        style={{
-                                            fontFamily: FONT_UI,
-                                            fontSize: "0.65rem",
-                                            letterSpacing: "0.1em",
-                                            textTransform: "uppercase",
-                                            color: C_MUTED,
-                                        }}
-                                    >
+                                    <div style={{ fontFamily: FONT_UI, fontSize: "0.65rem", letterSpacing: "0.1em", textTransform: "uppercase", color: C_MUTED }}>
                                         {label}
                                     </div>
                                 </div>
                             ))}
                         </div>
                     </div>
+                </div>
+            </div>
 
-                    {/* Loresheet cards */}
-                    <div
-                        style={{
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: 20,
-                            maxWidth: 700,
-                            margin: "0 auto",
-                        }}
+            {/* ── Tabs ── */}
+            <Tabs
+                value={activeTab}
+                onChange={setActiveTab}
+                style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}
+                styles={{
+                    list: { gap: 10, borderBottom: "1px solid rgba(255,255,255,0.08)", paddingBottom: 10, padding: "0 20px 10px" },
+                    tab: {
+                        borderRadius: 999,
+                        border: "1px solid rgba(255,255,255,0.08)",
+                        background: "rgba(255,255,255,0.03)",
+                        color: C_MUTED,
+                        fontFamily: FONT_DISPLAY,
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                        fontSize: "0.78rem",
+                        fontWeight: 600,
+                    },
+                    panel: { flex: 1, minHeight: 0, overflow: "hidden", display: "flex", flexDirection: "column", paddingTop: 12 },
+                }}
+            >
+                <Tabs.List>
+                    <Tabs.Tab value="attributes" style={activeTab === "attributes" ? activeTabStyle : undefined}>
+                        Attributes
+                    </Tabs.Tab>
+                    <Tabs.Tab value="skills" style={activeTab === "skills" ? activeTabStyle : undefined}>
+                        Skills
+                    </Tabs.Tab>
+                    <Tabs.Tab value="loresheets" style={activeTab === "loresheets" ? activeTabStyle : undefined}>
+                        Loresheets
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                {/* ── Attributes panel ── */}
+                <Tabs.Panel value="attributes">
+                    <ScrollArea
+                        style={{ flex: 1 }}
+                        px={20}
+                        pb={40}
+                        scrollbarSize={nightfallScrollbarSize}
+                        type="always"
+                        styles={nightfallScrollAreaStyles}
                     >
-                        {visibleLoresheets.map((loresheet) => {
-                            const isExpanded = expandedIds.has(loresheet.id)
-                            const purchasedCount = (character.loresheet_purchases ?? []).filter(
-                                (p) => p.loresheet_id === loresheet.id,
-                            ).length
-
-                            return (
-                            <div
-                                key={loresheet.id}
-                                style={{
-                                    borderRadius: 10,
-                                    border: `1px solid ${purchasedCount > 0 ? rgba(RAW_RED, 0.35) : C_BORDER}`,
-                                    background: C_CARD,
-                                    overflow: "hidden",
-                                }}
-                            >
-                                {/* Loresheet header — clickable toggle */}
-                                <button
-                                    onClick={() => toggleExpanded(loresheet.id)}
-                                    style={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        justifyContent: "space-between",
-                                        gap: 12,
-                                        width: "100%",
-                                        padding: "14px 18px 12px",
-                                        background: "transparent",
-                                        border: "none",
-                                        borderBottom: isExpanded ? `1px solid rgba(125, 91, 72, 0.2)` : "none",
-                                        cursor: "pointer",
-                                        textAlign: "left",
-                                        fontFamily: "inherit",
-                                    }}
-                                >
-                                    <div style={{ flex: 1, minWidth: 0 }}>
-                                        <p
-                                            style={{
-                                                margin: 0,
-                                                fontFamily: FONT_DISPLAY,
-                                                fontSize: "0.95rem",
-                                                fontWeight: 600,
-                                                letterSpacing: "0.06em",
-                                                color: C_FG,
-                                            }}
-                                        >
-                                            {loresheet.name}
-                                        </p>
-                                        {loresheet.requiresStPermission && (
-                                            <p
-                                                style={{
-                                                    margin: "3px 0 0",
-                                                    fontFamily: FONT_UI,
-                                                    fontSize: "0.68rem",
-                                                    letterSpacing: "0.08em",
-                                                    textTransform: "uppercase",
-                                                    color: C_GOLD_DIM,
-                                                }}
-                                            >
-                                                Requires ST approval
-                                            </p>
-                                        )}
+                        <div style={generatorScrollableContentStyle}>
+                            <Text size="xs" c="dimmed" mb={8} style={{ fontFamily: FONT_UI }}>
+                                Cost: new level × 5 XP &nbsp;·&nbsp; Grey dots were set in the Attributes step
+                            </Text>
+                            {ATTR_GROUPS.map(group => (
+                                <div key={group.label} style={{ marginBottom: 20 }}>
+                                    <div style={{ fontFamily: FONT_DISPLAY, fontSize: "0.7rem", letterSpacing: "0.1em", textTransform: "uppercase", color: C_GOLD_DIM, marginBottom: 6 }}>
+                                        {group.label}
                                     </div>
-                                    <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
-                                        {/* Purchased dots badge */}
-                                        {purchasedCount > 0 && (
-                                            <span
-                                                style={{
-                                                    padding: "2px 8px",
-                                                    borderRadius: 4,
-                                                    border: `1px solid ${rgba(RAW_RED, 0.45)}`,
-                                                    background: rgba(RAW_RED, 0.12),
-                                                    fontFamily: FONT_UI,
-                                                    fontSize: "0.62rem",
-                                                    letterSpacing: "0.1em",
-                                                    textTransform: "uppercase",
-                                                    color: C_RED_DIM,
-                                                }}
-                                            >
-                                                {purchasedCount} dot{purchasedCount !== 1 ? "s" : ""}
-                                            </span>
-                                        )}
-                                        {/* Source badge */}
-                                        <span
-                                            style={{
-                                                padding: "3px 8px",
-                                                borderRadius: 4,
-                                                border: `1px solid rgba(125, 91, 72, 0.3)`,
-                                                fontFamily: FONT_UI,
-                                                fontSize: "0.62rem",
-                                                letterSpacing: "0.1em",
-                                                textTransform: "uppercase",
-                                                color: C_MUTED,
-                                            }}
-                                        >
-                                            {sourceLabel(loresheet.source)}
-                                        </span>
-                                        {/* Chevron */}
-                                        <span style={{ color: "rgba(220, 210, 205, 0.45)", fontSize: "0.8rem" }}>
-                                            {isExpanded ? "▲" : "▼"}
-                                        </span>
+                                    {group.attrs.map(key => (
+                                        <StatRow
+                                            key={key}
+                                            name={key}
+                                            base={baseAttrs[key]}
+                                            current={character.attributes[key]}
+                                            min={1}
+                                            max={5}
+                                            costFn={attrLevelCost}
+                                            remaining={remaining}
+                                            onSet={level => setAttr(key, level)}
+                                        />
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    </ScrollArea>
+                </Tabs.Panel>
+
+                {/* ── Skills panel ── */}
+                <Tabs.Panel value="skills">
+                    <ScrollArea
+                        style={{ flex: 1 }}
+                        px={20}
+                        pb={40}
+                        scrollbarSize={nightfallScrollbarSize}
+                        type="always"
+                        styles={nightfallScrollAreaStyles}
+                    >
+                        <div style={generatorScrollableContentStyle}>
+                            <Text size="xs" c="dimmed" mb={8} style={{ fontFamily: FONT_UI }}>
+                                Cost: new level × 3 XP &nbsp;·&nbsp; Grey dots were set in the Skills step
+                            </Text>
+                            {SKILL_GROUPS.map(group => (
+                                <div key={group.label} style={{ marginBottom: 20 }}>
+                                    <div style={{ fontFamily: FONT_DISPLAY, fontSize: "0.7rem", letterSpacing: "0.1em", textTransform: "uppercase", color: C_GOLD_DIM, marginBottom: 6 }}>
+                                        {group.label}
                                     </div>
-                                </button>
+                                    {group.skills.map(key => (
+                                        <StatRow
+                                            key={key}
+                                            name={key}
+                                            base={baseSkills[key]}
+                                            current={character.skills[key]}
+                                            min={0}
+                                            max={5}
+                                            costFn={skillLevelCost}
+                                            remaining={remaining}
+                                            onSet={level => setSkill(key, level)}
+                                        />
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    </ScrollArea>
+                </Tabs.Panel>
 
-                                {/* Dots — only when expanded */}
-                                {isExpanded && <div style={{ padding: "8px 0" }}>
-                                    {loresheet.dots.map((dotEntry) => {
-                                        const purchased = isPurchased(character, loresheet.id, dotEntry.dot)
-                                        const dotAvailable = isDotAvailable(dotEntry, clan)
-                                        const cost = loresheetDotCost(dotEntry.dot)
-
-                                        return (
+                {/* ── Loresheets panel ── */}
+                <Tabs.Panel value="loresheets">
+                    <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "0 20px" }}>
+                        <div style={{ ...generatorScrollableContentStyle, marginBottom: 8 }}>
+                            <TextInput
+                                placeholder="Search loresheets…"
+                                value={lsSearch}
+                                onChange={e => setLsSearch(e.currentTarget.value)}
+                                size="xs"
+                                styles={{ input: { background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", color: C_FG } }}
+                            />
+                        </div>
+                        <ScrollArea
+                            style={{ flex: 1, minHeight: 0 }}
+                            pb={8}
+                            type="always"
+                            scrollbarSize={nightfallScrollbarSize}
+                            styles={nightfallScrollAreaStyles}
+                        >
+                            <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 700, margin: "0 auto", paddingBottom: 40 }}>
+                                {visibleLoresheets.map(loresheet => {
+                                    const isExpanded = expandedIds.has(loresheet.id)
+                                    const purchasedCount = (character.loresheet_purchases ?? []).filter(p => p.loresheet_id === loresheet.id).length
+                                    return (
+                                        <div
+                                            key={loresheet.id}
+                                            style={{ borderRadius: 10, border: `1px solid ${purchasedCount > 0 ? rgba(RAW_RED, 0.35) : C_BORDER}`, background: C_CARD, overflow: "hidden" }}
+                                        >
                                             <button
-                                                key={dotEntry.dot}
-                                                onClick={() => {
-                                                    if (!dotAvailable) return
-                                                    setCharacter(togglePurchase(character, loresheet.id, dotEntry))
-                                                }}
-                                                disabled={!dotAvailable}
-                                                style={{
-                                                    display: "flex",
-                                                    alignItems: "flex-start",
-                                                    gap: 14,
-                                                    width: "100%",
-                                                    padding: "10px 18px",
-                                                    background: purchased
-                                                        ? rgba(RAW_RED, 0.07)
-                                                        : "transparent",
-                                                    border: "none",
-                                                    borderBottom: `1px solid rgba(125, 91, 72, 0.12)`,
-                                                    cursor: dotAvailable ? "pointer" : "not-allowed",
-                                                    textAlign: "left",
-                                                    fontFamily: "inherit",
-                                                    transition: "background 150ms ease",
-                                                    opacity: dotAvailable ? 1 : 0.38,
-                                                }}
-                                                onMouseEnter={(e) => {
-                                                    if (!dotAvailable || purchased) return
-                                                    e.currentTarget.style.background = "rgba(255, 255, 255, 0.04)"
-                                                }}
-                                                onMouseLeave={(e) => {
-                                                    e.currentTarget.style.background = purchased
-                                                        ? rgba(RAW_RED, 0.07)
-                                                        : "transparent"
-                                                }}
+                                                onClick={() => toggleExpanded(loresheet.id)}
+                                                style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, width: "100%", padding: "14px 18px 12px", background: "transparent", border: "none", borderBottom: isExpanded ? "1px solid rgba(125,91,72,0.2)" : "none", cursor: "pointer", textAlign: "left", fontFamily: "inherit" }}
                                             >
-                                                {/* Checkbox */}
-                                                <div
-                                                    style={{
-                                                        flexShrink: 0,
-                                                        width: 20,
-                                                        height: 20,
-                                                        marginTop: 1,
-                                                        borderRadius: 4,
-                                                        border: `1.5px solid ${purchased ? C_RED : "rgba(125, 91, 72, 0.5)"}`,
-                                                        background: purchased ? rgba(RAW_RED, 0.15) : "transparent",
-                                                        display: "flex",
-                                                        alignItems: "center",
-                                                        justifyContent: "center",
-                                                        transition: "all 150ms ease",
-                                                    }}
-                                                >
-                                                    {purchased && <IconCheck size={12} color={C_RED} strokeWidth={2.5} />}
-                                                </div>
-
-                                                {/* Dot label + description */}
                                                 <div style={{ flex: 1, minWidth: 0 }}>
-                                                    <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
-                                                        <span
-                                                            style={{
-                                                                fontFamily: FONT_UI,
-                                                                fontSize: "0.65rem",
-                                                                letterSpacing: "0.1em",
-                                                                color: purchased ? C_RED_DIM : C_MUTED,
-                                                                flexShrink: 0,
-                                                            }}
-                                                        >
-                                                            {"●".repeat(dotEntry.dot)}{"○".repeat(5 - dotEntry.dot)}
-                                                        </span>
-                                                        <span
-                                                            style={{
-                                                                fontFamily: FONT_BODY,
-                                                                fontSize: "0.92rem",
-                                                                fontWeight: 600,
-                                                                color: C_FG,
-                                                            }}
-                                                        >
-                                                            {dotEntry.name}
-                                                        </span>
-                                                        {!dotAvailable && dotEntry.clanRestriction && (
-                                                            <span
-                                                                style={{
-                                                                    fontFamily: FONT_UI,
-                                                                    fontSize: "0.62rem",
-                                                                    letterSpacing: "0.08em",
-                                                                    textTransform: "uppercase",
-                                                                    color: C_GOLD_DIM,
-                                                                }}
-                                                            >
-                                                                {dotEntry.clanRestriction.join(" / ")} only
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                    <p
-                                                        style={{
-                                                            margin: "3px 0 0",
-                                                            fontFamily: FONT_BODY,
-                                                            fontSize: "0.85rem",
-                                                            color: C_MUTED,
-                                                            lineHeight: 1.4,
-                                                        }}
-                                                    >
-                                                        {dotEntry.description}
+                                                    <p style={{ margin: 0, fontFamily: FONT_DISPLAY, fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.06em", color: C_FG }}>
+                                                        {loresheet.name}
                                                     </p>
+                                                    {loresheet.requiresStPermission && (
+                                                        <p style={{ margin: "3px 0 0", fontFamily: FONT_UI, fontSize: "0.68rem", letterSpacing: "0.08em", textTransform: "uppercase", color: C_GOLD_DIM }}>
+                                                            Requires ST approval
+                                                        </p>
+                                                    )}
                                                 </div>
-
-                                                {/* Cost badge */}
-                                                <div
-                                                    style={{
-                                                        flexShrink: 0,
-                                                        padding: "4px 10px",
-                                                        borderRadius: 6,
-                                                        border: `1px solid ${purchased ? rgba(RAW_RED, 0.4) : "rgba(125, 91, 72, 0.25)"}`,
-                                                        background: purchased
-                                                            ? rgba(RAW_RED, 0.1)
-                                                            : "rgba(255, 255, 255, 0.03)",
-                                                        textAlign: "center",
-                                                    }}
-                                                >
-                                                    <div
-                                                        style={{
-                                                            fontFamily: FONT_DISPLAY,
-                                                            fontSize: "0.85rem",
-                                                            fontWeight: 700,
-                                                            color: purchased ? C_RED : C_MUTED,
-                                                        }}
-                                                    >
-                                                        {cost} XP
-                                                    </div>
+                                                <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                                                    {purchasedCount > 0 && (
+                                                        <span style={{ padding: "2px 8px", borderRadius: 4, border: `1px solid ${rgba(RAW_RED, 0.45)}`, background: rgba(RAW_RED, 0.12), fontFamily: FONT_UI, fontSize: "0.62rem", letterSpacing: "0.1em", textTransform: "uppercase", color: C_RED_DIM }}>
+                                                            {purchasedCount} dot{purchasedCount !== 1 ? "s" : ""}
+                                                        </span>
+                                                    )}
+                                                    <span style={{ padding: "3px 8px", borderRadius: 4, border: "1px solid rgba(125,91,72,0.3)", fontFamily: FONT_UI, fontSize: "0.62rem", letterSpacing: "0.1em", textTransform: "uppercase", color: C_MUTED }}>
+                                                        {SOURCE_LABELS[loresheet.source] ?? loresheet.source}
+                                                    </span>
+                                                    <span style={{ color: "rgba(220,210,205,0.45)", fontSize: "0.8rem" }}>
+                                                        {isExpanded ? "▲" : "▼"}
+                                                    </span>
                                                 </div>
                                             </button>
-                                        )
-                                    })}
-                                </div>}
-                            </div>
-                        )
-                        })}
-                    </div>
 
-                    {/* Continue button */}
-                    <div style={{ maxWidth: 700, margin: "24px auto 0", textAlign: "right" }}>
-                        <Button
-                            onClick={nextStep}
-                            variant="filled"
-                            color="red.8"
-                            style={{ fontFamily: FONT_UI, letterSpacing: "0.06em" }}
-                        >
-                            Continue
-                        </Button>
+                                            {isExpanded && (
+                                                <div style={{ padding: "8px 0" }}>
+                                                    {loresheet.dots.map(dotEntry => {
+                                                        const purchased = isPurchased(character, loresheet.id, dotEntry.dot)
+                                                        const available = isDotAvailable(dotEntry, character.clan ?? "")
+                                                        const cost = loresheetDotCost(dotEntry.dot)
+                                                        const canAfford = purchased || remaining >= cost
+                                                        return (
+                                                            <button
+                                                                key={dotEntry.dot}
+                                                                onClick={() => { if (available) setCharacter(togglePurchase(character, loresheet.id, dotEntry.dot)) }}
+                                                                disabled={!available || (!purchased && !canAfford)}
+                                                                style={{ display: "flex", alignItems: "flex-start", gap: 14, width: "100%", padding: "10px 18px", background: purchased ? rgba(RAW_RED, 0.07) : "transparent", border: "none", borderBottom: "1px solid rgba(125,91,72,0.12)", cursor: available ? "pointer" : "not-allowed", textAlign: "left", fontFamily: "inherit", transition: "background 150ms ease", opacity: available && (purchased || canAfford) ? 1 : 0.38 }}
+                                                            >
+                                                                <div style={{ flexShrink: 0, width: 20, height: 20, marginTop: 1, borderRadius: 4, border: `1.5px solid ${purchased ? C_RED : "rgba(125,91,72,0.5)"}`, background: purchased ? rgba(RAW_RED, 0.15) : "transparent", display: "flex", alignItems: "center", justifyContent: "center", transition: "all 150ms ease" }}>
+                                                                    {purchased && <IconCheck size={12} color={C_RED} strokeWidth={2.5} />}
+                                                                </div>
+                                                                <div style={{ flex: 1, minWidth: 0 }}>
+                                                                    <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+                                                                        <span style={{ fontFamily: FONT_UI, fontSize: "0.65rem", letterSpacing: "0.1em", color: purchased ? C_RED_DIM : C_MUTED, flexShrink: 0 }}>
+                                                                            {"●".repeat(dotEntry.dot)}{"○".repeat(5 - dotEntry.dot)}
+                                                                        </span>
+                                                                        <span style={{ fontFamily: FONT_BODY, fontSize: "0.92rem", fontWeight: 600, color: C_FG }}>
+                                                                            {dotEntry.name}
+                                                                        </span>
+                                                                        {!available && dotEntry.clanRestriction && (
+                                                                            <span style={{ fontFamily: FONT_UI, fontSize: "0.62rem", letterSpacing: "0.08em", textTransform: "uppercase", color: C_GOLD_DIM }}>
+                                                                                {dotEntry.clanRestriction.join(" / ")} only
+                                                                            </span>
+                                                                        )}
+                                                                    </div>
+                                                                    <p style={{ margin: "3px 0 0", fontFamily: FONT_BODY, fontSize: "0.85rem", color: C_MUTED, lineHeight: 1.4 }}>
+                                                                        {dotEntry.description}
+                                                                    </p>
+                                                                </div>
+                                                                <div style={{ flexShrink: 0, padding: "4px 10px", borderRadius: 6, border: `1px solid ${purchased ? rgba(RAW_RED, 0.4) : "rgba(125,91,72,0.25)"}`, background: purchased ? rgba(RAW_RED, 0.1) : "rgba(255,255,255,0.03)", textAlign: "center" }}>
+                                                                    <div style={{ fontFamily: FONT_DISPLAY, fontSize: "0.85rem", fontWeight: 700, color: purchased ? C_RED : C_MUTED }}>
+                                                                        {cost} XP
+                                                                    </div>
+                                                                </div>
+                                                            </button>
+                                                        )
+                                                    })}
+                                                </div>
+                                            )}
+                                        </div>
+                                    )
+                                })}
+                            </div>
+                        </ScrollArea>
                     </div>
+                </Tabs.Panel>
+            </Tabs>
+
+            {/* ── Continue button ── */}
+            <div style={{ flexShrink: 0, padding: "12px 20px", display: "flex", justifyContent: "flex-end" }}>
+                <div style={generatorScrollableContentStyle}>
+                    <Button
+                        onClick={nextStep}
+                        variant="filled"
+                        color="red.8"
+                        disabled={overBudget}
+                        style={{ fontFamily: FONT_UI, letterSpacing: "0.06em" }}
+                    >
+                        {overBudget ? "Over budget — adjust purchases" : "Continue"}
+                    </Button>
                 </div>
-            </ScrollArea>
+            </div>
         </div>
     )
 }

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -11,6 +11,7 @@ import {
     Stack,
     Tabs,
     Text,
+    TextInput,
     Tooltip,
     useMantineTheme
 } from "@mantine/core"
@@ -124,13 +125,19 @@ const MeritOrFlawCard = memo(
         const alreadyPickedItem = pickedByName.get(meritOrFlaw.name)
         const wasPickedLevel = alreadyPickedItem?.level ?? 0
         const excludingItems = exclusionMap.get(meritOrFlaw.name) ?? []
-        const isExcluded = excludingItems.length > 0
+        // PT-provided merits that this merit excludes can be "upgraded through" — pay the difference
+        const ptUpgradeItems = excludingItems.filter(name => predatorTypeMeritsByName.has(name))
+        const hardExcludingItems = excludingItems.filter(name => !predatorTypeMeritsByName.has(name))
+        const isExcluded = hardExcludingItems.length > 0
+        const ptUpgradeCredit = ptUpgradeItems.reduce(
+            (sum, name) => sum + (predatorTypeMeritsByName.get(name)?.level ?? 0), 0
+        )
 
         const meritInPredatorType = predatorTypeMeritsByName.get(meritOrFlaw.name)
         const meritInPredatorTypeLevel = meritInPredatorType?.level ?? 0
 
         const createButton = (level: number) => {
-            const cost = level - meritInPredatorTypeLevel
+            const cost = level - meritInPredatorTypeLevel - ptUpgradeCredit
             return (
                 <Button
                     key={meritOrFlaw.name + level}
@@ -187,7 +194,7 @@ const MeritOrFlawCard = memo(
         const summaryText = meritInPredatorType
             ? "Already picked in Predator Type"
             : isExcluded
-              ? `Excluded by: ${excludingItems.join(", ")}`
+              ? `Excluded by: ${hardExcludingItems.join(", ")}`
               : meritOrFlaw.summary
 
         const textContent = (
@@ -268,7 +275,7 @@ const MeritOrFlawCard = memo(
             return (
                 <Tooltip
                     key={lineKey}
-                    label={`This ${type} is excluded because you already have: ${excludingItems.join(", ")}`}
+                    label={`This ${type} is excluded because you already have: ${hardExcludingItems.join(", ")}`}
                     withArrow
                 >
                     {textContent}
@@ -289,6 +296,9 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
 
     const [activeTab, setActiveTab] = useState<string | null>("backgrounds")
     const [resetTarget, setResetTarget] = useState<ResetTarget>(null)
+    const [bgSearch, setBgSearch] = useState("")
+    const [mfSearch, setMfSearch] = useState("")
+    const [lsSearch, setLsSearch] = useState("")
 
     const [pickedMeritsAndFlaws, setPickedMeritsAndFlaws] = useState<MeritFlaw[]>([
         ...character.merits,
@@ -648,11 +658,21 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                             padding: "0 20px"
                         }}
                     >
+                        <TextInput
+                            placeholder="Search backgrounds…"
+                            value={bgSearch}
+                            onChange={e => setBgSearch(e.currentTarget.value)}
+                            size="xs"
+                            mb="xs"
+                            styles={{ input: { background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(244,236,232,0.9)" } }}
+                        />
                         <ScrollArea {...columnScrollProps}>
                             <Stack gap="sm" pb="xl">
-                                {allBackgroundEntries.map((entry) =>
-                                    getMeritOrFlawLine(entry.item, entry.entryType)
-                                )}
+                                {allBackgroundEntries
+                                    .filter(e => !bgSearch || e.item.name.toLowerCase().includes(bgSearch.toLowerCase()))
+                                    .map((entry) =>
+                                        getMeritOrFlawLine(entry.item, entry.entryType)
+                                    )}
                             </Stack>
                         </ScrollArea>
                     </div>
@@ -669,7 +689,30 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                             padding: "0 20px"
                         }}
                     >
-                        {isThinBlood && phoneScreen ? (
+                        <TextInput
+                            placeholder="Search merits & flaws…"
+                            value={mfSearch}
+                            onChange={e => setMfSearch(e.currentTarget.value)}
+                            size="xs"
+                            mb="xs"
+                            styles={{ input: { background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(244,236,232,0.9)" } }}
+                        />
+                        {mfSearch ? (
+                            <ScrollArea {...columnScrollProps}>
+                                <Stack gap="sm" pb="xl">
+                                    {[
+                                        ...essentialThinbloodMeritsAndFlaws.merits.map(m => ({ item: m, type: "merit" as const })),
+                                        ...essentialThinbloodMeritsAndFlaws.flaws.map(f => ({ item: f, type: "flaw" as const })),
+                                        ...allMFCategories.flatMap(cat => [
+                                            ...cat.merits.map(m => ({ item: m, type: "merit" as const })),
+                                            ...cat.flaws.map(f => ({ item: f, type: "flaw" as const }))
+                                        ])
+                                    ]
+                                        .filter(({ item }) => item.name.toLowerCase().includes(mfSearch.toLowerCase()))
+                                        .map(({ item, type }) => getMeritOrFlawLine(item, type))}
+                                </Stack>
+                            </ScrollArea>
+                        ) : isThinBlood && phoneScreen ? (
                             <Text
                                 ta="center"
                                 style={{
@@ -683,7 +726,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                                 Pick Thin-blood flaws to gain Thin-blood merit points
                             </Text>
                         ) : null}
-                        {phoneScreen ? (
+                        {!mfSearch && phoneScreen ? (
                             <ScrollArea {...columnScrollProps}>
                                 <Stack gap="sm" pb="xl">
                                     {isThinBlood ? (
@@ -764,10 +807,20 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                 <Tabs.Panel value="loresheets">
                     <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "0 20px" }}>
                         <div style={{ ...generatorScrollableContentStyle, height: "100%", display: "flex", flexDirection: "column" }}>
+                            <TextInput
+                                placeholder="Search loresheets…"
+                                value={lsSearch}
+                                onChange={e => setLsSearch(e.currentTarget.value)}
+                                size="xs"
+                                mb={8}
+                                styles={{ input: { background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(244,236,232,0.9)" } }}
+                            />
                             <ScrollArea style={{ flex: 1, minHeight: 0 }} pb={8} type="always" scrollbarSize={nightfallScrollbarSize} styles={nightfallScrollAreaStyles}>
                                 <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 700, margin: "0 auto", paddingTop: 8, paddingBottom: 40 }}>
                                     {LORESHEETS
                                         .filter(ls => !ls.clanRestriction?.length || ls.clanRestriction.includes(character.clan))
+                                        .filter(ls => !lsSearch || ls.name.toLowerCase().includes(lsSearch.toLowerCase()))
+                                        .sort((a, b) => a.name.localeCompare(b.name))
                                         .map(ls => {
                                             const isExpanded = expandedLoresheetIds.has(ls.id)
                                             const purchasedCount = ls.dots.filter(d => isLoresheetDotSelected(ls.name, d.name)).length


### PR DESCRIPTION
## Summary
- Credits the Protean merit upgrade cost toward freebies correctly
- Adds search and alphabetical sorting to the Loresheets picker in the Freebies tab
- Opens starting XP spend to attributes, skills, and loresheets (previously restricted)

## Test plan
- [ ] Freebie step: Protean merit upgrade reflected in freebie cost correctly
- [ ] Loresheets picker: search filters results; list is alphabetized
- [ ] Starting XP: can spend on attributes, skills, and loresheets without restriction

🤖 Generated with [Claude Code](https://claude.com/claude-code)