### PR TITLE
fix: unarchive source thread before locking on retirement

### DIFF
--- a/apps/bot/src/__tests__/retirementAutomationWorker.test.ts
+++ b/apps/bot/src/__tests__/retirementAutomationWorker.test.ts
@@ -189,8 +189,9 @@ describe('RetirementAutomationWorker', () => {
     expect(deleteClone).toHaveBeenCalledWith('Undo retirement automation for Alice Voss');
     expect(sourceSetLocked).toHaveBeenNthCalledWith(1, true, 'Character retired: Alice Voss');
     expect(sourceSetLocked).toHaveBeenNthCalledWith(2, false, 'Undo retirement automation for Alice Voss');
-    expect(sourceSetArchived).toHaveBeenNthCalledWith(1, true, 'Character retired: Alice Voss');
-    expect(sourceSetArchived).toHaveBeenNthCalledWith(2, false, 'Undo retirement automation for Alice Voss');
+    expect(sourceSetArchived).toHaveBeenNthCalledWith(1, false, 'Preparing to lock: Alice Voss');
+    expect(sourceSetArchived).toHaveBeenNthCalledWith(2, true, 'Character retired: Alice Voss');
+    expect(sourceSetArchived).toHaveBeenNthCalledWith(3, false, 'Undo retirement automation for Alice Voss');
     expect(adapter.failRetirementJobDiscordWork).toHaveBeenCalledWith(7, {
       error: 'Error: completion endpoint failed',
     });

--- a/apps/bot/src/services/retirementAutomationWorker.ts
+++ b/apps/bot/src/services/retirementAutomationWorker.ts
@@ -338,8 +338,8 @@ export class RetirementAutomationWorker {
       // Unconditionally unarchive before locking — thread.archived is boolean | null in
       // Discord.js so a conditional check silently skips when null, leaving setLocked to throw.
       await sourceThread.setArchived(false, `Preparing to lock: ${characterName}`).catch(() => null);
-      await sourceThread.setLocked(true, `Character retired: ${characterName}`);
-      await sourceThread.setArchived(true, `Character retired: ${characterName}`);
+      // Register rollback before the lock/archive sequence so any failure in that sequence
+      // is covered (otherwise the thread would be left unarchived with no rollback).
       rollbackActions.push({
         label: 'restore_source_thread_open_state',
         run: async () => {
@@ -347,6 +347,8 @@ export class RetirementAutomationWorker {
           await sourceThread.setArchived(false, `Undo retirement automation for ${characterName}`);
         },
       });
+      await sourceThread.setLocked(true, `Character retired: ${characterName}`);
+      await sourceThread.setArchived(true, `Character retired: ${characterName}`);
       return { sourceThreadId: sourceThread.id, retiredThreadId: existingRetired.id };
     }
 
@@ -389,8 +391,8 @@ export class RetirementAutomationWorker {
     }
 
     await sourceThread.setArchived(false, `Preparing to lock: ${characterName}`).catch(() => null);
-    await sourceThread.setLocked(true, `Character retired: ${characterName}`);
-    await sourceThread.setArchived(true, `Character retired: ${characterName}`);
+    // Register rollback before the lock/archive sequence so any failure in that sequence
+    // is covered (otherwise the thread would be left unarchived with no rollback).
     rollbackActions.push({
       label: 'restore_source_thread_open_state',
       run: async () => {
@@ -398,6 +400,8 @@ export class RetirementAutomationWorker {
         await sourceThread.setArchived(false, `Undo retirement automation for ${characterName}`);
       },
     });
+    await sourceThread.setLocked(true, `Character retired: ${characterName}`);
+    await sourceThread.setArchived(true, `Character retired: ${characterName}`);
     return { sourceThreadId: sourceThread.id, retiredThreadId: newThread.id };
   }
 

--- a/apps/bot/src/services/retirementAutomationWorker.ts
+++ b/apps/bot/src/services/retirementAutomationWorker.ts
@@ -335,8 +335,11 @@ export class RetirementAutomationWorker {
       return { sourceThreadId: null, retiredThreadId: existingRetired?.id ?? null };
     }
     if (existingRetired) {
-      await sourceThread.setArchived(true, `Character retired: ${characterName}`);
+      // Unconditionally unarchive before locking — thread.archived is boolean | null in
+      // Discord.js so a conditional check silently skips when null, leaving setLocked to throw.
+      await sourceThread.setArchived(false, `Preparing to lock: ${characterName}`).catch(() => null);
       await sourceThread.setLocked(true, `Character retired: ${characterName}`);
+      await sourceThread.setArchived(true, `Character retired: ${characterName}`);
       rollbackActions.push({
         label: 'restore_source_thread_open_state',
         run: async () => {
@@ -385,8 +388,9 @@ export class RetirementAutomationWorker {
       await newThread.send({ content: chunk });
     }
 
-    await sourceThread.setArchived(true, `Character retired: ${characterName}`);
+    await sourceThread.setArchived(false, `Preparing to lock: ${characterName}`).catch(() => null);
     await sourceThread.setLocked(true, `Character retired: ${characterName}`);
+    await sourceThread.setArchived(true, `Character retired: ${characterName}`);
     rollbackActions.push({
       label: 'restore_source_thread_open_state',
       run: async () => {


### PR DESCRIPTION
## Summary

- `setLocked(true)` throws Discord error 50083 when called on an archived thread
- `thread.archived` is `boolean | null` in Discord.js — a conditional `if (thread.archived)` silently skips when the value is `null`, leaving the thread locked and the job in backoff
- Fix: unconditionally call `setArchived(false).catch(() => null)` before `setLocked(true)` in both code paths (`existingRetired` branch and full-clone branch)
- Updated test assertions to reflect the new `(false, prepare-to-lock) → (true, retired) → rollback (false, undo)` call order

## Test plan
- [ ] All 61 bot tests pass (`npm run check`)
- [ ] Trigger retirement on a character whose Children of the Night thread is already archived — job should complete instead of entering backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)