### PR TITLE
web: cleaner Discord evidence links in claim review + live link preview in claim forms

### DIFF
--- a/apps/web/app/templates/claims/review.html
+++ b/apps/web/app/templates/claims/review.html
@@ -28,31 +28,36 @@
         <h6 class="text-muted mb-3" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.1em;">
             Evidence Review
         </h6>
+        <style>.evidence-pill:hover { background:#2d3346 !important; color:#fff !important; }</style>
         {% for category in claim.categories %}
-        <div class="evidence-card {% if category.claimed %}claimed{% else %}not-claimed{% endif %}">
-            <div class="d-flex align-items-start gap-2">
-                <span class="mt-1">
-                    {% if category.claimed %}
-                    <i class="bi bi-check-circle-fill text-success"></i>
-                    {% else %}
-                    <i class="bi bi-x-circle text-secondary"></i>
-                    {% endif %}
-                </span>
-                <div class="flex-grow-1">
-                    <div class="evidence-label">{{ category.name }}</div>
-                    {% if category.link %}
-                    <a href="{{ category.link }}" target="_blank" rel="noopener" class="evidence-link">
-                        <i class="bi bi-box-arrow-up-right me-1" style="font-size:0.7rem;"></i>{{ category.link }}
-                    </a>
-                    {% endif %}
-                    {% if category.reason %}
-                    <div class="text-muted small mt-1">{{ category.reason }}</div>
-                    {% endif %}
+        <div class="evidence-row d-flex align-items-center gap-3 py-2" style="border-bottom:1px solid #1a1e2a;">
+            {% if category.claimed %}
+                <i class="bi bi-check-circle-fill text-success" style="font-size:1rem;flex-shrink:0;"></i>
+            {% else %}
+                <i class="bi bi-x-circle text-secondary" style="font-size:1rem;flex-shrink:0;"></i>
+            {% endif %}
+            <div class="flex-grow-1">
+                <div class="evidence-label {% if not category.claimed %}text-muted{% endif %}" style="font-weight:500;">
+                    {{ category.name }}
                     {% if category.amount and category.amount != '1' %}
-                    <span class="badge bg-secondary ms-1">{{ category.amount }} XP</span>
+                        <span class="badge bg-secondary ms-1">{{ category.amount }} XP</span>
                     {% endif %}
                 </div>
+                {% if category.reason %}<div class="text-muted small">{{ category.reason }}</div>{% endif %}
             </div>
+            {% if category.link %}
+                {% set msg_id = category.link.rsplit('/', 1)[-1] %}
+                <a href="{{ category.link }}" target="_blank" rel="noopener"
+                   class="evidence-pill d-inline-flex align-items-center gap-2 text-decoration-none flex-shrink-0"
+                   style="padding:5px 10px; background:#252a3a; border:1px solid #323849; border-radius:999px; font-size:0.8rem; color:#c4cbdb;">
+                    <i class="bi bi-discord" style="color:#5865f2;"></i>
+                    <span>Discord</span>
+                    <span class="font-monospace text-secondary" style="font-size:0.7rem;">#{{ msg_id[-6:] }}</span>
+                    <i class="bi bi-arrow-up-right" style="font-size:0.7rem;opacity:0.6;"></i>
+                </a>
+            {% elif not category.claimed %}
+                <span class="text-secondary small flex-shrink-0">Not claimed</span>
+            {% endif %}
         </div>
         {% endfor %}
     </div>

--- a/apps/web/app/templates/player/amend_claim.html
+++ b/apps/web/app/templates/player/amend_claim.html
@@ -59,11 +59,18 @@
                             <label class="form-check-label" for="{{ key }}">{{ label }}</label>
                         </div>
                         <div class="mt-2 {% if not was_checked %}d-none{% endif %}" id="{{ key }}_link_group">
-                            <input type="url" class="form-control form-control-sm claim-link-input"
-                                   name="{{ key }}_link"
-                                   value="{{ old_link or '' }}"
-                                   placeholder="Discord post link (required)"
-                                   pattern="https?://.*">
+                            <div class="input-group input-group-sm">
+                                <input type="url" class="form-control claim-link-input"
+                                       name="{{ key }}_link"
+                                       value="{{ old_link or '' }}"
+                                       placeholder="Discord post link (required)"
+                                       pattern="https?://.*">
+                                <a class="btn btn-outline-secondary evidence-open-btn {% if not old_link %}disabled{% endif %}"
+                                   href="{{ old_link or '#' }}" target="_blank" rel="noopener" title="Open link in new tab">
+                                    <i class="bi bi-box-arrow-up-right"></i>
+                                </a>
+                            </div>
+                            <div class="evidence-preview small mt-1" style="min-height:1.2em;"></div>
                         </div>
                     </div>
                 </div>
@@ -80,11 +87,18 @@
                             <label class="form-check-label" for="wildcard">Wildcard / Special XP</label>
                         </div>
                         <div class="mt-2 {% if not claim.wildcard %}d-none{% endif %}" id="wildcard_link_group">
-                            <input type="url" class="form-control form-control-sm mb-2"
-                                   name="wildcard_link"
-                                   value="{{ claim.wildcard_link or '' }}"
-                                   placeholder="Discord post link (required)"
-                                   pattern="https?://.*">
+                            <div class="input-group input-group-sm mb-1">
+                                <input type="url" class="form-control claim-link-input"
+                                       name="wildcard_link"
+                                       value="{{ claim.wildcard_link or '' }}"
+                                       placeholder="Discord post link (required)"
+                                       pattern="https?://.*">
+                                <a class="btn btn-outline-secondary evidence-open-btn {% if not claim.wildcard_link %}disabled{% endif %}"
+                                   href="{{ claim.wildcard_link or '#' }}" target="_blank" rel="noopener" title="Open link in new tab">
+                                    <i class="bi bi-box-arrow-up-right"></i>
+                                </a>
+                            </div>
+                            <div class="evidence-preview small mt-1 mb-2" style="min-height:1.2em;"></div>
                             <input type="text" class="form-control form-control-sm mb-2"
                                    name="wildcard_reason"
                                    value="{{ claim.wildcard_reason or '' }}"
@@ -111,11 +125,49 @@
 </div>
 
 <script>
-document.querySelectorAll('.claim-cat-check').forEach(function(cb) {
-    cb.addEventListener('change', function() {
-        var target = document.getElementById(this.dataset.linkTarget);
-        if (target) target.classList.toggle('d-none', !this.checked);
-    });
+document.querySelectorAll('.claim-cat-check').forEach(function (cb) {
+  cb.addEventListener('change', function () {
+    var target = document.getElementById(this.dataset.linkTarget);
+    if (target) target.classList.toggle('d-none', !this.checked);
+  });
 });
+
+(function () {
+  var DISCORD_RE = /^https?:\/\/(?:\w+\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)\/?$/;
+  function render(inp) {
+    var group   = inp.closest('[id$="_link_group"]');
+    if (!group) return;
+    var btn     = group.querySelector('.evidence-open-btn');
+    var preview = group.querySelector('.evidence-preview');
+    var val     = inp.value.trim();
+    var ok      = /^https?:\/\/.+/.test(val);
+    if (btn) {
+      btn.classList.toggle('disabled', !ok);
+      btn.href = ok ? val : '#';
+    }
+    if (!preview) return;
+    if (!val) { preview.innerHTML = ''; return; }
+    var m = val.match(DISCORD_RE);
+    if (m) {
+      preview.innerHTML =
+        '<i class="bi bi-discord" style="color:#5865f2;"></i> ' +
+        '<span class="text-secondary">Discord</span> ' +
+        '<span class="font-monospace text-secondary">· channel …' + m[2].slice(-6) +
+        ' · msg #' + m[3].slice(-6) + '</span> ' +
+        '<i class="bi bi-check-circle-fill text-success ms-1" style="font-size:0.75rem;"></i>';
+    } else if (ok) {
+      preview.innerHTML =
+        '<i class="bi bi-exclamation-triangle text-warning"></i> ' +
+        '<span class="text-warning">Link doesn\'t look like a Discord message URL</span>';
+    } else {
+      preview.innerHTML = '<span class="text-danger">Must start with https://</span>';
+    }
+  }
+  document.querySelectorAll('.claim-link-input').forEach(function (inp) {
+    inp.addEventListener('input', function () { render(inp); });
+    inp.addEventListener('blur',  function () { render(inp); });
+    render(inp);
+  });
+})();
 </script>
 {% endblock %}

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -506,9 +506,16 @@
                                         <label class="form-check-label" for="{{ key }}">{{ label }}</label>
                                     </div>
                                     <div class="mt-2 d-none" id="{{ key }}_link_group">
-                                        <input type="url" class="form-control form-control-sm claim-link-input"
-                                               name="{{ key }}_link" placeholder="Discord post link (required)"
-                                               pattern="https?://.*">
+                                        <div class="input-group input-group-sm">
+                                            <input type="url" class="form-control claim-link-input"
+                                                   name="{{ key }}_link" placeholder="Discord post link (required)"
+                                                   pattern="https?://.*">
+                                            <a class="btn btn-outline-secondary evidence-open-btn disabled"
+                                               href="#" target="_blank" rel="noopener" title="Open link in new tab">
+                                                <i class="bi bi-box-arrow-up-right"></i>
+                                            </a>
+                                        </div>
+                                        <div class="evidence-preview small mt-1" style="min-height:1.2em;"></div>
                                     </div>
                                 </div>
                             </div>
@@ -537,9 +544,16 @@
                                                    placeholder="XP" title="Number of XP">
                                           </div>
                                         </div>
-                                        <input type="url" class="form-control form-control-sm claim-link-input"
-                                               name="wildcard_link" placeholder="Discord post link (required)"
-                                               pattern="https?://.*">
+                                        <div class="input-group input-group-sm">
+                                            <input type="url" class="form-control claim-link-input"
+                                                   name="wildcard_link" placeholder="Discord post link (required)"
+                                                   pattern="https?://.*">
+                                            <a class="btn btn-outline-secondary evidence-open-btn disabled"
+                                               href="#" target="_blank" rel="noopener" title="Open link in new tab">
+                                                <i class="bi bi-box-arrow-up-right"></i>
+                                            </a>
+                                        </div>
+                                        <div class="evidence-preview small mt-1" style="min-height:1.2em;"></div>
                                     </div>
                                 </div>
                             </div>
@@ -1457,6 +1471,43 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     render();
+})();
+
+(function () {
+  var DISCORD_RE = /^https?:\/\/(?:\w+\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)\/?$/;
+  function renderPreview(inp) {
+    var group   = inp.closest('[id$="_link_group"]');
+    if (!group) return;
+    var btn     = group.querySelector('.evidence-open-btn');
+    var preview = group.querySelector('.evidence-preview');
+    var val     = inp.value.trim();
+    var ok      = /^https?:\/\/.+/.test(val);
+    if (btn) {
+      btn.classList.toggle('disabled', !ok);
+      btn.href = ok ? val : '#';
+    }
+    if (!preview) return;
+    if (!val) { preview.innerHTML = ''; return; }
+    var m = val.match(DISCORD_RE);
+    if (m) {
+      preview.innerHTML =
+        '<i class="bi bi-discord" style="color:#5865f2;"></i> ' +
+        '<span class="text-secondary">Discord</span> ' +
+        '<span class="font-monospace text-secondary">· channel …' + m[2].slice(-6) +
+        ' · msg #' + m[3].slice(-6) + '</span> ' +
+        '<i class="bi bi-check-circle-fill text-success ms-1" style="font-size:0.75rem;"></i>';
+    } else if (ok) {
+      preview.innerHTML =
+        '<i class="bi bi-exclamation-triangle text-warning"></i> ' +
+        '<span class="text-warning">Link doesn\'t look like a Discord message URL</span>';
+    } else {
+      preview.innerHTML = '<span class="text-danger">Must start with https://</span>';
+    }
+  }
+  document.querySelectorAll('.claim-link-input').forEach(function (inp) {
+    inp.addEventListener('input', function () { renderPreview(inp); });
+    inp.addEventListener('blur',  function () { renderPreview(inp); });
+  });
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **Review page**: replaces verbose full-URL evidence cards with compact single-line rows — Discord message pill (glyph + last-6-char message ID + arrow) on the right, muted "Not claimed" tag for unclaimed rows
- **Claim forms** (`character.html` + `amend_claim.html`): wraps every evidence link input in a Bootstrap input-group with an open-in-new-tab icon button; adds a live preview line beneath each input that parses the Discord URL and shows channel/message IDs (or a warning if it's not a Discord message link)
- Hover style on evidence pills for the review page

## Test plan
- [ ] Open a pending claim review — evidence rows are single-line, URLs replaced by Discord pills; unclaimed rows show "Not claimed"
- [ ] Amend-claim page with prefilled links: open button is active and navigates correctly; preview shows parsed IDs with green check
- [ ] New claim on character page: tick a category → input-group appears; type a valid Discord URL → open button enables + preview shows IDs; non-Discord https → warning state; bad input → red hint
- [ ] No regressions to checkbox show/hide behaviour or XP counter on `character.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)