### PR TITLE
Fix clan/age/sect symbols invisible on dark background

### DIFF
--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -1752,7 +1752,8 @@ body.login-page {
 .char-list-clan-symbol {
   width: 28px; height: 28px;
   object-fit: contain;
-  opacity: .8;
+  opacity: .55;
+  filter: invert(1);
   flex-shrink: 0;
 }
 .clan-badge {
@@ -1946,20 +1947,24 @@ body.login-page {
 }
 .char-hero-clan-symbol {
   position: absolute;
-  top: 16px; right: 16px;
-  width: 60px; height: 60px;
+  top: -1rem; right: -1rem;
+  width: 160px; height: 160px;
   object-fit: contain;
-  opacity: .12;
+  opacity: .06;
+  filter: invert(1);
 }
 .char-hero-age-symbol {
-  width: 48px; height: 48px;
+  width: 72px; height: 72px;
   object-fit: contain;
-  opacity: .3;
+  opacity: .5;
+  filter: invert(1);
+  display: block;
 }
 .hero-sect-symbol {
-  width: 14px; height: 14px;
+  width: 16px; height: 16px;
   object-fit: contain;
   opacity: .7;
+  filter: invert(1);
   vertical-align: middle;
   margin: 0 3px;
 }


### PR DESCRIPTION
Black-on-white PNG symbols need `filter: invert(1)` to show on dark backgrounds. Also restores original sizes (clan watermark 160px, age symbol 72px) and list symbol opacity.