### PR TITLE
Fix bot alerts for one character suppressing alerts for another

### DIFF
--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -230,10 +230,13 @@ def create_app():
         if isinstance(exc, HTTPException):
             return exc
         from .db import AppLogEntry, db as _db
-        from .discord_alert import send_alert, dashboard_link
+        from .discord_alert import send_alert, send_escalation_alert, check_escalation, dashboard_link
         message = f'{type(exc).__name__}: {exc}'
         tb = _traceback.format_exc()
         path = request.path if request else ''
+        # event is constant ('unhandled_exception') for every web crash — dedupe on
+        # exception type + route instead, so one noisy route can't hide an unrelated one.
+        dedupe_key = f'web:unhandled_exception:{type(exc).__name__}:{path}'
         try:
             entry = AppLogEntry(
                 ts=datetime.now(timezone.utc).isoformat(),
@@ -242,6 +245,7 @@ def create_app():
                 event='unhandled_exception',
                 message=message,
                 details=f'{path}\n\n{tb}'[:4000],
+                dedupe_key=dedupe_key,
             )
             _db.session.add(entry)
             _db.session.commit()
@@ -250,16 +254,20 @@ def create_app():
         # Short excerpt for the alert itself — full traceback lives in AppLogEntry,
         # linked below. Last few lines are usually the actual failing statement.
         tb_excerpt = '\n'.join(tb.strip().splitlines()[-6:])
+        webhook_url = app.config.get('DISCORD_WEBHOOK_URL', '')
+        link = dashboard_link(app.config.get('DISCORD_REDIRECT_URI', ''),
+                               source='web', level='error', event='unhandled_exception')
         send_alert(
-            app.config.get('DISCORD_WEBHOOK_URL', ''),
+            webhook_url,
             source='web', level='error', event='unhandled_exception', message=message,
             details=f'{path}\n{tb_excerpt}' if path else tb_excerpt,
-            link=dashboard_link(app.config.get('DISCORD_REDIRECT_URI', ''),
-                                 source='web', level='error', event='unhandled_exception'),
-            # event is constant ('unhandled_exception') for every web crash — dedupe on
-            # exception type + route instead, so one noisy route can't hide an unrelated one.
-            dedupe_key=f'web:unhandled_exception:{type(exc).__name__}:{path}',
+            link=link,
+            dedupe_key=dedupe_key,
         )
+        if webhook_url:
+            count = check_escalation(dedupe_key)
+            if count:
+                send_escalation_alert(webhook_url, dedupe_key, count, message, link)
         # Re-raise so Flask's default 500 handling still applies
         raise exc
 

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1290,7 +1290,7 @@ def bot_log():
     """Bot forwards its warn/error log entries here for persistent storage."""
     from datetime import datetime, timezone
     from app.db import AppLogEntry, db
-    from app.discord_alert import send_alert, dashboard_link
+    from app.discord_alert import send_alert, send_escalation_alert, check_escalation, dashboard_link
     from flask import current_app
     entries = request.get_json(silent=True) or []
     if not isinstance(entries, list):
@@ -1298,6 +1298,7 @@ def bot_log():
     now = datetime.now(timezone.utc)
     webhook_url = current_app.config.get('DISCORD_WEBHOOK_URL', '')
     redirect_uri = current_app.config.get('DISCORD_REDIRECT_URI', '')
+    pending_escalation_checks = []  # (dedupe_key, message, link)
     for raw in entries[:100]:
         if not isinstance(raw, dict):
             continue
@@ -1310,20 +1311,27 @@ def bot_log():
         context = {k: v for k, v in raw.items() if k not in ('ts', 'level', 'event', 'error', 'reason', 'message')}
         import json as _json
         details = _json.dumps(context, ensure_ascii=False) if context else ''
