### PR TITLE
Suggest closest-matching cubby channel when review notifier can't resolve one

### DIFF
--- a/apps/bot/src/__tests__/cubbyChannels.test.ts
+++ b/apps/bot/src/__tests__/cubbyChannels.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { findClosestChannelName, normalizeChannelName } from '../services/cubbyChannels';
+
+describe('normalizeChannelName', () => {
+  it('lowercases, hyphenates, and trims', () => {
+    expect(normalizeChannelName('Emmet Brown')).toBe('emmet-brown');
+    expect(normalizeChannelName('  Sylvester   Glass  ')).toBe('sylvester-glass');
+  });
+});
+
+describe('findClosestChannelName', () => {
+  it('suggests a single-character typo of an existing channel', () => {
+    const candidates = ['emmit-brown', 'aliyah', 'sylvester-glass'];
+    expect(findClosestChannelName('emmet-brown', candidates)).toBe('emmit-brown');
+  });
+
+  it('returns null when nothing is close enough to be a plausible match', () => {
+    const candidates = ['aliyah', 'sylvester-glass', 'the-owl'];
+    expect(findClosestChannelName('emmet-brown', candidates)).toBeNull();
+  });
+
+  it('returns null for an empty candidate list', () => {
+    expect(findClosestChannelName('emmet-brown', [])).toBeNull();
+  });
+
+  it('returns the exact match when one exists', () => {
+    const candidates = ['emmet-brown', 'aliyah'];
+    expect(findClosestChannelName('emmet-brown', candidates)).toBe('emmet-brown');
+  });
+});

--- a/apps/bot/src/services/cubbyChannels.ts
+++ b/apps/bot/src/services/cubbyChannels.ts
@@ -20,6 +20,44 @@ export function normalizeChannelName(value: string): string {
     .replace(/-+/g, '-');
 }
 
+function levenshteinDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[] = new Array(n + 1);
+  for (let j = 0; j <= n; j++) dp[j] = j;
+  for (let i = 1; i <= m; i++) {
+    let prev = dp[0];
+    dp[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const temp = dp[j];
+      dp[j] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j], dp[j - 1]);
+      prev = temp;
+    }
+  }
+  return dp[n];
+}
+
+/**
+ * Find the closest-matching existing channel name for a target, to help
+ * staff spot typos (e.g. "emmit-brown" cubby vs a character named "Emmet
+ * Brown"). Returns null if nothing is close enough to be a plausible match —
+ * a genuinely unmapped character shouldn't "match" an unrelated channel.
+ */
+export function findClosestChannelName(target: string, candidates: Iterable<string>): string | null {
+  let best: string | null = null;
+  let bestDistance = Infinity;
+  for (const candidate of candidates) {
+    const distance = levenshteinDistance(target, candidate);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  if (best === null) return null;
+  const threshold = Math.max(2, Math.ceil(target.length * 0.25));
+  return bestDistance <= threshold ? best : null;
+}
+
 function isNotificationChannel(channel: GuildBasedChannel | null | undefined): channel is NotificationChannel {
   if (!channel) {
     return false;

--- a/apps/bot/src/services/reviewNotifier.ts
+++ b/apps/bot/src/services/reviewNotifier.ts
@@ -5,7 +5,7 @@ import type { BotClient } from '../discord';
 import { errorToMessage, logEvent } from '../logger';
 import type { TrackerAdapter } from './adapter';
 import type { ReviewEvent } from '../types';
-import { buildCubbyChannelMap, normalizeChannelName, type NotificationChannel } from './cubbyChannels';
+import { buildCubbyChannelMap, findClosestChannelName, normalizeChannelName, type NotificationChannel } from './cubbyChannels';
 import { liveConfig } from '../liveConfig';
 
 const STATE_PATH = path.resolve('./data/review-notifier-cursor.json');
@@ -130,9 +130,11 @@ function resolveChannel(
     return null;
   }
 
+  const suggestedChannel = findClosestChannelName(fullKey, channelMap.keys());
   logEvent('error', 'review_notifier_channel_missing', {
     characterName,
     eventKey,
+    ...(suggestedChannel ? { suggestedChannel } : {}),
   });
   return null;
 }


### PR DESCRIPTION
## Summary

Prompted by a real case: a character named "Emmet Brown" had a cubby channel named `emmit-brown` — a one-character typo — so the notifier logged `review_notifier_channel_missing` with no indication of what actually went wrong. Finding and fixing it required manually diffing the character list against the Discord channel list.

Adds `findClosestChannelName()` (Levenshtein distance, bounded by a threshold relative to name length so a genuinely-missing channel doesn't "match" an unrelated one) and includes the suggestion as `suggestedChannel` in the log event's context when one is found close enough. It already flows through to the Discord alert via `bot-log`'s existing `details` field — no changes needed on the web side.

Deliberately **not** auto-renaming or auto-creating channels — a typo and a genuinely new/unmapped character look identical to the bot, and a wrong automatic rename is worse than a missed notification. This just makes the manual fix faster next time.

## Changes
- `services/cubbyChannels.ts`: new `findClosestChannelName()` helper.
- `services/reviewNotifier.ts`: `resolveChannel()`'s missing-channel branch now includes `suggestedChannel` in the log context when applicable.
- New `__tests__/cubbyChannels.test.ts`.

## Test plan
- [x] `npm test` — 66 passed (full bot suite).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)