### PR TITLE
feat: coterie domain ratings + /coterie status Discord command

### DIFF
--- a/apps/bot/src/commands/coterie.ts
+++ b/apps/bot/src/commands/coterie.ts
@@ -1,0 +1,144 @@
+/**
+ * /coterie — coterie info commands for players.
+ */
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { errorToMessage } from '../logger';
+import { config } from '../config';
+
+const _BLOOD = 0x8b1a1a;
+const _GOLD  = 0xc8a85b;
+const _GREY  = 0x5a5a5a;
+
+function _dots(rating: number, max = 5): string {
+  const n = Math.max(0, Math.min(max, rating ?? 0));
+  return '●'.repeat(n) + '○'.repeat(max - n);
+}
+
+export const name = 'coterie';
+
+export const data = new SlashCommandBuilder()
+  .setName('coterie')
+  .setDescription('Coterie information')
+  .addSubcommand((s) =>
+    s
+      .setName('status')
+      .setDescription("Show your coterie's domain and members.")
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name (only needed if you have multiple)')
+          .setRequired(false),
+      ),
+  );
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+  { adapter }: CommandContext,
+): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub === 'status') {
+    await handleStatus(interaction, adapter);
+  }
+}
+
+async function handleStatus(
+  interaction: ChatInputCommandInteraction,
+  adapter: CommandContext['adapter'],
+): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const discordId = interaction.user.id;
+
+  let data: Awaited<ReturnType<typeof adapter.getCoterieForCharacter>>;
+  try {
+    data = await adapter.getCoterieForCharacter(discordId);
+  } catch (err) {
+    await interaction.editReply(
+      `❌ Could not reach the tracker right now. Try again in a moment.\n\`${errorToMessage(err)}\``,
+    );
+    return;
+  }
+
+  if (!data) {
+    await interaction.editReply(
+      'You have no active character registered in the tracker.',
+    );
+    return;
+  }
+
+  const requestedName = interaction.options.getString('character');
+  if (requestedName && data.character_name.toLowerCase() !== requestedName.toLowerCase()) {
+    await interaction.editReply(
+      `No active character named **${requestedName}** found for your account. ` +
+      `Your registered character is **${data.character_name}**.`,
+    );
+    return;
+  }
+
+  if (!data.coterie) {
+    await interaction.editReply(
+      `**${data.character_name}** is not in a coterie.\n\n` +
+      'Coterie formations are reviewed by staff — talk to your Storyteller.',
+    );
+    return;
+  }
+
+  const embed = buildCoterieEmbed(data);
+  await interaction.editReply({ embeds: [embed] });
+}
+
+function buildCoterieEmbed(
+  data: NonNullable<Awaited<ReturnType<CommandContext['adapter']['getCoterieForCharacter']>>>,
+): EmbedBuilder {
+  const co = data.coterie!;
+  const members = data.members;
+
+  const color = co.status === 'active' ? _BLOOD : _GREY;
+
+  const embed = new EmbedBuilder()
+    .setTitle(`🩸 ${co.name}`)
+    .setColor(color);
+
+  if (co.description) {
+    embed.setDescription(co.description);
+  }
+
+  // Domain
+  const domainLines = [
+    `Chasse     ${_dots(co.chasse)}  ${co.chasse}/5`,
+    `Lien       ${_dots(co.lien)}  ${co.lien}/5`,
+    `Portillon  ${_dots(co.portillon)}  ${co.portillon}/5`,
+  ];
+  embed.addFields({
+    name: 'Domain',
+    value: `\`\`\`\n${domainLines.join('\n')}\n\`\`\``,
+    inline: false,
+  });
+
+  // Members
+  const memberLines = members.map((m) => {
+    const clan = (m.clan || '').replace(/-/g, ' ');
+    let line = `• **${m.character_name}**`;
+    if (clan) line += `  ·  _${clan}_`;
+    if (m.player_name) line += `  ·  \`${m.player_name}\``;
+    if (m.character_name === data.character_name) line += '  ·  **you**';
+    return line;
+  });
+  embed.addFields({
+    name: `Members (${members.length})`,
+    value: memberLines.join('\n') || '—',
+    inline: false,
+  });
+
+  const webUrl = config.webAppBaseUrl;
+  embed.setFooter({
+    text: `Status: ${co.status.charAt(0).toUpperCase() + co.status.slice(1)}  ·  View at ${webUrl}/coteries/${co.slug}`,
+  });
+
+  return embed;
+}

