### PR TITLE
fix: commit retirement job to DB and scope wiki-sync ack correctly

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1226,7 +1226,18 @@ def wiki_sync_ack():
             delete_key('BOT_WIKI_SYNC_RUN_ID')
         upsert('BOT_WIKI_SYNC_FINISHED_AT', now)
         delete_key('BOT_WIKI_SYNC_ERROR')
-        retirement_jobs_synced = mark_retirement_jobs_wiki_synced()
+        # Only mark jobs whose Discord work completed before the sync started;
+        # jobs that complete mid-sync will be caught by the next wiki run.
+        sync_started_rec = db.session.get(AppSetting, 'BOT_WIKI_SYNC_STARTED_AT')
+        sync_started_dt: datetime | None = None
+        if sync_started_rec and sync_started_rec.value:
+            try:
+                sync_started_dt = datetime.fromisoformat(sync_started_rec.value)
+                if sync_started_dt.tzinfo is None:
+                    sync_started_dt = sync_started_dt.replace(tzinfo=timezone.utc)
+            except ValueError:
+                sync_started_dt = None
+        retirement_jobs_synced = mark_retirement_jobs_wiki_synced(synced_before=sync_started_dt)
     else:
         upsert('BOT_WIKI_SYNC_STATUS', 'error')
         upsert('BOT_WIKI_SYNC_SOURCE', source)

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1226,17 +1226,24 @@ def wiki_sync_ack():
             delete_key('BOT_WIKI_SYNC_RUN_ID')
         upsert('BOT_WIKI_SYNC_FINISHED_AT', now)
         delete_key('BOT_WIKI_SYNC_ERROR')
-        # Only mark jobs whose Discord work completed before the sync started;
-        # jobs that complete mid-sync will be caught by the next wiki run.
-        sync_started_rec = db.session.get(AppSetting, 'BOT_WIKI_SYNC_STARTED_AT')
+        # Only mark jobs whose Discord work completed before this sync started.
+        # Guard: only use BOT_WIKI_SYNC_STARTED_AT if its run id matches this
+        # request's runId — if the running ack failed, the stored timestamp may
+        # belong to a previous run and would incorrectly exclude jobs processed
+        # by the current sync.
         sync_started_dt: datetime | None = None
-        if sync_started_rec and sync_started_rec.value:
-            try:
-                sync_started_dt = datetime.fromisoformat(sync_started_rec.value)
-                if sync_started_dt.tzinfo is None:
-                    sync_started_dt = sync_started_dt.replace(tzinfo=timezone.utc)
-            except ValueError:
-                sync_started_dt = None
+        if run_id:
+            run_id_rec = db.session.get(AppSetting, 'BOT_WIKI_SYNC_RUN_ID')
+            stored_run_id = (run_id_rec.value if run_id_rec else '') or ''
+            if stored_run_id == run_id:
+                sync_started_rec = db.session.get(AppSetting, 'BOT_WIKI_SYNC_STARTED_AT')
+                if sync_started_rec and sync_started_rec.value:
+                    try:
+                        sync_started_dt = datetime.fromisoformat(sync_started_rec.value)
+                        if sync_started_dt.tzinfo is None:
+                            sync_started_dt = sync_started_dt.replace(tzinfo=timezone.utc)
+                    except ValueError:
+                        pass
         retirement_jobs_synced = mark_retirement_jobs_wiki_synced(synced_before=sync_started_dt)
     else:
         upsert('BOT_WIKI_SYNC_STATUS', 'error')

--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -641,6 +641,7 @@ def set_status(name):
     )
     if previous_status != 'retired' and new_status == 'retired':
         enqueue_retirement_job(name, staff)
+        db.session.commit()
 
     labels = {'active': 'reactivated', 'deceased': 'marked as deceased', 'retired': 'marked as retired'}
     flash(f'{name} has been {labels[new_status]}.', 'warning' if new_status != 'active' else 'success')

--- a/apps/web/app/retirement_automation.py
+++ b/apps/web/app/retirement_automation.py
@@ -45,13 +45,22 @@ def enqueue_retirement_job(character_name: str, requested_by: str) -> Retirement
     return job
 
 
-def mark_retirement_jobs_wiki_synced() -> int:
-    """Mark all discord-complete retirement jobs as synced by the latest wiki run."""
+def mark_retirement_jobs_wiki_synced(synced_before: datetime | None = None) -> int:
+    """Mark discord-complete retirement jobs as synced by the latest wiki run.
+
+    Only jobs whose Discord work completed before *synced_before* are marked,
+    so jobs that finish Discord work mid-sync (after the wiki batch was gathered
+    but before the success ack arrives) are not falsely marked as wiki-synced.
+    If *synced_before* is None, all discord-complete unsynced jobs are marked.
+    """
     now = datetime.now(timezone.utc)
-    rows = RetirementAutomationJob.query.filter(
+    q = RetirementAutomationJob.query.filter(
         RetirementAutomationJob.discord_completed_at.is_not(None),
         RetirementAutomationJob.wiki_synced_at.is_(None),
-    ).all()
+    )
+    if synced_before is not None:
+        q = q.filter(RetirementAutomationJob.discord_completed_at <= synced_before)
+    rows = q.all()
     for row in rows:
         row.wiki_synced_at = now
         row.last_error = ''


### PR DESCRIPTION
Bug 1: enqueue_retirement_job() added the job to the SQLAlchemy session but set_status() returned without committing, rolling back the queued row at request teardown. Added db.session.commit() after the enqueue call.

Bug 2: mark_retirement_jobs_wiki_synced() was marking all discord-complete jobs synced on any wiki success, including jobs whose Discord work finished mid-sync (after the batch was gathered but before the ack arrived). Fixed by accepting a synced_before cutoff and filtering on discord_completed_at; the api.py wiki_sync_ack route reads BOT_WIKI_SYNC_STARTED_AT to populate the cutoff so only jobs that were done before the sync started are marked.

## Summary

- What changed?
- Why?

## Checklist

- [ ] Tests added/updated where appropriate
- [ ] `./venv/bin/pytest -q` passes locally
- [ ] Docs updated (`README.md`, `CHANGELOG.md`, or release notes) if needed
- [ ] No secrets/tokens included in code, logs, or screenshots

### Shared Contract Change Checklist (if touching `packages/api-contract` or `packages/rules`)

- [ ] Updated both web and bot consumers (or confirmed no consumer impact)
- [ ] Added/updated contract tests in both apps
- [ ] Documented rollout/rollback plan for contract version consumers

## Validation

- Steps used to verify behavior:
  1.
  2.
  3.

## Risks / Rollback

- Known risks:
- Rollback plan:
