### PR TITLE
fix: bulk UPDATE retirement jobs on wiki sync ack to avoid StaleDataError

### DIFF
--- a/apps/web/app/retirement_automation.py
+++ b/apps/web/app/retirement_automation.py
@@ -60,11 +60,11 @@ def mark_retirement_jobs_wiki_synced(synced_before: datetime | None = None) -> i
     )
     if synced_before is not None:
         q = q.filter(RetirementAutomationJob.discord_completed_at <= synced_before)
-    rows = q.all()
-    for row in rows:
-        row.wiki_synced_at = now
-        row.last_error = ''
-    return len(rows)
+    # Use a single bulk UPDATE instead of ORM-style per-row modifications.
+    # The libsql/Turso driver reports combined rowcount as 1 across multiple
+    # UPDATE statements, causing SQLAlchemy's StaleDataError. synchronize_session=False
+    # skips the rowcount check; the caller commits immediately after.
+    return q.update({'wiki_synced_at': now, 'last_error': ''}, synchronize_session=False)
 
 
 def retirement_retry_delay_seconds(job: RetirementAutomationJob) -> int:


### PR DESCRIPTION
## Summary

- Wiki sync ack POST was returning 500 on `2026-06-26T09:08:10Z` with `StaleDataError: UPDATE statement on table 'retirement_automation_jobs' expected to update 7 row(s); 1 were matched`
- Root cause: `mark_retirement_jobs_wiki_synced()` used ORM-style per-row modifications (`for row in rows: row.wiki_synced_at = now`), which generates 7 individual UPDATE statements. The libsql/Turso SQLAlchemy driver reports a combined `rowcount` of 1 across multiple statements, causing SQLAlchemy to raise `StaleDataError` when it expects 7
- Fix: replace with a single bulk `q.update({'wiki_synced_at': now, 'last_error': ''}, synchronize_session=False)` — one SQL UPDATE statement, and `synchronize_session=False` skips the rowcount validation entirely (safe since the caller commits immediately after)

## Test plan
- [ ] 127 web tests pass
- [ ] Manually trigger wiki sync after merge and verify it completes with `200 OK` even when multiple retirement jobs are pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)