-        db.session.add(AppLogEntry(
-            ts=ts, source='bot', level=level, event=event,
-            message=msg[:2000], details=details[:4000], created_at=now,
-        ))
         # Some bot events recur per-character/per-channel (e.g. a review
         # notifier that can't resolve a cubby channel). Deduping on event
         # name alone would let the first character's alert suppress every
         # other distinct character hitting the same event for 15 minutes.
         subject = str(context.get('characterName') or context.get('channelName') or '')
         dedupe_key = f'bot:{event}:{subject}' if subject else ''
+        db.session.add(AppLogEntry(
+            ts=ts, source='bot', level=level, event=event,
+            message=msg[:2000], details=details[:4000], created_at=now,
+            dedupe_key=dedupe_key,
+        ))
+        link = dashboard_link(redirect_uri, 'bot', level, event)
         send_alert(webhook_url, source='bot', level=level, event=event, message=msg,
-                   details=details, link=dashboard_link(redirect_uri, 'bot', level, event),
-                   dedupe_key=dedupe_key)
+                   details=details, link=link, dedupe_key=dedupe_key)
+        pending_escalation_checks.append((dedupe_key, msg, link))
     db.session.commit()
+    if webhook_url:
+        for dedupe_key, msg, link in pending_escalation_checks:
+            count = check_escalation(dedupe_key)
+            if count:
+                send_escalation_alert(webhook_url, dedupe_key, count, msg, link)
     # Prune to 500 most recent entries
     cutoff_query = db.session.query(AppLogEntry.id).order_by(AppLogEntry.created_at.desc()).offset(500).limit(1).scalar()
     if cutoff_query:

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1314,8 +1314,15 @@ def bot_log():
             ts=ts, source='bot', level=level, event=event,
             message=msg[:2000], details=details[:4000], created_at=now,
         ))
+        # Some bot events recur per-character/per-channel (e.g. a review
+        # notifier that can't resolve a cubby channel). Deduping on event
+        # name alone would let the first character's alert suppress every
+        # other distinct character hitting the same event for 15 minutes.
+        subject = str(context.get('characterName') or context.get('channelName') or '')
+        dedupe_key = f'bot:{event}:{subject}' if subject else ''
         send_alert(webhook_url, source='bot', level=level, event=event, message=msg,
-                   details=details, link=dashboard_link(redirect_uri, 'bot', level, event))
+                   details=details, link=dashboard_link(redirect_uri, 'bot', level, event),
+                   dedupe_key=dedupe_key)
     db.session.commit()
     # Prune to 500 most recent entries
     cutoff_query = db.session.query(AppLogEntry.id).order_by(AppLogEntry.created_at.desc()).offset(500).limit(1).scalar()

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -21,6 +21,9 @@ class AppLogEntry(db.Model):
     details = db.Column(Text, default='')
     created_at = db.Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
     dismissed = db.Column(Boolean, nullable=False, default=False, index=True)
+    # Same grouping key used for Discord alert dedupe (source:event[:subject]) —
+    # lets us count occurrences of "this specific thing" for escalation.
+    dedupe_key = db.Column(String(250), nullable=False, default='', index=True)
 
 
 class DbCharacter(db.Model):

--- a/apps/web/app/discord_alert.py
+++ b/apps/web/app/discord_alert.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from datetime import datetime, timedelta
 from urllib.parse import quote, urlparse
 
 import requests
@@ -23,6 +24,13 @@ logger = logging.getLogger(__name__)
 _RATE_LIMIT_SECONDS = 15 * 60
 _last_sent: dict[str, float] = {}
 _lock = threading.Lock()
+
+# A single recurring thing (same dedupe_key) that crosses this many
+# occurrences within this window gets a distinct "may not be
+# self-correcting" escalation, on top of (not instead of) the normal
+# rate-limited per-occurrence alert.
+ESCALATION_THRESHOLD = 5
+ESCALATION_WINDOW_HOURS = 24
 
 
 def _should_send(event: str) -> bool:
@@ -77,3 +85,52 @@ def send_alert(webhook_url: str, source: str, level: str, event: str, message: s
         requests.post(webhook_url, json={'content': content[:2000]}, timeout=5)
     except Exception as exc:
         logger.warning('discord_alert_failed: %s', exc)
+
+
+def check_escalation(dedupe_key: str) -> int | None:
+    """Count AppLogEntry rows sharing *dedupe_key* within ESCALATION_WINDOW_HOURS.
+
+    Returns the count if it just crossed a multiple of ESCALATION_THRESHOLD
+    (5, 10, 15, ...), else None. Call this once per newly-inserted row, after
+    it's committed, so each integer count is checked exactly once.
+
+    Best-effort: returns None on any failure (e.g. the DB itself is the
+    thing that's down) rather than raising into the caller's error handler.
+    """
+    if not dedupe_key:
+        return None
+    try:
+        from .db import AppLogEntry
+        cutoff = datetime.utcnow() - timedelta(hours=ESCALATION_WINDOW_HOURS)
+        count = AppLogEntry.query.filter(
+            AppLogEntry.dedupe_key == dedupe_key,
+            AppLogEntry.created_at >= cutoff,
+        ).count()
+    except Exception as exc:
+        logger.warning('escalation_check_failed: %s', exc)
+        return None
+    if count and count % ESCALATION_THRESHOLD == 0:
+        return count
+    return None
+
+
+def send_escalation_alert(webhook_url: str, dedupe_key: str, count: int, message: str, link: str = '') -> None:
+    """Best-effort Discord webhook post flagging a recurring issue. Never raises.
+
+    Deliberately bypasses the normal rate limiter — check_escalation() above
+    already only returns non-None at threshold multiples, so this can't fire
+    more often than every ESCALATION_THRESHOLD occurrences.
+    """
+    if not webhook_url:
+        return
+    try:
+        content = (
+            f'⚠️ **Recurring issue** — `{dedupe_key}` has happened '
+            f'**{count} times** in the last {ESCALATION_WINDOW_HOURS}h and may not be self-correcting.\n'
+            f'Most recent: {message[:500]}'
+        )
+        if link:
+            content += f'\n🔗 <{link}>'
+        requests.post(webhook_url, json={'content': content[:2000]}, timeout=5)
+    except Exception as exc:
+        logger.warning('discord_escalation_alert_failed: %s', exc)

--- a/apps/web/migrations/versions/b2d6e91a4c73_add_dedupe_key_to_app_log_entries.py
+++ b/apps/web/migrations/versions/b2d6e91a4c73_add_dedupe_key_to_app_log_entries.py
@@ -1,0 +1,34 @@
+"""add dedupe_key to app_log_entries
+
+Revision ID: b2d6e91a4c73
+Revises: a91c5f7b2d4e
+Create Date: 2026-07-02
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2d6e91a4c73'
+down_revision = 'a91c5f7b2d4e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c['name'] for c in inspector.get_columns('app_log_entries')}
+    if 'dedupe_key' not in cols:
+        op.add_column('app_log_entries', sa.Column('dedupe_key', sa.String(length=250), nullable=False, server_default=''))
+    indexes = {ix['name'] for ix in inspector.get_indexes('app_log_entries')}
+    if 'ix_app_log_entries_dedupe_key' not in indexes:
+        op.create_index('ix_app_log_entries_dedupe_key', 'app_log_entries', ['dedupe_key'])
+
+
+def downgrade():
+    op.drop_index('ix_app_log_entries_dedupe_key', table_name='app_log_entries')
+    op.drop_column('app_log_entries', 'dedupe_key')

--- a/apps/web/tests/test_bot_log_alert_dedupe.py
+++ b/apps/web/tests/test_bot_log_alert_dedupe.py
@@ -1,0 +1,64 @@
+"""POST /api/bot-log must not let one character's alert suppress another's.
+
+Regression: the Discord alert rate limiter dedupes per key. Bot events that
+recur per-character (e.g. a review notifier that can't resolve a cubby
+channel) need a key that includes the subject, or the first character's
+alert silently swallows every other distinct character's alert for 15
+minutes.
+"""
+
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.blueprints.api import bp as api_bp
+from app.db import db
+from app import discord_alert
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WEB_APP_API_TOKEN'] = 'test-token'
+    app.config['WEB_APP_API_WRITE_TOKEN'] = 'write-token'
+    app.config['BOT_API_REPLAY_PROTECTION_ENABLED'] = False
+    app.config['DISCORD_WEBHOOK_URL'] = 'https://discord.com/api/webhooks/test'
+    db.init_app(app)
+    app.register_blueprint(api_bp, url_prefix='/api')
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_distinct_characters_both_alert_within_rate_limit_window():
+    app = _app()
+    discord_alert._last_sent.clear()
+    payload = [
+        {'level': 'error', 'event': 'review_notifier_channel_missing',
+         'error': 'no channel', 'characterName': 'Emmet Brown', 'eventKey': 'claim:1:approved:1'},
+        {'level': 'error', 'event': 'review_notifier_channel_missing',
+         'error': 'no channel', 'characterName': 'Aliyah', 'eventKey': 'claim:2:approved:2'},
+    ]
+    with app.test_client() as client, patch('app.discord_alert.requests.post') as mock_post:
+        res = client.post('/api/bot-log', json=payload,
+                           headers={'Authorization': 'Bearer write-token'})
+    assert res.status_code == 200
+    assert mock_post.call_count == 2
+
+
+def test_same_character_repeated_event_is_still_rate_limited():
+    app = _app()
+    discord_alert._last_sent.clear()
+    payload = [
+        {'level': 'error', 'event': 'review_notifier_channel_missing',
+         'error': 'no channel', 'characterName': 'Emmet Brown', 'eventKey': 'claim:1:approved:1'},
+        {'level': 'error', 'event': 'review_notifier_channel_missing',
+         'error': 'no channel', 'characterName': 'Emmet Brown', 'eventKey': 'claim:3:approved:3'},
+    ]
+    with app.test_client() as client, patch('app.discord_alert.requests.post') as mock_post:
+        res = client.post('/api/bot-log', json=payload,
+                           headers={'Authorization': 'Bearer write-token'})
+    assert res.status_code == 200
+    assert mock_post.call_count == 1

--- a/apps/web/tests/test_discord_escalation.py
+++ b/apps/web/tests/test_discord_escalation.py
@@ -1,0 +1,104 @@
+"""Tests for occurrence-count escalation alerts (a recurring issue that
+crosses ESCALATION_THRESHOLD within ESCALATION_WINDOW_HOURS gets a distinct
+'may not be self-correcting' message, on top of the normal per-occurrence one).
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from flask import Flask
+
+from app import discord_alert
+from app.db import AppLogEntry, db
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(dedupe_key: str, count: int, created_at=None):
+    created_at = created_at or datetime.utcnow()
+    for _ in range(count):
+        db.session.add(AppLogEntry(
+            ts=created_at.isoformat(), source='bot', level='error', event='x',
+            message='x', details='', created_at=created_at, dedupe_key=dedupe_key,
+        ))
+    db.session.commit()
+
+
+def test_check_escalation_returns_none_below_threshold():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD - 1)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') is None
+
+
+def test_check_escalation_returns_count_at_threshold():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') == discord_alert.ESCALATION_THRESHOLD
+
+
+def test_check_escalation_none_between_thresholds():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD + 1)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') is None
+
+
+def test_check_escalation_fires_again_at_next_multiple():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD * 2)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') == discord_alert.ESCALATION_THRESHOLD * 2
+
+
+def test_check_escalation_ignores_entries_outside_window():
+    app = _app()
+    with app.app_context():
+        old = datetime.utcnow() - timedelta(hours=discord_alert.ESCALATION_WINDOW_HOURS + 1)
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD, created_at=old)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') is None
+
+
+def test_check_escalation_empty_dedupe_key_returns_none():
+    app = _app()
+    with app.app_context():
+        assert discord_alert.check_escalation('') is None
+
+
+def test_check_escalation_distinct_keys_counted_separately():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD)
+        _seed('bot:x:aliyah', discord_alert.ESCALATION_THRESHOLD - 1)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') == discord_alert.ESCALATION_THRESHOLD
+        assert discord_alert.check_escalation('bot:x:aliyah') is None
+
+
+def test_send_escalation_alert_posts_and_mentions_count():
+    with patch('app.discord_alert.requests.post') as mock_post:
+        discord_alert.send_escalation_alert('https://x', 'bot:x:emmet-brown', 5, 'no channel found')
+    mock_post.assert_called_once()
+    content = mock_post.call_args.kwargs['json']['content']
+    assert '5 times' in content
+    assert 'bot:x:emmet-brown' in content
+
+
+def test_send_escalation_alert_skips_when_no_webhook_url():
+    with patch('app.discord_alert.requests.post') as mock_post:
+        discord_alert.send_escalation_alert('', 'bot:x:emmet-brown', 5, 'no channel found')
+    mock_post.assert_not_called()
+
+
+def test_send_escalation_alert_never_raises_on_request_failure():
+    with patch('app.discord_alert.requests.post', side_effect=RuntimeError('down')):
+        discord_alert.send_escalation_alert('https://x', 'bot:x:emmet-brown', 5, 'no channel found')