--- a/apps/bot/src/commands/coterie.ts
+++ b/apps/bot/src/commands/coterie.ts
@@ -53,10 +53,11 @@ async function handleStatus(
   await interaction.deferReply({ ephemeral: true });
 
   const discordId = interaction.user.id;
+  const requestedName = interaction.options.getString('character') ?? undefined;
 
   let data: Awaited<ReturnType<typeof adapter.getCoterieForCharacter>>;
   try {
-    data = await adapter.getCoterieForCharacter(discordId);
+    data = await adapter.getCoterieForCharacter(discordId, requestedName);
   } catch (err) {
     await interaction.editReply(
       `❌ Could not reach the tracker right now. Try again in a moment.\n\`${errorToMessage(err)}\``,
@@ -65,17 +66,9 @@ async function handleStatus(
   }
 
   if (!data) {
+    const suffix = requestedName ? ` named **${requestedName}**` : '';
     await interaction.editReply(
-      'You have no active character registered in the tracker.',
-    );
-    return;
-  }
-
-  const requestedName = interaction.options.getString('character');
-  if (requestedName && data.character_name.toLowerCase() !== requestedName.toLowerCase()) {
-    await interaction.editReply(
-      `No active character named **${requestedName}** found for your account. ` +
-      `Your registered character is **${data.character_name}**.`,
+      `You have no active character${suffix} registered in the tracker.`,
     );
     return;
   }

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -149,6 +149,20 @@ export interface TrackerAdapter {
     discord_channel_id: string | null;
     members: Array<{ character_name: string; clan: string; player_discord_id: string }>;
   }>>;
+  getCoterieForCharacter(discordId: string): Promise<{
+    character_name: string;
+    coterie: {
+      id: number;
+      name: string;
+      slug: string;
+      description: string;
+      status: string;
+      chasse: number;
+      lien: number;
+      portillon: number;
+    } | null;
+    members: Array<{ character_name: string; clan: string; player_discord_id: string; player_name: string }>;
+  } | null>;
 }
 
 export type CharacterDetails = {
@@ -1331,6 +1345,16 @@ export class WebAppAdapter implements TrackerAdapter {
     if (!res.ok) throw new Error(`coteries GET failed: ${res.status}`);
     const data = await res.json() as { coteries: ReturnType<TrackerAdapter['listCoteries']> extends Promise<infer T> ? T : never };
     return data.coteries;
+  }
+
+  async getCoterieForCharacter(discordId: string) {
+    const res = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/coteries/by-character/${encodeURIComponent(discordId)}`,
+      { method: 'GET', headers: this.readAuthHeaders() },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`coteries/by-character GET failed: ${res.status}`);
+    return res.json() as Promise<ReturnType<TrackerAdapter['getCoterieForCharacter']> extends Promise<infer T> ? T : never>;
   }
 
   private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -149,7 +149,7 @@ export interface TrackerAdapter {
     discord_channel_id: string | null;
     members: Array<{ character_name: string; clan: string; player_discord_id: string }>;
   }>>;
-  getCoterieForCharacter(discordId: string): Promise<{
+  getCoterieForCharacter(discordId: string, characterName?: string): Promise<{
     character_name: string;
     coterie: {
       id: number;
@@ -1347,9 +1347,10 @@ export class WebAppAdapter implements TrackerAdapter {
     return data.coteries;
   }
 
-  async getCoterieForCharacter(discordId: string) {
+  async getCoterieForCharacter(discordId: string, characterName?: string) {
+    const qs = characterName ? `?character_name=${encodeURIComponent(characterName)}` : '';
     const res = await this.fetchWithTimeout(
-      `${this.baseUrl}/api/coteries/by-character/${encodeURIComponent(discordId)}`,
+      `${this.baseUrl}/api/coteries/by-character/${encodeURIComponent(discordId)}${qs}`,
       { method: 'GET', headers: this.readAuthHeaders() },
     );
     if (res.status === 404) return null;

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -2044,10 +2044,13 @@ def get_coterie_for_character(discord_id: str):
     Response: { coterie, character_name, members } or 404.
     """
     from app.db import Coterie, CoterieMember, DbCharacter
+    from sqlalchemy import func as _func
 
-    char = DbCharacter.query.filter_by(
-        player_discord=discord_id, active=True
-    ).first()
+    character_name = request.args.get('character_name', '').strip()
+    q = DbCharacter.query.filter_by(player_discord=discord_id, active=True)
+    if character_name:
+        q = q.filter(_func.lower(DbCharacter.character_name) == character_name.lower())
+    char = q.first()
     if not char:
         return jsonify({'error': 'No active character found for this Discord user'}), 404
 

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -2033,3 +2033,52 @@ def activate_coterie():
             'free_pool_total': sum(m.free_dots_remaining for m in coterie.members),
         },
     })
+
+
+@bp.route('/coteries/by-character/<discord_id>', methods=['GET'])
+@require_bot_scope('read')
+def get_coterie_for_character(discord_id: str):
+    """Return the coterie for the given player's active character.
+
+    Used by the bot's /coterie status command.
+    Response: { coterie, character_name, members } or 404.
+    """
+    from app.db import Coterie, CoterieMember, DbCharacter
+
+    char = DbCharacter.query.filter_by(
+        player_discord=discord_id, active=True
+    ).first()
+    if not char:
+        return jsonify({'error': 'No active character found for this Discord user'}), 404
+
+    membership = CoterieMember.query.filter_by(
+        roster_character_id=char.id
+    ).first()
+    if not membership:
+        return jsonify({'coterie': None, 'character_name': char.character_name}), 200
+
+    coterie = membership.coterie
+    members = []
+    for m in coterie.members:
+        c = m.character
+        members.append({
+            'character_name': c.character_name,
+            'clan': c.clan or '',
+            'player_discord_id': c.player_discord or '',
+            'player_name': c.player_discord_name or '',
+        })
+
+    return jsonify({
+        'character_name': char.character_name,
+        'coterie': {
+            'id': coterie.id,
+            'name': coterie.name,
+            'slug': coterie.slug,
+            'description': coterie.description or '',
+            'status': coterie.status,
+            'chasse': coterie.chasse,
+            'lien': coterie.lien,
+            'portillon': coterie.portillon,
+        },
+        'members': members,
+    })

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -2043,7 +2043,7 @@ def get_coterie_for_character(discord_id: str):
     Used by the bot's /coterie status command.
     Response: { coterie, character_name, members } or 404.
     """
-    from app.db import Coterie, CoterieMember, DbCharacter
+    from app.db import CoterieMember, DbCharacter
     from sqlalchemy import func as _func
 
     character_name = request.args.get('character_name', '').strip()

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -273,6 +273,20 @@ def edit(slug: str):
     return redirect(url_for('coteries.manage', slug=slug))
 
 
+@bp.route('/<slug>/domain', methods=['POST'])
+@require_staff
+def update_domain(slug: str):
+    """Staff: set Chasse / Lien / Portillon ratings."""
+    coterie = _get_coterie_or_404(slug)
+    coterie.chasse = max(0, min(5, request.form.get('chasse', 0, type=int)))
+    coterie.lien = max(0, min(5, request.form.get('lien', 0, type=int)))
+    coterie.portillon = max(0, min(5, request.form.get('portillon', 0, type=int)))
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash('Domain ratings updated.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
 # ---------------------------------------------------------------------------
 # Staff/member: add pool advantage
 # ---------------------------------------------------------------------------

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -306,6 +306,11 @@ class Coterie(db.Model):
                            default=lambda: datetime.now(timezone.utc),
                            onupdate=lambda: datetime.now(timezone.utc))
 
+    # Domain ratings (0–5 each). Advanced via coterie XP spends, set by staff.
+    chasse = db.Column(Integer, nullable=False, default=0)
+    lien = db.Column(Integer, nullable=False, default=0)
+    portillon = db.Column(Integer, nullable=False, default=0)
+
     members = db.relationship('CoterieMember', back_populates='coterie',
                               cascade='all, delete-orphan')
     advantages = db.relationship('CoterieAdvantage', back_populates='coterie',

--- a/apps/web/app/templates/coteries/manage.html
+++ b/apps/web/app/templates/coteries/manage.html
@@ -135,6 +135,33 @@
             </div>
         </div>
 
+        <!-- Domain -->
+        <div class="card mb-3">
+            <div class="card-header fw-bold"><i class="bi bi-map"></i> Domain</div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('coteries.update_domain', slug=coterie.slug) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="row g-2 mb-3">
+                        {% for label, field, val in [
+                            ('Chasse', 'chasse', coterie.chasse),
+                            ('Lien', 'lien', coterie.lien),
+                            ('Portillon', 'portillon', coterie.portillon),
+                        ] %}
+                        <div class="col-4">
+                            <label class="form-label fw-bold small mb-1">{{ label }}</label>
+                            <select name="{{ field }}" class="form-select form-select-sm">
+                                {% for n in range(6) %}
+                                <option value="{{ n }}" {% if val == n %}selected{% endif %}>{{ n }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    <button class="btn btn-sm btn-outline-secondary">Update Domain</button>
+                </form>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-header fw-bold small text-muted">Pool Summary</div>
             <div class="card-body small text-muted">

--- a/apps/web/app/templates/coteries/view.html
+++ b/apps/web/app/templates/coteries/view.html
@@ -26,6 +26,26 @@
 
 <div class="row g-4">
 
+    <!-- Domain -->
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header fw-bold"><i class="bi bi-map"></i> Domain</div>
+            <div class="card-body">
+                <div class="row g-3 text-center">
+                    {% for label, val in [('Chasse', coterie.chasse), ('Lien', coterie.lien), ('Portillon', coterie.portillon)] %}
+                    <div class="col-4">
+                        <div class="small text-muted text-uppercase mb-1" style="letter-spacing:.05em;font-size:.7rem;">{{ label }}</div>
+                        <div class="dot-pips justify-content-center d-flex gap-1 mb-1">
+                            {% for i in range(1,6) %}<span class="dot-pip {% if i <= val %}filled{% endif %}"></span>{% endfor %}
+                        </div>
+                        <small class="text-muted">{{ val }}/5</small>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Members -->
     <div class="col-md-4">
         <div class="card">

--- a/apps/web/migrations/versions/5a9b2c7e1d3f_add_domain_to_coteries.py
+++ b/apps/web/migrations/versions/5a9b2c7e1d3f_add_domain_to_coteries.py
@@ -1,0 +1,32 @@
+"""add chasse/lien/portillon domain columns to coteries
+
+Revision ID: 5a9b2c7e1d3f
+Revises: 4f2a1b8e6c9d
+Create Date: 2026-06-17
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+revision = '5a9b2c7e1d3f'
+down_revision = '4f2a1b8e6c9d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    columns = [c['name'] for c in inspector.get_columns('coteries')]
+    if 'chasse' not in columns:
+        op.add_column('coteries', sa.Column('chasse', sa.Integer(), nullable=False, server_default='0'))
+    if 'lien' not in columns:
+        op.add_column('coteries', sa.Column('lien', sa.Integer(), nullable=False, server_default='0'))
+    if 'portillon' not in columns:
+        op.add_column('coteries', sa.Column('portillon', sa.Integer(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('coteries', 'portillon')
+    op.drop_column('coteries', 'lien')
+    op.drop_column('coteries', 'chasse')


### PR DESCRIPTION
## Summary

- **Domain tracking**: Adds `chasse`, `lien`, `portillon` (0–5 each) to coteries. Staff can set them from the Manage page; all players see them on the coterie view page as dot pips.
- **API endpoint**: `GET /api/coteries/by-character/<discord_id>` — returns coterie info, domain ratings, and member list for a player's active character.
- **Discord command**: `/coterie status` — ephemeral embed showing domain + members. Works with or without a character name argument.

## Depends on
- Stacks on `feat/coterie-bg-donation-approval` (PR #289), which stacks on `feat/coterie-spend-donate` (PR #288).
- Merge order: #288 → #289 → this PR.

## Test plan
- [ ] Merge #288 and #289 first (or test on dev after those auto-deploy)
- [ ] Staff: Manage a coterie → set Chasse/Lien/Portillon → save → verify dots show on view page
- [ ] Player view: coterie page shows domain row with correct pips
- [ ] Bot: `/coterie status` for a character in a coterie shows embed with domain + members
- [ ] Bot: `/coterie status` for a character with no coterie returns "not in a coterie" message
- [ ] Bot: `/coterie status` for a Discord user with no character returns appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)