### PR TITLE
fix: coterie status lookup for multi-character players

### DIFF
--- a/apps/bot/src/commands/coterie.ts
+++ b/apps/bot/src/commands/coterie.ts
@@ -53,10 +53,11 @@ async function handleStatus(
   await interaction.deferReply({ ephemeral: true });
 
   const discordId = interaction.user.id;
+  const requestedName = interaction.options.getString('character') ?? undefined;
 
   let data: Awaited<ReturnType<typeof adapter.getCoterieForCharacter>>;
   try {
-    data = await adapter.getCoterieForCharacter(discordId);
+    data = await adapter.getCoterieForCharacter(discordId, requestedName);
   } catch (err) {
     await interaction.editReply(
       `❌ Could not reach the tracker right now. Try again in a moment.\n\`${errorToMessage(err)}\``,
@@ -65,17 +66,9 @@ async function handleStatus(
   }
 
   if (!data) {
+    const suffix = requestedName ? ` named **${requestedName}**` : '';
     await interaction.editReply(
-      'You have no active character registered in the tracker.',
-    );
-    return;
-  }
-
-  const requestedName = interaction.options.getString('character');
-  if (requestedName && data.character_name.toLowerCase() !== requestedName.toLowerCase()) {
-    await interaction.editReply(
-      `No active character named **${requestedName}** found for your account. ` +
-      `Your registered character is **${data.character_name}**.`,
+      `You have no active character${suffix} registered in the tracker.`,
     );
     return;
   }

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -149,7 +149,7 @@ export interface TrackerAdapter {
     discord_channel_id: string | null;
     members: Array<{ character_name: string; clan: string; player_discord_id: string }>;
   }>>;
-  getCoterieForCharacter(discordId: string): Promise<{
+  getCoterieForCharacter(discordId: string, characterName?: string): Promise<{
     character_name: string;
     coterie: {
       id: number;
@@ -1347,9 +1347,10 @@ export class WebAppAdapter implements TrackerAdapter {
     return data.coteries;
   }
 
-  async getCoterieForCharacter(discordId: string) {
+  async getCoterieForCharacter(discordId: string, characterName?: string) {
+    const qs = characterName ? `?character_name=${encodeURIComponent(characterName)}` : '';
     const res = await this.fetchWithTimeout(
-      `${this.baseUrl}/api/coteries/by-character/${encodeURIComponent(discordId)}`,
+      `${this.baseUrl}/api/coteries/by-character/${encodeURIComponent(discordId)}${qs}`,
       { method: 'GET', headers: this.readAuthHeaders() },
     );
     if (res.status === 404) return null;

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -2053,10 +2053,13 @@ def get_coterie_for_character(discord_id: str):
     Response: { coterie, character_name, members } or 404.
     """
     from app.db import CoterieMember, DbCharacter
+    from sqlalchemy import func as _func
 
-    char = DbCharacter.query.filter_by(
-        player_discord=discord_id, active=True
-    ).first()
+    character_name = request.args.get('character_name', '').strip()
+    q = DbCharacter.query.filter_by(player_discord=discord_id, active=True)
+    if character_name:
+        q = q.filter(_func.lower(DbCharacter.character_name) == character_name.lower())
+    char = q.first()
     if not char:
         return jsonify({'error': 'No active character found for this Discord user'}), 404
 


### PR DESCRIPTION
## Summary

Cherry-pick of the fix from PR #290 that didn't land in main through the merge chain.

The `/coteries/by-character/<discord_id>` API endpoint and `/coterie status` bot command were fetching only the first active character for a Discord account. Players with multiple characters couldn't use the `character` option to disambiguate.

- API now accepts `?character_name=` query param and filters by both discord_id and name
- Bot adapter passes the character option as a query string
- Bot command reads the option before the fetch; "not found" message includes the requested name

🤖 Generated with [Claude Code](https://claude.com/claude-code)