### PR DESCRIPTION
## Summary

Prompted by seeing `review_notifier_channel_missing` for one character (Emmet Brown) in production — that error itself is a real Discord-side data gap (no cubby channel resolves for that character name), not a code bug. But while looking into it I found a real bug in the alerting shipped in #312, plus built out the follow-on "flag recurring issues" idea from that conversation.

### Part 1: per-subject alert dedupe (original fix)
`/api/bot-log` deduped Discord alerts on `source:event` alone. Several bot events recur per-character — `review_notifier_channel_missing`, `review_notifier_channel_ambiguous`, `review_notifier_channel_first_name_fallback` — so with a constant event name, whichever character hits the error *first* within a 15-minute window silently suppresses the alert for every other distinct character hitting the same error. Same class of bug Codex flagged on the web crash handler in #313, just not caught there since that PR didn't touch the bot-log path.

- `app/blueprints/api.py`: `bot_log()` now includes `characterName`/`channelName` (when present in the event's own context) in the alert's dedupe key, so distinct subjects get distinct alerts while true repeats of the same character/event are still rate-limited.

### Part 2: occurrence-count escalation for recurring issues
A brief Turso `502` blip surfaced via this same alerting led to a follow-up question: instead of either alerting on every single occurrence (noisy) or relying on the 15-minute dedupe to quietly re-suppress reminders (silent), track occurrence counts and escalate distinctly when a threshold is crossed.

- `app/db.py`: new indexed `AppLogEntry.dedupe_key` column — the same grouping key already used for alert rate-limiting, now persisted so occurrences can be counted.
- `migrations/versions/b2d6e91a4c73`: adds the column + index. Verified against a simulated pre-migration DB, not just a fresh install (where `db.create_all()` would mask a broken `ADD COLUMN`).
- `app/discord_alert.py`: `check_escalation()` counts matching rows in a rolling 24h window; `send_escalation_alert()` posts a distinct "⚠️ Recurring issue" message when the count crosses a multiple of 5. Both best-effort — a failure here (e.g. the DB itself being the problem) logs a warning instead of raising into the caller's error handler.
- Wired into both `AppLogEntry` write sites (web unhandled exceptions, bot-reported errors).

## Test plan
- [x] `pytest` — 153 passed, including `tests/test_bot_log_alert_dedupe.py` and `tests/test_discord_escalation.py`.
- [x] `ruff check` — clean.
- [x] Manually verified the new migration against a simulated pre-migration SQLite DB (seeded old schema + `alembic_version` at the prior head) — confirms the real `ADD COLUMN` path, not just the fresh-install `create_all()` shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)