### PR TITLE
feat: coterie creation state machine + player proposal flow

### DIFF
--- a/apps/bot/src/commands/coterie.ts
+++ b/apps/bot/src/commands/coterie.ts
@@ -1,0 +1,144 @@
+/**
+ * /coterie — coterie info commands for players.
+ */
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { errorToMessage } from '../logger';
+import { config } from '../config';
+
+const _BLOOD = 0x8b1a1a;
+const _GOLD  = 0xc8a85b;
+const _GREY  = 0x5a5a5a;
+
+function _dots(rating: number, max = 5): string {
+  const n = Math.max(0, Math.min(max, rating ?? 0));
+  return '●'.repeat(n) + '○'.repeat(max - n);
+}
+
+export const name = 'coterie';
+
+export const data = new SlashCommandBuilder()
+  .setName('coterie')
+  .setDescription('Coterie information')
+  .addSubcommand((s) =>
+    s
+      .setName('status')
+      .setDescription("Show your coterie's domain and members.")
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Character name (only needed if you have multiple)')
+          .setRequired(false),
+      ),
+  );
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+  { adapter }: CommandContext,
+): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub === 'status') {
+    await handleStatus(interaction, adapter);
+  }
+}
+
+async function handleStatus(
+  interaction: ChatInputCommandInteraction,
+  adapter: CommandContext['adapter'],
+): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const discordId = interaction.user.id;
+
+  let data: Awaited<ReturnType<typeof adapter.getCoterieForCharacter>>;
+  try {
+    data = await adapter.getCoterieForCharacter(discordId);
+  } catch (err) {
+    await interaction.editReply(
+      `❌ Could not reach the tracker right now. Try again in a moment.\n\`${errorToMessage(err)}\``,
+    );
+    return;
+  }
+
+  if (!data) {
+    await interaction.editReply(
+      'You have no active character registered in the tracker.',
+    );
+    return;
+  }
+
+  const requestedName = interaction.options.getString('character');
+  if (requestedName && data.character_name.toLowerCase() !== requestedName.toLowerCase()) {
+    await interaction.editReply(
+      `No active character named **${requestedName}** found for your account. ` +
+      `Your registered character is **${data.character_name}**.`,
+    );
+    return;
+  }
+
+  if (!data.coterie) {
+    await interaction.editReply(
+      `**${data.character_name}** is not in a coterie.\n\n` +
+      'Coterie formations are reviewed by staff — talk to your Storyteller.',
+    );
+    return;
+  }
+
+  const embed = buildCoterieEmbed(data);
+  await interaction.editReply({ embeds: [embed] });
+}
+
+function buildCoterieEmbed(
+  data: NonNullable<Awaited<ReturnType<CommandContext['adapter']['getCoterieForCharacter']>>>,
+): EmbedBuilder {
+  const co = data.coterie!;
+  const members = data.members;
+
+  const color = co.status === 'active' ? _BLOOD : _GREY;
+
+  const embed = new EmbedBuilder()
+    .setTitle(`🩸 ${co.name}`)
+    .setColor(color);
+
+  if (co.description) {
+    embed.setDescription(co.description);
+  }
+
+  // Domain
+  const domainLines = [
+    `Chasse     ${_dots(co.chasse)}  ${co.chasse}/5`,
+    `Lien       ${_dots(co.lien)}  ${co.lien}/5`,
+    `Portillon  ${_dots(co.portillon)}  ${co.portillon}/5`,
+  ];
+  embed.addFields({
+    name: 'Domain',
+    value: `\`\`\`\n${domainLines.join('\n')}\n\`\`\``,
+    inline: false,
+  });
+
+  // Members
+  const memberLines = members.map((m) => {
+    const clan = (m.clan || '').replace(/-/g, ' ');
+    let line = `• **${m.character_name}**`;
+    if (clan) line += `  ·  _${clan}_`;
+    if (m.player_name) line += `  ·  \`${m.player_name}\``;
+    if (m.character_name === data.character_name) line += '  ·  **you**';
+    return line;
+  });
+  embed.addFields({
+    name: `Members (${members.length})`,
+    value: memberLines.join('\n') || '—',
+    inline: false,
+  });
+
+  const webUrl = config.webAppBaseUrl;
+  embed.setFooter({
+    text: `Status: ${co.status.charAt(0).toUpperCase() + co.status.slice(1)}  ·  View at ${webUrl}/coteries/${co.slug}`,
+  });
+
+  return embed;
+}

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -149,6 +149,20 @@ export interface TrackerAdapter {
     discord_channel_id: string | null;
     members: Array<{ character_name: string; clan: string; player_discord_id: string }>;
   }>>;
+  getCoterieForCharacter(discordId: string): Promise<{
+    character_name: string;
+    coterie: {
+      id: number;
+      name: string;
+      slug: string;
+      description: string;
+      status: string;
+      chasse: number;
+      lien: number;
+      portillon: number;
+    } | null;
+    members: Array<{ character_name: string; clan: string; player_discord_id: string; player_name: string }>;
+  } | null>;
 }
 
 export type CharacterDetails = {
@@ -1331,6 +1345,16 @@ export class WebAppAdapter implements TrackerAdapter {
     if (!res.ok) throw new Error(`coteries GET failed: ${res.status}`);
     const data = await res.json() as { coteries: ReturnType<TrackerAdapter['listCoteries']> extends Promise<infer T> ? T : never };
     return data.coteries;
+  }
+
+  async getCoterieForCharacter(discordId: string) {
+    const res = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/coteries/by-character/${encodeURIComponent(discordId)}`,
+      { method: 'GET', headers: this.readAuthHeaders() },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`coteries/by-character GET failed: ${res.status}`);
+    return res.json() as Promise<ReturnType<TrackerAdapter['getCoterieForCharacter']> extends Promise<infer T> ? T : never>;
   }
 
   private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {

--- a/apps/character-app/src/character_sheet/CharacterSheet.tsx
+++ b/apps/character-app/src/character_sheet/CharacterSheet.tsx
@@ -57,7 +57,8 @@ const CharacterSheet = ({ character, setCharacter }: CharacterSheetProps) => {
             character.sire === emptyChar.sire &&
             character.disciplines.length === 0 &&
             character.merits.length === 0 &&
-            character.flaws.length === 0
+            character.flaws.length === 0 &&
+            (character.backgrounds ?? []).length === 0
         )
     }, [character])
 
@@ -230,7 +231,7 @@ const CharacterSheet = ({ character, setCharacter }: CharacterSheetProps) => {
 
                                 <Touchstones options={sheetOptions} />
 
-                                {character.merits.length > 0 || character.flaws.length > 0 ? (
+                                {character.merits.length > 0 || character.flaws.length > 0 || (character.backgrounds ?? []).length > 0 ? (
                                     <Divider />
                                 ) : null}
 

--- a/apps/character-app/src/character_sheet/sections/MeritsAndFlaws.tsx
+++ b/apps/character-app/src/character_sheet/sections/MeritsAndFlaws.tsx
@@ -87,9 +87,12 @@ const MeritsAndFlaws = ({ options }: MeritsAndFlawsProps) => {
         return [...regularFlaws, ...autoFlaws]
     }, [character.flaws, predatorTypeFlaws])
 
+    const allBackgrounds = character.backgrounds ?? []
+
     if (
         character.merits.length === 0 &&
         character.flaws.length === 0 &&
+        allBackgrounds.length === 0 &&
         predatorTypeMerits.length === 0 &&
         predatorTypeFlaws.length === 0 &&
         !isEditable
@@ -127,11 +130,38 @@ const MeritsAndFlaws = ({ options }: MeritsAndFlawsProps) => {
         <>
             <Box>
                 <Title order={2} mb="md" c={primaryColor}>
-                    Merits & Flaws
+                    Advantages & Flaws
                 </Title>
                 <Grid>
+                    {allBackgrounds.length > 0 ? (
+                        <Grid.Col span={{ base: 12, md: 4 }}>
+                            <Title order={4} mb="sm">
+                                Backgrounds
+                            </Title>
+                            <Stack gap="xs">
+                                {allBackgrounds.map((bg, index) => (
+                                    <Paper
+                                        key={index}
+                                        p="sm"
+                                        withBorder
+                                        style={{ backgroundColor: paperBg }}
+                                    >
+                                        <Group justify="space-between">
+                                            <Text fw={700}>{bg.name}</Text>
+                                            <Badge color={primaryColor} circle>{bg.level}</Badge>
+                                        </Group>
+                                        {bg.summary ? (
+                                            <Text size="sm" c="dimmed" mt="xs">
+                                                {bg.summary.charAt(0).toUpperCase() + bg.summary.slice(1)}
+                                            </Text>
+                                        ) : null}
+                                    </Paper>
+                                ))}
+                            </Stack>
+                        </Grid.Col>
+                    ) : null}
                     {allMerits.length > 0 || isEditable ? (
-                        <Grid.Col span={{ base: 12, md: 6 }}>
+                        <Grid.Col span={{ base: 12, md: allBackgrounds.length > 0 ? 4 : 6 }}>
                             <Title order={4} mb="sm">
                                 Merits
                             </Title>
@@ -251,7 +281,7 @@ const MeritsAndFlaws = ({ options }: MeritsAndFlawsProps) => {
                         </Grid.Col>
                     ) : null}
                     {allFlaws.length > 0 || isEditable ? (
-                        <Grid.Col span={{ base: 12, md: 6 }}>
+                        <Grid.Col span={{ base: 12, md: allBackgrounds.length > 0 ? 4 : 6 }}>
                             <Title order={4} mb="sm">
                                 Flaws
                             </Title>

--- a/apps/character-app/src/data/Character.ts
+++ b/apps/character-app/src/data/Character.ts
@@ -14,7 +14,7 @@ import {
 import { skillsSchema } from "./Skills.js";
 import { specialtySchema } from "./Specialties.js";
 import { clans } from "./Clans";
-import { getAllKnownMeritsAndFlaws } from "./MeritsAndFlaws";
+import { getAllKnownMeritsAndFlaws, getKnownBackgroundNames } from "./MeritsAndFlaws";
 import type { Power } from "./Disciplines.js";
 
 export const inMemoriamEraSchema = z.object({
@@ -77,7 +77,7 @@ export const touchstoneSchema = z.object({
 
 export type Touchstone = z.infer<typeof touchstoneSchema>;
 
-export const schemaVersion = 6;
+export const schemaVersion = 7;
 
 export const characterSchema = z.object({
   id: z.string().optional().default(""),
@@ -121,6 +121,7 @@ export const characterSchema = z.object({
 
   merits: meritFlawSchema.array(),
   flaws: meritFlawSchema.array(),
+  backgrounds: meritFlawSchema.array().optional().default([]),
 
   notes: z.string().optional().default(""),
 
@@ -234,6 +235,7 @@ export const getEmptyCharacter = (): Character => {
     experience: 0,
     humanity: 0,
 
+    backgrounds: [],
     merits: [],
     flaws: [],
 
@@ -329,6 +331,7 @@ export const applyCharacterCompatibilityPatches = (
   patchV2ToV3Compatibility(parsed);
   patchV3ToV4Compatibility(parsed);
   patchV5ToV6Compatibility(parsed);
+  patchV6ToV7Compatibility(parsed);
 
   parsed["version"] = schemaVersion;
 };
@@ -390,5 +393,18 @@ export const patchV5ToV6Compatibility = (
 ): void => {
   if (!Array.isArray(parsed["ceremonies"])) {
     parsed["ceremonies"] = [];
+  }
+};
+
+export const patchV6ToV7Compatibility = (
+  parsed: Record<string, unknown>,
+): void => {
+  // Separate backgrounds out of merits into their own top-level array.
+  // Pre-v7 characters stored backgrounds mixed into merits[]; we move them here.
+  if (!Array.isArray(parsed["backgrounds"])) {
+    const knownBgNames = getKnownBackgroundNames()
+    const merits = Array.isArray(parsed["merits"]) ? (parsed["merits"] as Record<string, unknown>[]) : []
+    parsed["backgrounds"] = merits.filter((m) => typeof m["name"] === "string" && knownBgNames.has(m["name"] as string))
+    parsed["merits"] = merits.filter((m) => typeof m["name"] === "string" && !knownBgNames.has(m["name"] as string))
   }
 };

--- a/apps/character-app/src/data/MeritsAndFlaws.ts
+++ b/apps/character-app/src/data/MeritsAndFlaws.ts
@@ -98,6 +98,25 @@ export const essentialLoresheets = filterLoresheetsByComplexity(loresheets, "ess
 
 export const advancedLoresheets = filterLoresheetsByComplexity(loresheets, "advanced")
 
+// Category titles that are treated as Backgrounds (must match MeritsAndFlawsPicker)
+const ESSENTIAL_BG_TITLES = new Set(["🏠 Haven", "💰 Resources", "🧛 Kindred", "👱 Mortals"])
+const ADVANCED_BG_TITLES = new Set(["Haven", "Resources", "Fame", "Influence"])
+
+export const getKnownBackgroundNames = (): Set<string> => {
+    const names = new Set<string>()
+    for (const cat of essentialMeritsAndFlaws) {
+        if (!ESSENTIAL_BG_TITLES.has(cat.title)) continue
+        cat.merits.forEach((m) => names.add(m.name))
+        cat.flaws.forEach((f) => names.add(f.name))
+    }
+    for (const cat of advancedMeritsAndFlaws) {
+        if (!ADVANCED_BG_TITLES.has(cat.title)) continue
+        cat.merits.forEach((m) => names.add(m.name))
+        cat.flaws.forEach((f) => names.add(f.name))
+    }
+    return names
+}
+
 export const getAllKnownMeritsAndFlaws = (): Map<string, MeritOrFlaw> => {
     const map = new Map<string, MeritOrFlaw>()
 

--- a/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
+++ b/apps/character-app/src/generator/components/MeritsAndFlawsPicker.tsx
@@ -24,6 +24,7 @@ import {
     advancedMeritsAndFlaws,
     essentialMeritsAndFlaws,
     essentialThinbloodMeritsAndFlaws,
+    getKnownBackgroundNames,
     isThinbloodFlaw,
     isThinbloodMerit,
     MeritOrFlaw
@@ -301,6 +302,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
     const [lsSearch, setLsSearch] = useState("")
 
     const [pickedMeritsAndFlaws, setPickedMeritsAndFlaws] = useState<MeritFlaw[]>([
+        ...(character.backgrounds ?? []),
         ...character.merits,
         ...character.flaws
     ])
@@ -316,7 +318,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
         return new Set([...autoPredatorTypeNames, ...pickedPredatorTypeNames])
     }, [character.predatorType.name, character.predatorType.pickedMeritsAndFlaws])
 
-    const usedMeritsLevel = character.merits
+    const usedMeritsLevel = [...(character.backgrounds ?? []), ...character.merits]
         .filter((m) => !isThinbloodMerit(m.name) && !predatorTypeProvidedNames.has(m.name))
         .reduce((acc, { level }) => acc + level, 0)
     const usedFLawsLevel = character.flaws
@@ -502,6 +504,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
         (isThinBlood && remainingThinbloodMeritPoints < 0) ||
         (hasMandatoryFlaws && remainingFlaws > 0)
     const handleReset = () => {
+        const bgNames = getKnownBackgroundNames()
         if (resetTarget === "merit") {
             const nextPickedMeritsAndFlaws = pickedMeritsAndFlaws.filter(
                 (item) => item.type !== "merit"
@@ -511,6 +514,7 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
             setRemainingThinbloodMeritPoints(tbFlawCount)
             setCharacter({
                 ...character,
+                backgrounds: [],
                 merits: [],
                 flaws: nextPickedMeritsAndFlaws.filter((item) => item.type === "flaw")
             })
@@ -525,7 +529,8 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
             setRemainingThinbloodMeritPoints(-tbMeritCount)
             setCharacter({
                 ...character,
-                merits: nextPickedMeritsAndFlaws.filter((item) => item.type === "merit"),
+                backgrounds: nextPickedMeritsAndFlaws.filter((item) => item.type === "merit" && bgNames.has(item.name)),
+                merits: nextPickedMeritsAndFlaws.filter((item) => item.type === "merit" && !bgNames.has(item.name)),
                 flaws: []
             })
         }
@@ -1043,10 +1048,12 @@ const MeritsAndFlawsPicker = ({ character, setCharacter, nextStep }: MeritsAndFl
                     color="grape"
                     disabled={isConfirmDisabled}
                     onClick={() => {
+                        const bgNames = getKnownBackgroundNames()
                         updateHealthAndWillpowerAndBloodPotencyAndHumanity(character)
                         setCharacter({
                             ...character,
-                            merits: pickedMeritsAndFlaws.filter((l) => l.type === "merit"),
+                            backgrounds: pickedMeritsAndFlaws.filter((l) => l.type === "merit" && bgNames.has(l.name)),
+                            merits: pickedMeritsAndFlaws.filter((l) => l.type === "merit" && !bgNames.has(l.name)),
                             flaws: pickedMeritsAndFlaws.filter((l) => l.type === "flaw")
                         })
                         trackEvent({

--- a/apps/character-app/src/generator/foundryWoDJsonCreator.ts
+++ b/apps/character-app/src/generator/foundryWoDJsonCreator.ts
@@ -476,6 +476,7 @@ export const createWoD5EVttJson = (
 
     // Merit items
     const allMerits = [
+        ...(character.backgrounds || []),
         ...(character.merits || []),
         ...(character.predatorType?.pickedMeritsAndFlaws?.filter((m) => m.type === "merit") || [])
     ]

--- a/apps/character-app/src/generator/inconnuJsonCreator.ts
+++ b/apps/character-app/src/generator/inconnuJsonCreator.ts
@@ -347,6 +347,7 @@ export const createInconnuJson = (character: Character): InconnuCreationBody => 
     }
 
     for (const meritFlaw of [
+        ...asArray<{ name?: unknown; level?: unknown }>(character.backgrounds ?? []),
         ...asArray<{ name?: unknown; level?: unknown }>(character.merits),
         ...asArray<{ name?: unknown; level?: unknown }>(character.flaws),
         ...asArray<{ name?: unknown; level?: unknown }>(

--- a/apps/character-app/src/generator/pdfCreator.ts
+++ b/apps/character-app/src/generator/pdfCreator.ts
@@ -387,7 +387,7 @@ export const createPdf_nerdbert = async (character: Character): Promise<Uint8Arr
     }
 
     // Merits & flaws
-    const characterMeritsFlaws = [...character.merits, ...character.flaws]
+    const characterMeritsFlaws = [...(character.backgrounds ?? []), ...character.merits, ...character.flaws]
     const predatorTypeMeritsFlaws = PredatorTypes[
         character.predatorType.name
     ].meritsAndFlaws.filter((m) => !characterMeritsFlaws.map((cm) => cm.name).includes(m.name))

--- a/apps/character-app/src/pages/MePage.tsx
+++ b/apps/character-app/src/pages/MePage.tsx
@@ -2649,7 +2649,25 @@ const CharacterSummaryContent = ({
                 </Accordion.Control>
                 <Accordion.Panel>
                     <Grid>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
+                        {(character.backgrounds ?? []).length > 0 ? (
+                            <Grid.Col span={{ base: 12, md: 4 }}>
+                                <Text fw={500} size="sm" c="dimmed" mb="sm">
+                                    BACKGROUNDS
+                                </Text>
+                                <Stack gap="xs">
+                                    {(character.backgrounds ?? []).map((bg, idx) => (
+                                        <Paper key={idx} p="xs" withBorder radius="sm">
+                                            <Group justify="space-between" mb={2}>
+                                                <Text fw={500} size="sm">{bg.name}</Text>
+                                                <Badge size="xs" color="blue" variant="light">{bg.level}</Badge>
+                                            </Group>
+                                            <Text size="xs" c="dimmed">{bg.summary}</Text>
+                                        </Paper>
+                                    ))}
+                                </Stack>
+                            </Grid.Col>
+                        ) : null}
+                        <Grid.Col span={{ base: 12, md: (character.backgrounds ?? []).length > 0 ? 4 : 6 }}>
                             <Text fw={500} size="sm" c="dimmed" mb="sm">
                                 MERITS
                             </Text>
@@ -2677,7 +2695,7 @@ const CharacterSummaryContent = ({
                                 )}
                             </Stack>
                         </Grid.Col>
-                        <Grid.Col span={{ base: 12, md: 6 }}>
+                        <Grid.Col span={{ base: 12, md: (character.backgrounds ?? []).length > 0 ? 4 : 6 }}>
                             <Text fw={500} size="sm" c="dimmed" mb="sm">
                                 FLAWS
                             </Text>

--- a/apps/character-app/src/routes/sheet.tsx
+++ b/apps/character-app/src/routes/sheet.tsx
@@ -25,7 +25,8 @@ function Sheet() {
                 character.sire === emptyChar.sire &&
                 character.disciplines.length === 0 &&
                 character.merits.length === 0 &&
-                character.flaws.length === 0
+                character.flaws.length === 0 &&
+                (character.backgrounds ?? []).length === 0
 
             if (isEmpty) {
                 posthog.capture("sheet-page-visit-empty", {

--- a/apps/character-app/src/sidebar/Sidebar.tsx
+++ b/apps/character-app/src/sidebar/Sidebar.tsx
@@ -440,8 +440,8 @@ const Sidebar = ({
                     {notDefault(character, "touchstones") ? (
                         <TouchstoneDisplay touchstones={character.touchstones} />
                     ) : null}
-                    {notDefault(character, "merits") || notDefault(character, "flaws") ? (
-                        <MeritsAndFlawsDisplay merits={character.merits} flaws={character.flaws} />
+                    {notDefault(character, "merits") || notDefault(character, "flaws") || (character.backgrounds ?? []).length > 0 ? (
+                        <MeritsAndFlawsDisplay backgrounds={character.backgrounds ?? []} merits={character.merits} flaws={character.flaws} />
                     ) : null}
                 </Stack>
             </ScrollArea>

--- a/apps/character-app/src/sidebar/components/MeritsAndFlawsDisplay.tsx
+++ b/apps/character-app/src/sidebar/components/MeritsAndFlawsDisplay.tsx
@@ -3,11 +3,12 @@ import { MeritFlaw } from "../../data/Character"
 import Tally from "../../components/Tally"
 
 export type MeritsAndFlawsProps = {
+    backgrounds: MeritFlaw[]
     merits: MeritFlaw[]
     flaws: MeritFlaw[]
 }
 
-const MeritsAndFlawsDisplay = ({ merits, flaws }: MeritsAndFlawsProps) => {
+const MeritsAndFlawsDisplay = ({ backgrounds, merits, flaws }: MeritsAndFlawsProps) => {
     const textStyle: React.CSSProperties = {
         fontFamily: "Courier New"
     }
@@ -20,8 +21,25 @@ const MeritsAndFlawsDisplay = ({ merits, flaws }: MeritsAndFlawsProps) => {
 
     return (
         <Stack>
-            <Title order={2}>Merits & Flaws</Title>
+            <Title order={2}>Advantages & Flaws</Title>
             <Grid>
+                {backgrounds.length > 0 ? (
+                    <Grid.Col span={12}>
+                        <Title order={4} mb={4}>Backgrounds</Title>
+                        <List>
+                            {backgrounds.map((bg) => (
+                                <List.Item key={bg.name}>
+                                    <Group gap={0} wrap="nowrap" align="center">
+                                        <Text c="blue" style={nameStyle}>{bg.name.slice(0, 7)}:</Text>
+                                        <Box style={textStyle}>
+                                            <Tally n={bg.level} style={{ color: "var(--mantine-color-blue-6)" }} />
+                                        </Box>
+                                    </Group>
+                                </List.Item>
+                            ))}
+                        </List>
+                    </Grid.Col>
+                ) : null}
                 <Grid.Col span={6}>
                     <List>
                         {merits.map((merit) => {

--- a/apps/character-app/src/test/testUtils.ts
+++ b/apps/character-app/src/test/testUtils.ts
@@ -120,6 +120,7 @@ export const getBasicTestCharacter = (): Character => {
         willpower: 4,
         experience: 15,
         humanity: 7,
+        backgrounds: [],
         merits: [
             {
                 name: "Direct Merit",

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -2043,7 +2043,7 @@ def get_coterie_for_character(discord_id: str):
     Used by the bot's /coterie status command.
     Response: { coterie, character_name, members } or 404.
     """
-    from app.db import Coterie, CoterieMember, DbCharacter
+    from app.db import CoterieMember, DbCharacter
 
     char = DbCharacter.query.filter_by(
         player_discord=discord_id, active=True

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -2033,3 +2033,52 @@ def activate_coterie():
             'free_pool_total': sum(m.free_dots_remaining for m in coterie.members),
         },
     })
+
+
+@bp.route('/coteries/by-character/<discord_id>', methods=['GET'])
+@require_bot_scope('read')
+def get_coterie_for_character(discord_id: str):
+    """Return the coterie for the given player's active character.
+
+    Used by the bot's /coterie status command.
+    Response: { coterie, character_name, members } or 404.
+    """
+    from app.db import Coterie, CoterieMember, DbCharacter
+
+    char = DbCharacter.query.filter_by(
+        player_discord=discord_id, active=True
+    ).first()
+    if not char:
+        return jsonify({'error': 'No active character found for this Discord user'}), 404
+
+    membership = CoterieMember.query.filter_by(
+        roster_character_id=char.id
+    ).first()
+    if not membership:
+        return jsonify({'coterie': None, 'character_name': char.character_name}), 200
+
+    coterie = membership.coterie
+    members = []
+    for m in coterie.members:
+        c = m.character
+        members.append({
+            'character_name': c.character_name,
+            'clan': c.clan or '',
+            'player_discord_id': c.player_discord or '',
+            'player_name': c.player_discord_name or '',
+        })
+
+    return jsonify({
+        'character_name': char.character_name,
+        'coterie': {
+            'id': coterie.id,
+            'name': coterie.name,
+            'slug': coterie.slug,
+            'description': coterie.description or '',
+            'status': coterie.status,
+            'chasse': coterie.chasse,
+            'lien': coterie.lien,
+            'portillon': coterie.portillon,
+        },
+        'members': members,
+    })

--- a/apps/web/app/blueprints/cc_admin.py
+++ b/apps/web/app/blueprints/cc_admin.py
@@ -21,7 +21,7 @@ from flask import Blueprint, abort, flash, jsonify, redirect, render_template, r
 import logging
 
 from app.auth import require_staff
-from app.db import CharacterDraft, CcRestriction, DbCharacter, db
+from app.db import CharacterDraft, CcRestriction, DbCharacter, DbCharacterBackground, db
 from app import db_service, sheets_sync
 from app.models import Character
 
@@ -281,6 +281,36 @@ def draft_approve(draft_id):
                 logger.info('CC approval: created roster entry for %s', char_name)
             except Exception as exc:
                 logger.warning('CC approval: failed to create roster for %s: %s', char_name, exc)
+
+    # Sync backgrounds from char_data into DbCharacterBackground (upsert by key)
+    approval_actor = f'cc_approval:{actor}'
+    char_name_for_bg = draft.character_name or ''
+    raw_backgrounds = char_data.get('backgrounds') or []
+    if char_name_for_bg and raw_backgrounds:
+        for bg in raw_backgrounds:
+            name = (bg.get('name') or '').strip()
+            dots = int(bg.get('level') or 0)
+            if not name or dots <= 0:
+                continue
+            bg_key = db_service._background_key(name)
+            existing = DbCharacterBackground.query.filter_by(
+                character_name=char_name_for_bg,
+                background_key=bg_key,
+            ).first()
+            if existing:
+                existing.dots_total = dots
+                existing.updated_by = approval_actor
+                existing.updated_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
+            else:
+                db.session.add(DbCharacterBackground(
+                    character_name=char_name_for_bg,
+                    background_key=bg_key,
+                    background_name=name,
+                    dots_total=dots,
+                    dots_blanked=0,
+                    updated_by=approval_actor,
+                    updated_at=datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+                ))
 
     db.session.commit()
     flash(f'Character "{draft.character_name or draft.id}" approved.', 'success')

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -575,7 +575,7 @@ def propose():
     # Characters eligible to invite (active, approved, not already in a coterie)
     already_in = db.session.query(CoterieMember.roster_character_id).subquery()
     invitable = DbCharacter.query.filter(
-        DbCharacter.active == True,
+        DbCharacter.active,
         DbCharacter.id != player_char.id,
         ~DbCharacter.id.in_(already_in),
     ).order_by(DbCharacter.character_name).all()
@@ -625,7 +625,7 @@ def propose():
         # Add invited members
         invited_chars = DbCharacter.query.filter(
             DbCharacter.id.in_(invite_ids),
-            DbCharacter.active == True,
+            DbCharacter.active,
         ).all()
         for char in invited_chars:
             # Skip anyone already in a coterie
@@ -661,15 +661,7 @@ def _creation_flaw_dots(coterie: Coterie) -> int:
 def _creation_budget(coterie: Coterie) -> dict:
     base = len(coterie.members) * _CREATION_DOTS_PER_MEMBER
     bonus = _creation_flaw_dots(coterie)
-    total = base + bonus
-    used = sum(
-        a.dots for a in coterie.advantages
-        if a.notes == '__creation__' and a.advantage_type != 'flaw'
-    ) + coterie.chasse + coterie.lien + coterie.portillon
-    # domain is tracked separately; subtract only what was added during forming
-    # We track creation-phase domain via free_dots_remaining reduction
-    used_dots = base - sum(m.free_dots_remaining for m in coterie.members) + bonus
-    used_dots = max(0, used_dots)
+    used_dots = max(0, base - sum(m.free_dots_remaining for m in coterie.members) + bonus)
     return {
         'base': base,
         'bonus': bonus,

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -893,3 +893,32 @@ def sendback_formation(slug: str):
     db.session.commit()
     flash(f'{coterie.name} sent back to formation with notes.', 'info')
     return redirect(url_for('coteries.manage', slug=slug))
+
+
+# ---------------------------------------------------------------------------
+# Staff: delete a draft/pending coterie
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/delete', methods=['POST'])
+@require_staff
+def delete(slug: str):
+    coterie = _get_coterie_or_404(slug)
+
+    if coterie.status == 'active':
+        flash('Active coteries cannot be deleted.', 'danger')
+        return redirect(url_for('coteries.manage', slug=slug))
+
+    name = coterie.name
+
+    # Clear background donation references before deleting
+    DbCharacterBackground.query.filter_by(donated_coterie_id=coterie.id).update(
+        {'donated_coterie_id': None}
+    )
+    DbCharacterBackground.query.filter_by(donation_pending_coterie_id=coterie.id).update(
+        {'donation_pending_coterie_id': None}
+    )
+
+    db.session.delete(coterie)  # cascades members + advantages
+    db.session.commit()
+    flash(f'Coterie "{name}" deleted.', 'success')
+    return redirect(url_for('coteries.index'))

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -273,6 +273,20 @@ def edit(slug: str):
     return redirect(url_for('coteries.manage', slug=slug))
 
 
+@bp.route('/<slug>/domain', methods=['POST'])
+@require_staff
+def update_domain(slug: str):
+    """Staff: set Chasse / Lien / Portillon ratings."""
+    coterie = _get_coterie_or_404(slug)
+    coterie.chasse = max(0, min(5, request.form.get('chasse', 0, type=int)))
+    coterie.lien = max(0, min(5, request.form.get('lien', 0, type=int)))
+    coterie.portillon = max(0, min(5, request.form.get('portillon', 0, type=int)))
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash('Domain ratings updated.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
 # ---------------------------------------------------------------------------
 # Staff/member: add pool advantage
 # ---------------------------------------------------------------------------

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -110,9 +110,13 @@ def view(slug: str):
         else:
             my_pending = []
 
-    # Pool items: exclude creation-tagged entries from the public pool display
-    # (they show separately in the formation panel)
-    public_advantages = [a for a in coterie.advantages if a.notes != '__creation__']
+    # Pool items: hide creation-tagged entries from the pool only while forming
+    # (they appear in the formation panel instead); once submitted/active they join the pool
+    forming = _is_forming(coterie)
+    public_advantages = [
+        a for a in coterie.advantages
+        if not (forming and a.notes == '__creation__')
+    ]
     pool_backgrounds = [a for a in public_advantages if a.advantage_type == 'background']
     pool_merits = [a for a in public_advantages if a.advantage_type == 'merit']
     pool_flaws = [a for a in public_advantages if a.advantage_type == 'flaw']
@@ -129,7 +133,7 @@ def view(slug: str):
         my_backgrounds=my_backgrounds,
         my_pending=my_pending,
         is_staff_user=is_staff(),
-        is_forming=_is_forming(coterie),
+        is_forming=forming,
     )
 
 
@@ -824,13 +828,22 @@ def creation_remove(slug: str, adv_id: int):
     dots = adv.dots
     is_flaw = adv.advantage_type == 'flaw'
 
-    db.session.delete(adv)
-
-    # Refund dots to the current member
     member = _get_coterie_member(coterie, player_char)
     if is_flaw:
-        # Removing a flaw reduces the bonus pool — take dots back
-        member.free_dots_remaining = max(0, member.free_dots_remaining - dots)
+        # Removing a flaw claws back the bonus dots it granted.
+        # If the pool has already spent those dots, block the removal.
+        if member.free_dots_remaining < dots:
+            flash(
+                f'Cannot remove "{adv.name}" — its bonus dot(s) have already been spent. '
+                'Remove an allocation first.',
+                'danger',
+            )
+            return redirect(url_for('coteries.view', slug=slug))
+
+    db.session.delete(adv)
+
+    if is_flaw:
+        member.free_dots_remaining -= dots
     else:
         member.free_dots_remaining += dots
 

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -15,6 +15,11 @@ from app.db import (
 )
 from app.db_service import DBService
 
+# Creation-phase limits (V5 house rules)
+_CREATION_DOMAIN_MAX = 3   # max dots in any single domain rating at creation
+_CREATION_FLAW_MAX = 4     # max flaw dots (each grants +1 Advantage/Background dot)
+_CREATION_DOTS_PER_MEMBER = 2  # free dots each member contributes at formation
+
 logger = logging.getLogger(__name__)
 
 bp = Blueprint('coteries', __name__)
@@ -105,9 +110,12 @@ def view(slug: str):
         else:
             my_pending = []
 
-    pool_backgrounds = [a for a in coterie.advantages if a.advantage_type == 'background']
-    pool_merits = [a for a in coterie.advantages if a.advantage_type == 'merit']
-    pool_flaws = [a for a in coterie.advantages if a.advantage_type == 'flaw']
+    # Pool items: exclude creation-tagged entries from the public pool display
+    # (they show separately in the formation panel)
+    public_advantages = [a for a in coterie.advantages if a.notes != '__creation__']
+    pool_backgrounds = [a for a in public_advantages if a.advantage_type == 'background']
+    pool_merits = [a for a in public_advantages if a.advantage_type == 'merit']
+    pool_flaws = [a for a in public_advantages if a.advantage_type == 'flaw']
 
     return render_template(
         'coteries/view.html',
@@ -121,6 +129,7 @@ def view(slug: str):
         my_backgrounds=my_backgrounds,
         my_pending=my_pending,
         is_staff_user=is_staff(),
+        is_forming=_is_forming(coterie),
     )
 
 
@@ -542,3 +551,353 @@ def blank_donated_background(slug: str, bg_id: int):
         flash(str(exc), 'danger')
 
     return redirect(url_for('coteries.view', slug=slug))
+
+# ---------------------------------------------------------------------------
+# Player: propose a new coterie
+# ---------------------------------------------------------------------------
+
+@bp.route('/propose', methods=['GET', 'POST'])
+@require_login
+def propose():
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+
+    if not player_char:
+        flash('You need an active character to propose a coterie.', 'danger')
+        return redirect(url_for('coteries.index'))
+
+    # A character can only be in one coterie at a time
+    existing = CoterieMember.query.filter_by(roster_character_id=player_char.id).first()
+    if existing:
+        flash('Your character is already in a coterie.', 'warning')
+        return redirect(url_for('coteries.view', slug=existing.coterie.slug))
+
+    # Characters eligible to invite (active, approved, not already in a coterie)
+    already_in = db.session.query(CoterieMember.roster_character_id).subquery()
+    invitable = DbCharacter.query.filter(
+        DbCharacter.active == True,
+        DbCharacter.id != player_char.id,
+        ~DbCharacter.id.in_(already_in),
+    ).order_by(DbCharacter.character_name).all()
+
+    if request.method == 'POST':
+        name = request.form.get('name', '').strip()
+        description = request.form.get('description', '').strip()
+        invite_ids = request.form.getlist('invite_ids', type=int)
+
+        if not name:
+            flash('Coterie name is required.', 'danger')
+            return render_template('coteries/propose.html', player_char=player_char, invitable=invitable)
+
+        if Coterie.query.filter_by(name=name).first():
+            flash(f'A coterie named "{name}" already exists.', 'danger')
+            return render_template('coteries/propose.html', player_char=player_char, invitable=invitable)
+
+        slug = _slugify(name)
+        base_slug = slug
+        counter = 1
+        while Coterie.query.filter_by(slug=slug).first():
+            slug = f'{base_slug}-{counter}'
+            counter += 1
+
+        now = datetime.now(timezone.utc)
+        coterie = Coterie(
+            name=name,
+            slug=slug,
+            description=description,
+            status='pending',
+            creation_state='forming',
+            created_at=now,
+            updated_at=now,
+        )
+        db.session.add(coterie)
+        db.session.flush()  # get coterie.id
+
+        # Add proposer as leader
+        db.session.add(CoterieMember(
+            coterie_id=coterie.id,
+            roster_character_id=player_char.id,
+            free_dots_remaining=_CREATION_DOTS_PER_MEMBER,
+            role='leader',
+            joined_at=now,
+        ))
+
+        # Add invited members
+        invited_chars = DbCharacter.query.filter(
+            DbCharacter.id.in_(invite_ids),
+            DbCharacter.active == True,
+        ).all()
+        for char in invited_chars:
+            # Skip anyone already in a coterie
+            if CoterieMember.query.filter_by(roster_character_id=char.id).first():
+                continue
+            db.session.add(CoterieMember(
+                coterie_id=coterie.id,
+                roster_character_id=char.id,
+                free_dots_remaining=_CREATION_DOTS_PER_MEMBER,
+                role='member',
+                joined_at=now,
+            ))
+
+        db.session.commit()
+        flash(f'Coterie "{name}" proposed! Allocate your creation dots below.', 'success')
+        return redirect(url_for('coteries.view', slug=coterie.slug))
+
+    return render_template('coteries/propose.html', player_char=player_char, invitable=invitable)
+
+
+# ---------------------------------------------------------------------------
+# Member: allocate creation dots (forming phase only)
+# ---------------------------------------------------------------------------
+
+def _is_forming(coterie: Coterie) -> bool:
+    return coterie.creation_state == 'forming'
+
+
+def _creation_flaw_dots(coterie: Coterie) -> int:
+    return sum(a.dots for a in coterie.advantages if a.advantage_type == 'flaw' and a.notes == '__creation__')
+
+
+def _creation_budget(coterie: Coterie) -> dict:
+    base = len(coterie.members) * _CREATION_DOTS_PER_MEMBER
+    bonus = _creation_flaw_dots(coterie)
+    total = base + bonus
+    used = sum(
+        a.dots for a in coterie.advantages
+        if a.notes == '__creation__' and a.advantage_type != 'flaw'
+    ) + coterie.chasse + coterie.lien + coterie.portillon
+    # domain is tracked separately; subtract only what was added during forming
+    # We track creation-phase domain via free_dots_remaining reduction
+    used_dots = base - sum(m.free_dots_remaining for m in coterie.members) + bonus
+    used_dots = max(0, used_dots)
+    return {
+        'base': base,
+        'bonus': bonus,
+        'total': base + bonus,
+        'used': used_dots,
+        'left': max(0, base + bonus - used_dots),
+    }
+
+
+@bp.route('/<slug>/creation/allocate', methods=['POST'])
+@require_login
+def creation_allocate(slug: str):
+    """Member allocates a free creation dot toward domain or a named trait."""
+    coterie = _get_coterie_or_404(slug)
+
+    if not _is_forming(coterie):
+        flash('This coterie is not in the formation phase.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    target_kind = request.form.get('target_kind', '')
+    target_name = request.form.get('target_name', '').strip()
+    dots = request.form.get('dots', 1, type=int)
+
+    if dots < 1:
+        flash('Must allocate at least 1 dot.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    # Check pool budget
+    budget = _creation_budget(coterie)
+    if dots > budget['left']:
+        flash(f'Only {budget["left"]} creation dot(s) remaining.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    if target_kind in ('chasse', 'lien', 'portillon'):
+        current = getattr(coterie, target_kind)
+        if current + dots > _CREATION_DOMAIN_MAX:
+            flash(f'{target_kind.title()} cannot exceed {_CREATION_DOMAIN_MAX} at creation.', 'danger')
+            return redirect(url_for('coteries.view', slug=slug))
+        setattr(coterie, target_kind, current + dots)
+
+    elif target_kind in ('background', 'merit'):
+        if not target_name:
+            flash('Trait name is required.', 'danger')
+            return redirect(url_for('coteries.view', slug=slug))
+        adv = CoterieAdvantage(
+            coterie_id=coterie.id,
+            name=target_name,
+            dots=dots,
+            advantage_type=target_kind,
+            notes='__creation__',
+            added_by=player_char.character_name,
+            created_at=datetime.now(timezone.utc),
+        )
+        db.session.add(adv)
+
+    else:
+        flash('Invalid target type.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    # Deduct from member's free dot pool (distribute proportionally — simplest: deduct from current user)
+    member = _get_coterie_member(coterie, player_char)
+    if member.free_dots_remaining >= dots:
+        member.free_dots_remaining -= dots
+    else:
+        # Deduct from pool collectively (other members' remaining dots)
+        remaining = dots - member.free_dots_remaining
+        member.free_dots_remaining = 0
+        for m in coterie.members:
+            if m.id == member.id:
+                continue
+            take = min(m.free_dots_remaining, remaining)
+            m.free_dots_remaining -= take
+            remaining -= take
+            if remaining <= 0:
+                break
+
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    label = target_kind.title() if target_kind in ('chasse', 'lien', 'portillon') else target_name
+    flash(f'Allocated {dots} dot(s) to {label}.', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+@bp.route('/<slug>/creation/flaw', methods=['POST'])
+@require_login
+def creation_flaw(slug: str):
+    """Member takes a coterie flaw during formation, granting bonus creation dots."""
+    coterie = _get_coterie_or_404(slug)
+
+    if not _is_forming(coterie):
+        flash('This coterie is not in the formation phase.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    flaw_name = request.form.get('flaw_name', '').strip()
+    dots = request.form.get('dots', 1, type=int)
+
+    if not flaw_name:
+        flash('Flaw name is required.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    current_flaw_dots = _creation_flaw_dots(coterie)
+    if current_flaw_dots + dots > _CREATION_FLAW_MAX:
+        flash(f'Maximum {_CREATION_FLAW_MAX} flaw dots allowed at creation.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    # Create flaw entry (tagged __creation__ so we know it's from formation)
+    flaw = CoterieAdvantage(
+        coterie_id=coterie.id,
+        name=flaw_name,
+        dots=dots,
+        advantage_type='flaw',
+        notes='__creation__',
+        added_by=player_char.character_name,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.session.add(flaw)
+
+    # Grant bonus dots back to pool — add to the proposer/current member
+    member = _get_coterie_member(coterie, player_char)
+    member.free_dots_remaining += dots
+
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'Took flaw "{flaw_name}" ({dots} dot(s)) — gained {dots} bonus creation dot(s).', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+@bp.route('/<slug>/creation/remove/<int:adv_id>', methods=['POST'])
+@require_login
+def creation_remove(slug: str, adv_id: int):
+    """Remove a creation-phase allocation (undo before sign-off)."""
+    coterie = _get_coterie_or_404(slug)
+
+    if not _is_forming(coterie):
+        flash('Cannot edit allocations after sign-off.', 'danger')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    adv = CoterieAdvantage.query.filter_by(
+        id=adv_id, coterie_id=coterie.id, notes='__creation__'
+    ).first_or_404()
+
+    dots = adv.dots
+    is_flaw = adv.advantage_type == 'flaw'
+
+    db.session.delete(adv)
+
+    # Refund dots to the current member
+    member = _get_coterie_member(coterie, player_char)
+    if is_flaw:
+        # Removing a flaw reduces the bonus pool — take dots back
+        member.free_dots_remaining = max(0, member.free_dots_remaining - dots)
+    else:
+        member.free_dots_remaining += dots
+
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'Removed "{adv.name}" — {dots} creation dot(s) {"returned" if not is_flaw else "forfeited"}.', 'info')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+# ---------------------------------------------------------------------------
+# Member: submit coterie for staff sign-off
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/submit-for-review', methods=['POST'])
+@require_login
+def submit_for_review(slug: str):
+    coterie = _get_coterie_or_404(slug)
+
+    if not _is_forming(coterie):
+        flash('This coterie is not in the formation phase.', 'warning')
+        return redirect(url_for('coteries.view', slug=slug))
+
+    discord_id = get_player_discord_id()
+    player_char = _get_player_character(discord_id)
+    if not player_char or not _get_coterie_member(coterie, player_char):
+        abort(403)
+
+    coterie.creation_state = 'submitted'
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash('Coterie submitted for staff sign-off. You\'ll hear back soon.', 'success')
+    return redirect(url_for('coteries.view', slug=slug))
+
+
+# ---------------------------------------------------------------------------
+# Staff: approve or send back a submitted coterie
+# ---------------------------------------------------------------------------
+
+@bp.route('/<slug>/approve-formation', methods=['POST'])
+@require_staff
+def approve_formation(slug: str):
+    coterie = _get_coterie_or_404(slug)
+
+    coterie.creation_state = 'active'
+    coterie.status = 'active'
+    coterie.creation_notes = None
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'{coterie.name} formation approved — coterie is now active.', 'success')
+    return redirect(url_for('coteries.manage', slug=slug))
+
+
+@bp.route('/<slug>/sendback-formation', methods=['POST'])
+@require_staff
+def sendback_formation(slug: str):
+    coterie = _get_coterie_or_404(slug)
+
+    notes = request.form.get('notes', '').strip()
+    coterie.creation_state = 'forming'
+    coterie.creation_notes = notes or None
+    coterie.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+    flash(f'{coterie.name} sent back to formation with notes.', 'info')
+    return redirect(url_for('coteries.manage', slug=slug))

--- a/apps/web/app/blueprints/coteries.py
+++ b/apps/web/app/blueprints/coteries.py
@@ -244,7 +244,7 @@ def remove_member(slug: str, member_id: int):
     DbCharacterBackground.query.filter_by(
         character_name=char_name,
         donated_coterie_id=coterie.id,
-    ).update({'donated_coterie_id': None})
+    ).update({'donated_coterie_id': None, 'dots_blanked': 0})
     # Cancel any pending donation requests too
     DbCharacterBackground.query.filter_by(
         character_name=char_name,
@@ -442,6 +442,7 @@ def approve_donation(slug: str, bg_id: int):
 
     bg.donated_coterie_id = coterie.id
     bg.donation_pending_coterie_id = None
+    bg.dots_blanked = bg.dots_total
 
     notes = request.form.get('flaw_notes', '').strip()
     if notes:
@@ -496,6 +497,7 @@ def undonate_background(slug: str, bg_id: int):
     ).first_or_404()
 
     bg.donated_coterie_id = None
+    bg.dots_blanked = 0
     coterie.updated_at = datetime.now(timezone.utc)
     db.session.commit()
     flash(f'{bg.background_name} removed from coterie pool.', 'success')

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -235,6 +235,16 @@ def character(name):
                 except (json.JSONDecodeError, TypeError):
                     sheet_data = None
 
+    # Coterie membership
+    player_coterie = None
+    player_coterie_role = None
+    if char_row:
+        from app.db import CoterieMember
+        membership = CoterieMember.query.filter_by(roster_character_id=char_row.id).first()
+        if membership:
+            player_coterie = membership.coterie
+            player_coterie_role = membership.role
+
     return render_template(
         'player/character.html',
         char=char,
@@ -258,6 +268,8 @@ def character(name):
         has_approved_draft=has_approved_draft,
         sheet_data=sheet_data,
         chronicle_tenets=_get_chronicle_tenets(),
+        player_coterie=player_coterie,
+        player_coterie_role=player_coterie_role,
     )
 
 

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -832,11 +832,8 @@ def _map_rod_to_cc(rod: dict) -> dict:
             'type': 'merit',
         }
 
-    # Merits + Backgrounds (both map to CC merits list)
-    data['merits'] = (
-        [_map_adv(m) for m in (rod.get('merits') or [])]
-        + [_map_adv(b) for b in (rod.get('backgrounds') or [])]
-    )
+    data['merits'] = [_map_adv(m) for m in (rod.get('merits') or [])]
+    data['backgrounds'] = [_map_adv(b) for b in (rod.get('backgrounds') or [])]
     data['flaws'] = [_map_adv(f) for f in (rod.get('flaws') or [])]
 
     # Loresheets

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -310,6 +310,10 @@ class Coterie(db.Model):
     chasse = db.Column(Integer, nullable=False, default=0)
     lien = db.Column(Integer, nullable=False, default=0)
     portillon = db.Column(Integer, nullable=False, default=0)
+    # Creation lifecycle: forming → submitted → active (null = legacy/staff-created, treat as active)
+    creation_state = db.Column(String(20), nullable=True, default=None)
+    # Staff notes sent back during sign-off review
+    creation_notes = db.Column(Text, nullable=True, default=None)
 
     members = db.relationship('CoterieMember', back_populates='coterie',
                               cascade='all, delete-orphan')
@@ -330,6 +334,7 @@ class CoterieMember(db.Model):
     roster_character_id = db.Column(Integer, db.ForeignKey('characters.id'), nullable=False)
     free_dots_remaining = db.Column(Integer, nullable=False, default=2)
     setup_complete = db.Column(Boolean, nullable=False, default=False)
+    role = db.Column(String(20), nullable=False, default='member')  # member | leader
     joined_at = db.Column(DateTime, nullable=False,
                           default=lambda: datetime.now(timezone.utc))
 

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -306,6 +306,11 @@ class Coterie(db.Model):
                            default=lambda: datetime.now(timezone.utc),
                            onupdate=lambda: datetime.now(timezone.utc))
 
+    # Domain ratings (0–5 each). Advanced via coterie XP spends, set by staff.
+    chasse = db.Column(Integer, nullable=False, default=0)
+    lien = db.Column(Integer, nullable=False, default=0)
+    portillon = db.Column(Integer, nullable=False, default=0)
+
     members = db.relationship('CoterieMember', back_populates='coterie',
                               cascade='all, delete-orphan')
     advantages = db.relationship('CoterieAdvantage', back_populates='coterie',

--- a/apps/web/app/templates/cc_admin/draft_review.html
+++ b/apps/web/app/templates/cc_admin/draft_review.html
@@ -197,6 +197,21 @@
   </div>
   {% endif %}
 
+  {# ── Backgrounds ── #}
+  {% set backgrounds = char_data.get('backgrounds', []) %}
+  {% if backgrounds %}
+  <div class="card mb-3">
+    <div class="card-header py-2 fw-semibold">Backgrounds</div>
+    <div class="card-body">
+      <ul class="mb-0 ps-3">
+        {% for b in backgrounds %}
+          <li>{{ b.get('name', '?') }} (•{{ b.get('level', '') }})</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
   {# ── Merits & Flaws ── #}
   {% set merits = char_data.get('merits', []) %}
   {% set flaws = char_data.get('flaws', []) %}

--- a/apps/web/app/templates/coteries/index.html
+++ b/apps/web/app/templates/coteries/index.html
@@ -3,11 +3,21 @@
 {% block content %}
 <div class="d-flex align-items-center gap-3 mb-4 flex-wrap">
     <h2 class="mb-0"><i class="bi bi-people-fill text-danger"></i> Coteries</h2>
-    {% if session.get('is_staff') %}
-    <a href="{{ url_for('coteries.new') }}" class="btn btn-sm btn-outline-danger ms-auto">
-        <i class="bi bi-plus-lg"></i> New Coterie
-    </a>
-    {% endif %}
+    <div class="ms-auto d-flex gap-2">
+        {% if session.get('authenticated') and not session.get('is_staff') %}
+        <a href="{{ url_for('coteries.propose') }}" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-plus-lg"></i> Propose a Coterie
+        </a>
+        {% endif %}
+        {% if session.get('is_staff') %}
+        <a href="{{ url_for('coteries.propose') }}" class="btn btn-sm btn-outline-secondary">
+            <i class="bi bi-plus-lg"></i> Propose (as player)
+        </a>
+        <a href="{{ url_for('coteries.new') }}" class="btn btn-sm btn-outline-danger">
+            <i class="bi bi-shield-plus"></i> Create (staff)
+        </a>
+        {% endif %}
+    </div>
 </div>
 
 {% if coteries %}
@@ -20,7 +30,11 @@
                     <h5 class="card-title mb-0">
                         <a href="{{ url_for('coteries.view', slug=c.slug) }}" class="text-decoration-none">{{ c.name }}</a>
                     </h5>
-                    {% if c.status == 'pending' %}
+                    {% if c.creation_state == 'forming' %}
+                    <span class="badge bg-secondary ms-2">forming</span>
+                    {% elif c.creation_state == 'submitted' %}
+                    <span class="badge bg-warning text-dark ms-2">awaiting sign-off</span>
+                    {% elif c.status == 'pending' %}
                     <span class="badge bg-secondary ms-2">pending</span>
                     {% endif %}
                 </div>

--- a/apps/web/app/templates/coteries/manage.html
+++ b/apps/web/app/templates/coteries/manage.html
@@ -3,14 +3,40 @@
 {% block content %}
 <div class="d-flex align-items-center gap-3 mb-4 flex-wrap">
     <a href="{{ url_for('coteries.view', slug=coterie.slug) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-arrow-left"></i></a>
-    <h2 class="mb-0">{{ coterie.name }} <span class="badge {% if coterie.status == 'active' %}bg-success{% else %}bg-secondary{% endif %} fs-6">{{ coterie.status }}</span></h2>
-    {% if coterie.status == 'pending' %}
+    <h2 class="mb-0">
+        {{ coterie.name }}
+        <span class="badge {% if coterie.status == 'active' %}bg-success{% else %}bg-secondary{% endif %} fs-6">{{ coterie.status }}</span>
+        {% if coterie.creation_state == 'forming' %}
+        <span class="badge bg-secondary fs-6">forming</span>
+        {% elif coterie.creation_state == 'submitted' %}
+        <span class="badge bg-warning text-dark fs-6">awaiting sign-off</span>
+        {% endif %}
+    </h2>
+    {% if coterie.status == 'pending' and not coterie.creation_state %}
     <form method="POST" action="{{ url_for('coteries.activate', slug=coterie.slug) }}" class="ms-auto">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button class="btn btn-sm btn-success">Activate Coterie</button>
     </form>
     {% endif %}
 </div>
+
+{% if coterie.creation_state == 'submitted' %}
+<div class="alert alert-warning mb-4">
+    <strong><i class="bi bi-hourglass-split"></i> Sign-off Pending</strong>
+    <p class="mb-3 mt-1">This coterie has been submitted by the players and is ready for your review.</p>
+    <div class="d-flex gap-2 flex-wrap">
+        <form method="POST" action="{{ url_for('coteries.approve_formation', slug=coterie.slug) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button class="btn btn-success"><i class="bi bi-check-lg"></i> Approve Formation</button>
+        </form>
+        <form method="POST" action="{{ url_for('coteries.sendback_formation', slug=coterie.slug) }}" class="d-flex gap-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="text" name="notes" class="form-control form-control-sm" style="width:280px" placeholder="Notes for players (optional)">
+            <button class="btn btn-outline-secondary"><i class="bi bi-arrow-return-left"></i> Send Back</button>
+        </form>
+    </div>
+</div>
+{% endif %}
 
 {% with messages = get_flashed_messages(with_categories=true) %}
 {% for cat, msg in messages %}<div class="alert alert-{{ cat }} py-2">{{ msg }}</div>{% endfor %}

--- a/apps/web/app/templates/coteries/manage.html
+++ b/apps/web/app/templates/coteries/manage.html
@@ -18,6 +18,14 @@
         <button class="btn btn-sm btn-success">Activate Coterie</button>
     </form>
     {% endif %}
+    {% if coterie.status != 'active' %}
+    <form method="POST" action="{{ url_for('coteries.delete', slug=coterie.slug) }}"
+          class="{% if coterie.status == 'pending' and not coterie.creation_state %}{% else %}ms-auto{% endif %}"
+          onsubmit="return confirm('Permanently delete {{ coterie.name }}? This cannot be undone.')">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i> Delete Coterie</button>
+    </form>
+    {% endif %}
 </div>
 
 {% if coterie.creation_state == 'submitted' %}

--- a/apps/web/app/templates/coteries/manage.html
+++ b/apps/web/app/templates/coteries/manage.html
@@ -135,6 +135,33 @@
             </div>
         </div>
 
+        <!-- Domain -->
+        <div class="card mb-3">
+            <div class="card-header fw-bold"><i class="bi bi-map"></i> Domain</div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('coteries.update_domain', slug=coterie.slug) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="row g-2 mb-3">
+                        {% for label, field, val in [
+                            ('Chasse', 'chasse', coterie.chasse),
+                            ('Lien', 'lien', coterie.lien),
+                            ('Portillon', 'portillon', coterie.portillon),
+                        ] %}
+                        <div class="col-4">
+                            <label class="form-label fw-bold small mb-1">{{ label }}</label>
+                            <select name="{{ field }}" class="form-select form-select-sm">
+                                {% for n in range(6) %}
+                                <option value="{{ n }}" {% if val == n %}selected{% endif %}>{{ n }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    <button class="btn btn-sm btn-outline-secondary">Update Domain</button>
+                </form>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-header fw-bold small text-muted">Pool Summary</div>
             <div class="card-body small text-muted">

--- a/apps/web/app/templates/coteries/propose.html
+++ b/apps/web/app/templates/coteries/propose.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Propose a Coterie{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-4">
+    <a href="{{ url_for('coteries.index') }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-arrow-left"></i></a>
+    <h2 class="mb-0">Propose a Coterie</h2>
+</div>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+{% for cat, msg in messages %}<div class="alert alert-{{ cat }} py-2">{{ msg }}</div>{% endfor %}
+{% endwith %}
+
+<div class="row justify-content-center">
+<div class="col-lg-6">
+<div class="card">
+    <div class="card-body">
+        <p class="text-muted small mb-3">
+            Proposing as <strong>{{ player_char.character_name }}</strong>.
+            Your coterie will start in the <em>forming</em> phase — allocate creation dots,
+            then submit for staff sign-off.
+        </p>
+
+        <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+            <div class="mb-3">
+                <label class="form-label fw-bold">Coterie Name <span class="text-danger">*</span></label>
+                <input type="text" name="name" class="form-control" maxlength="200"
+                       placeholder="e.g. The Midnight Accord" required>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label fw-bold">Description</label>
+                <textarea name="description" class="form-control" rows="3"
+                          placeholder="A brief description of the coterie's purpose or focus…"></textarea>
+            </div>
+
+            {% if invitable %}
+            <div class="mb-4">
+                <label class="form-label fw-bold">Invite Members</label>
+                <p class="text-muted small mb-2">
+                    Select characters to include in the formation. They must not already be in a coterie.
+                    You can add or remove members before sign-off.
+                </p>
+                <div class="border border-secondary rounded p-2" style="max-height:240px;overflow-y:auto;">
+                    {% for c in invitable %}
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="invite_ids"
+                               value="{{ c.id }}" id="inv_{{ c.id }}">
+                        <label class="form-check-label" for="inv_{{ c.id }}">
+                            {{ c.character_name }}
+                            <small class="text-muted">— {{ c.clan or 'Unknown clan' }}</small>
+                        </label>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% else %}
+            <div class="mb-4">
+                <p class="text-muted small">No other characters are available to invite right now.</p>
+            </div>
+            {% endif %}
+
+            <button class="btn btn-danger w-100">
+                <i class="bi bi-people-fill"></i> Propose Coterie
+            </button>
+        </form>
+    </div>
+</div>
+</div>
+</div>
+{% endblock %}

--- a/apps/web/app/templates/coteries/view.html
+++ b/apps/web/app/templates/coteries/view.html
@@ -26,6 +26,26 @@
 
 <div class="row g-4">
 
+    <!-- Domain -->
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header fw-bold"><i class="bi bi-map"></i> Domain</div>
+            <div class="card-body">
+                <div class="row g-3 text-center">
+                    {% for label, val in [('Chasse', coterie.chasse), ('Lien', coterie.lien), ('Portillon', coterie.portillon)] %}
+                    <div class="col-4">
+                        <div class="small text-muted text-uppercase mb-1" style="letter-spacing:.05em;font-size:.7rem;">{{ label }}</div>
+                        <div class="dot-pips justify-content-center d-flex gap-1 mb-1">
+                            {% for i in range(1,6) %}<span class="dot-pip {% if i <= val %}filled{% endif %}"></span>{% endfor %}
+                        </div>
+                        <small class="text-muted">{{ val }}/5</small>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Members -->
     <div class="col-md-4">
         <div class="card">

--- a/apps/web/app/templates/coteries/view.html
+++ b/apps/web/app/templates/coteries/view.html
@@ -12,7 +12,19 @@
     {% endif %}
 </div>
 
-{% if coterie.status == 'pending' %}
+{% if coterie.creation_state == 'forming' %}
+<div class="alert alert-secondary py-2 mb-3">
+    <strong>Formation phase.</strong> Allocate your creation dots below, then submit for staff sign-off.
+    {% if coterie.creation_notes %}
+    <hr class="my-2">
+    <strong>Staff notes:</strong> {{ coterie.creation_notes }}
+    {% endif %}
+</div>
+{% elif coterie.creation_state == 'submitted' %}
+<div class="alert alert-warning py-2 mb-3">
+    <strong>Awaiting staff sign-off.</strong> Your coterie sheet has been submitted. Sit tight!
+</div>
+{% elif coterie.status == 'pending' %}
 <div class="alert alert-secondary py-2 mb-3">This coterie is pending setup.</div>
 {% endif %}
 
@@ -58,9 +70,12 @@
                            class="text-decoration-none">{{ m.character.character_name }}</a>
                         <br><small class="text-muted">{{ m.character.clan or '—' }}</small>
                     </div>
-                    {% if is_member and player_char and player_char.id == m.roster_character_id %}
-                    <span class="badge bg-secondary">you</span>
-                    {% endif %}
+                    <div class="d-flex gap-1 align-items-center">
+                        {% if m.role == 'leader' %}<span class="badge bg-danger">leader</span>{% endif %}
+                        {% if is_member and player_char and player_char.id == m.roster_character_id %}
+                        <span class="badge bg-secondary">you</span>
+                        {% endif %}
+                    </div>
                 </li>
                 {% else %}
                 <li class="list-group-item text-muted">No members yet.</li>
@@ -68,6 +83,116 @@
             </ul>
         </div>
     </div>
+
+    <!-- Formation controls (forming phase only, for members) -->
+    {% if coterie.creation_state == 'forming' and is_member %}
+    {% set creation_flaws = coterie.advantages | selectattr('advantage_type', 'equalto', 'flaw') | selectattr('notes', 'equalto', '__creation__') | list %}
+    {% set creation_items = coterie.advantages | rejectattr('advantage_type', 'equalto', 'flaw') | selectattr('notes', 'equalto', '__creation__') | list %}
+    {% set flaw_dots_taken = creation_flaws | sum(attribute='dots') %}
+    {% set base_dots = coterie.members | length * 2 %}
+    {% set bonus_dots = flaw_dots_taken %}
+    {% set dots_spent = base_dots - (coterie.members | sum(attribute='free_dots_remaining')) + bonus_dots %}
+    {% set dots_left = base_dots + bonus_dots - dots_spent %}
+    <div class="col-12">
+        <div class="card border-warning">
+            <div class="card-header fw-bold text-warning-emphasis bg-warning bg-opacity-10">
+                <i class="bi bi-hammer"></i> Coterie Formation
+                <small class="text-muted ms-2">Creation pool: <strong>{{ dots_spent }}</strong>/{{ base_dots + bonus_dots }} dots used ({{ dots_left }} remaining)</small>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+
+                    <!-- Allocate a dot -->
+                    <div class="col-md-6">
+                        <p class="small fw-bold mb-2">Allocate creation dot</p>
+                        <form method="POST" action="{{ url_for('coteries.creation_allocate', slug=coterie.slug) }}" class="d-flex flex-column gap-2">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <select name="target_kind" class="form-select form-select-sm" id="targetKind" onchange="toggleTraitName(this.value)">
+                                <option value="chasse">Chasse (Domain) — max 3 at creation</option>
+                                <option value="lien">Lien (Domain) — max 3 at creation</option>
+                                <option value="portillon">Portillon (Domain) — max 3 at creation</option>
+                                <option value="background">Background (named)</option>
+                                <option value="merit">Merit (named)</option>
+                            </select>
+                            <input type="text" name="target_name" class="form-control form-control-sm d-none" id="traitName" placeholder="Trait name (e.g. Haven)">
+                            <div class="d-flex gap-2">
+                                <input type="number" name="dots" class="form-control form-control-sm" style="width:80px" value="1" min="1" max="{{ dots_left }}">
+                                <button class="btn btn-sm btn-outline-warning" {% if dots_left == 0 %}disabled{% endif %}>Allocate</button>
+                            </div>
+                        </form>
+                        <script>
+                        function toggleTraitName(val) {
+                            const named = ['background', 'merit'];
+                            const el = document.getElementById('traitName');
+                            if (named.includes(val)) { el.classList.remove('d-none'); el.required = true; }
+                            else { el.classList.add('d-none'); el.required = false; }
+                        }
+                        </script>
+                    </div>
+
+                    <!-- Take a flaw -->
+                    <div class="col-md-6">
+                        <p class="small fw-bold mb-2">Take a coterie flaw <small class="text-muted">(+1 creation dot each, max 4)</small></p>
+                        {% if flaw_dots_taken < 4 %}
+                        <form method="POST" action="{{ url_for('coteries.creation_flaw', slug=coterie.slug) }}" class="d-flex gap-2">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="text" name="flaw_name" class="form-control form-control-sm" placeholder="Flaw name (e.g. Adversary)" required>
+                            <select name="dots" class="form-select form-select-sm" style="width:80px">
+                                {% for n in range(1, 4 - flaw_dots_taken + 1) %}
+                                <option value="{{ n }}">{{ n }}</option>
+                                {% endfor %}
+                            </select>
+                            <button class="btn btn-sm btn-outline-secondary">Take</button>
+                        </form>
+                        {% else %}
+                        <p class="text-muted small">Maximum flaw dots taken ({{ flaw_dots_taken }}/4).</p>
+                        {% endif %}
+                    </div>
+
+                    <!-- Current allocations -->
+                    {% if creation_items or creation_flaws %}
+                    <div class="col-12">
+                        <p class="small fw-bold mb-2">Current allocations</p>
+                        <div class="d-flex flex-wrap gap-2">
+                            {% for a in creation_items %}
+                            <div class="d-flex align-items-center gap-1 border border-secondary rounded px-2 py-1 small">
+                                <span>{{ a.name }} ({{ a.advantage_type }}, {{ a.dots }}●)</span>
+                                <form method="POST" action="{{ url_for('coteries.creation_remove', slug=coterie.slug, adv_id=a.id) }}" class="d-inline">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-link btn-sm p-0 text-danger ms-1" title="Remove">×</button>
+                                </form>
+                            </div>
+                            {% endfor %}
+                            {% for a in creation_flaws %}
+                            <div class="d-flex align-items-center gap-1 border border-danger rounded px-2 py-1 small text-danger">
+                                <span>Flaw: {{ a.name }} ({{ a.dots }}●)</span>
+                                <form method="POST" action="{{ url_for('coteries.creation_remove', slug=coterie.slug, adv_id=a.id) }}" class="d-inline">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-link btn-sm p-0 text-danger ms-1" title="Remove">×</button>
+                                </form>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% endif %}
+
+                    <!-- Submit for sign-off -->
+                    <div class="col-12 border-top pt-3">
+                        <form method="POST" action="{{ url_for('coteries.submit_for_review', slug=coterie.slug) }}"
+                              onsubmit="return confirm('Submit this coterie for staff sign-off? You can still make changes if staff send it back.')">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button class="btn btn-warning">
+                                <i class="bi bi-send"></i> Submit for Staff Sign-off
+                            </button>
+                            <small class="text-muted ms-2">Do this once the group has agreed in your cubby.</small>
+                        </form>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 
     <!-- Pool advantages -->
     <div class="col-md-4">
@@ -129,8 +254,8 @@
                 <p class="text-muted small mb-0">No pool items yet.</p>
                 {% endif %}
 
-                <!-- Add advantage (members + staff) -->
-                {% if is_member or is_staff_user %}
+                <!-- Add advantage (members + staff) — hidden during formation phase -->
+                {% if (is_member or is_staff_user) and not is_forming %}
                 {% set my_member = coterie.members | selectattr('roster_character_id', 'equalto', player_char.id if player_char else -1) | list %}
                 {% set dots_left = (my_member[0].free_dots_remaining if my_member else 0) if not is_staff_user else 99 %}
                 <hr class="my-3">

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -404,6 +404,36 @@
     </div><!-- /#background-blanking -->
 </div>
 
+{% if player_coterie %}
+<div class="card mb-4">
+    <div class="card-header fw-bold"><i class="bi bi-people-fill text-danger"></i> Coterie</div>
+    <div class="card-body">
+        <div class="d-flex align-items-center gap-3 flex-wrap">
+            <div>
+                <a href="{{ url_for('coteries.view', slug=player_coterie.slug) }}" class="fw-bold text-decoration-none">
+                    {{ player_coterie.name }}
+                </a>
+                <small class="text-muted ms-2">{{ player_coterie.members | length }} member{{ 's' if player_coterie.members | length != 1 }}</small>
+                {% if player_coterie_role == 'leader' %}
+                <span class="badge bg-danger ms-1">leader</span>
+                {% endif %}
+                {% if player_coterie.creation_state == 'forming' %}
+                <span class="badge bg-secondary ms-1">forming</span>
+                {% elif player_coterie.creation_state == 'submitted' %}
+                <span class="badge bg-warning text-dark ms-1">awaiting sign-off</span>
+                {% endif %}
+            </div>
+            <a href="{{ url_for('coteries.view', slug=player_coterie.slug) }}" class="btn btn-sm btn-outline-secondary ms-auto">
+                <i class="bi bi-arrow-right"></i> View Coterie
+            </a>
+        </div>
+        {% if player_coterie.description %}
+        <p class="text-muted small mt-2 mb-0">{{ player_coterie.description }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+
 <!-- ═══ Submission Forms ═══ -->
 <div class="row mb-4">
 

--- a/apps/web/migrations/versions/5a9b2c7e1d3f_add_domain_to_coteries.py
+++ b/apps/web/migrations/versions/5a9b2c7e1d3f_add_domain_to_coteries.py
@@ -1,0 +1,32 @@
+"""add chasse/lien/portillon domain columns to coteries
+
+Revision ID: 5a9b2c7e1d3f
+Revises: 4f2a1b8e6c9d
+Create Date: 2026-06-17
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+revision = '5a9b2c7e1d3f'
+down_revision = '4f2a1b8e6c9d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    columns = [c['name'] for c in inspector.get_columns('coteries')]
+    if 'chasse' not in columns:
+        op.add_column('coteries', sa.Column('chasse', sa.Integer(), nullable=False, server_default='0'))
+    if 'lien' not in columns:
+        op.add_column('coteries', sa.Column('lien', sa.Integer(), nullable=False, server_default='0'))
+    if 'portillon' not in columns:
+        op.add_column('coteries', sa.Column('portillon', sa.Integer(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('coteries', 'portillon')
+    op.drop_column('coteries', 'lien')
+    op.drop_column('coteries', 'chasse')

--- a/apps/web/migrations/versions/6b3c8d2f1a4e_coterie_creation_state.py
+++ b/apps/web/migrations/versions/6b3c8d2f1a4e_coterie_creation_state.py
@@ -1,0 +1,35 @@
+"""add creation_state, creation_notes to coteries; role to coterie_members
+
+Revision ID: 6b3c8d2f1a4e
+Revises: 5a9b2c7e1d3f
+Create Date: 2026-06-17
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+revision = '6b3c8d2f1a4e'
+down_revision = '5a9b2c7e1d3f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+
+    coterie_cols = [c['name'] for c in inspector.get_columns('coteries')]
+    if 'creation_state' not in coterie_cols:
+        op.add_column('coteries', sa.Column('creation_state', sa.String(20), nullable=True))
+    if 'creation_notes' not in coterie_cols:
+        op.add_column('coteries', sa.Column('creation_notes', sa.Text(), nullable=True))
+
+    member_cols = [c['name'] for c in inspector.get_columns('coterie_members')]
+    if 'role' not in member_cols:
+        op.add_column('coterie_members', sa.Column('role', sa.String(20), nullable=False, server_default='member'))
+
+
+def downgrade():
+    op.drop_column('coteries', 'creation_notes')
+    op.drop_column('coteries', 'creation_state')
+    op.drop_column('coterie_members', 'role')


### PR DESCRIPTION
## Summary

Players can now propose coteries from the web app without staff involvement until sign-off.

**Player flow:**
1. `/coteries/` → "Propose a Coterie" button
2. Fill in name, description, invite other characters (multi-select, filtered to available chars)
3. Coterie created in `forming` state; proposer is `leader`
4. Any member can allocate creation dots: domain (Chasse/Lien/Portillon, max 3 each at creation) or named background/merit; budget = 2 dots × member count
5. Optionally take coterie flaws (up to 4 flaw dots) for +1 creation dot each
6. Undo any allocation before sign-off
7. "Submit for Staff Sign-off" → `submitted`

**Staff flow:**
- Manage page shows sign-off banner when `submitted`
- Approve → `active`; Send Back with notes → back to `forming` (notes shown to players)

## New DB columns (migration `6b3c8d2f1a4e`)
- `coteries.creation_state` TEXT nullable (`forming | submitted | active | NULL`)
- `coteries.creation_notes` TEXT nullable
- `coterie_members.role` TEXT (`member | leader`, default `member`)

## Depends on
Stacks on `feat/coterie-domain-discord` (PR #290) → `feat/coterie-bg-donation-approval` (#289) → `feat/coterie-spend-donate` (#288).

**Merge order: #288 → #289 → #290 → this PR.**

## Test plan
- [ ] Player with active character: can propose a coterie
- [ ] Player already in a coterie: redirected, cannot propose
- [ ] Formation banner shows with creation dot allocation + flaw controls
- [ ] Domain max 3 enforced at creation (Chasse/Lien/Portillon)
- [ ] Flaw bonus adds dots, max 4 flaw dots enforced
- [ ] Undo button removes allocation and refunds dots
- [ ] Submit for sign-off → banner changes to "awaiting sign-off", controls locked
- [ ] Staff manage page shows approve/send-back banner when `submitted`
- [ ] Approve → coterie active, manage page clears banner
- [ ] Send back with notes → notes shown to players, editing re-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)