### PR TITLE
Fix RoD sheet imports always setting age_category to ancilla

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -786,8 +786,16 @@ def _normalize_sheet_data(data: dict) -> dict:
     return data
 
 
-def _map_rod_to_cc(rod: dict) -> dict:
-    """Map a Realm of Darkness V5 sheet export to CC character_data format."""
+_ROSTER_AGE_CATEGORIES = ('mortal', 'fledgling', 'neonate', 'ancilla')
+
+
+def _map_rod_to_cc(rod: dict, age_category: str = 'ancilla') -> dict:
+    """Map a Realm of Darkness V5 sheet export to CC character_data format.
+
+    *age_category* should be the character's actual roster age category
+    (one of _ROSTER_AGE_CATEGORIES); defaults to 'ancilla' only when the
+    caller has nothing better (e.g. roster age_category is blank/unrecognized).
+    """
     # Basic identity fields
     data: dict = {
         'name': rod.get('name', ''),
@@ -812,7 +820,7 @@ def _map_rod_to_cc(rod: dict) -> dict:
                 if c
             ]
         ),
-        'age_category': 'ancilla',  # existing characters are treated as ancilla
+        'age_category': age_category if age_category in _ROSTER_AGE_CATEGORIES else 'ancilla',
     }
 
     # Attributes (RoD already uses a flat dict)
@@ -922,7 +930,8 @@ def import_sheet(name):
         return render_template('player/import_sheet.html', char=char)
 
     try:
-        cc_data = _map_rod_to_cc(rod_data)
+        age_category = (char_row.age_category or '').strip().lower()
+        cc_data = _map_rod_to_cc(rod_data, age_category=age_category)
     except Exception as exc:
         logger.warning('RoD sheet import mapping error for %s: %s', name, exc)
         flash('Could not parse the sheet data. Please contact staff for help.', 'danger')

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -15,7 +15,7 @@ from app.auth import (
     get_player_discord_id,
 )
 from app.db import AppSetting, CharacterDraft, Coterie, CoterieMember, DbCharacter, db
-from app.models import SPEND_CATEGORIES
+from app.models import AGE_CATEGORIES, SPEND_CATEGORIES
 from app.game_calendar import get_calendar
 
 logger = logging.getLogger(__name__)
@@ -786,7 +786,14 @@ def _normalize_sheet_data(data: dict) -> dict:
     return data
 
 
-_ROSTER_AGE_CATEGORIES = ('mortal', 'fledgling', 'neonate', 'ancilla')
+# Lowercased app.models.AGE_CATEGORIES (the roster's canonical list, e.g.
+# includes 'elder') plus 'ghoul' — a valid CC-approval-flow value
+# (cc_admin.draft_approve capitalizes character_data['age_category'] straight
+# into DbCharacter.age_category without validating against AGE_CATEGORIES).
+# Derived rather than hand-listed so this can't silently drift out of sync
+# and re-introduce the same "unrecognized category falls back to ancilla"
+# bug this allowlist exists to prevent.
+_ROSTER_AGE_CATEGORIES = frozenset({c.lower() for c in AGE_CATEGORIES} | {'ghoul'})
 
 
 def _map_rod_to_cc(rod: dict, age_category: str = 'ancilla') -> dict:

--- a/apps/web/tests/test_rod_sheet_import.py
+++ b/apps/web/tests/test_rod_sheet_import.py
@@ -10,7 +10,10 @@ _MINIMAL_ROD = {'name': 'Test Char', 'clan': 'Toreador', 'attributes': {}}
 
 
 def test_uses_the_given_age_category():
-    for age in ('mortal', 'fledgling', 'neonate', 'ancilla'):
+    # Every category app.models.AGE_CATEGORIES actually contains (roster's
+    # canonical list — includes 'elder'), plus 'ghoul' (a valid CC-approval
+    # value not in AGE_CATEGORIES but reachable on DbCharacter.age_category).
+    for age in ('mortal', 'fledgling', 'neonate', 'ancilla', 'elder', 'ghoul'):
         data = _map_rod_to_cc(_MINIMAL_ROD, age_category=age)
         assert data['age_category'] == age
 
@@ -20,8 +23,8 @@ def test_falls_back_to_ancilla_when_blank():
     assert data['age_category'] == 'ancilla'
 
 
-def test_falls_back_to_ancilla_when_unrecognized():
-    data = _map_rod_to_cc(_MINIMAL_ROD, age_category='ghoul')
+def test_falls_back_to_ancilla_when_truly_unrecognized():
+    data = _map_rod_to_cc(_MINIMAL_ROD, age_category='not-a-real-category')
     assert data['age_category'] == 'ancilla'
 
 

--- a/apps/web/tests/test_rod_sheet_import.py
+++ b/apps/web/tests/test_rod_sheet_import.py
@@ -1,0 +1,30 @@
+"""Tests for _map_rod_to_cc's age_category mapping.
+
+Regression: RoD sheet imports used to hardcode age_category to 'ancilla'
+regardless of the character's actual roster age category.
+"""
+
+from app.blueprints.player import _map_rod_to_cc
+
+_MINIMAL_ROD = {'name': 'Test Char', 'clan': 'Toreador', 'attributes': {}}
+
+
+def test_uses_the_given_age_category():
+    for age in ('mortal', 'fledgling', 'neonate', 'ancilla'):
+        data = _map_rod_to_cc(_MINIMAL_ROD, age_category=age)
+        assert data['age_category'] == age
+
+
+def test_falls_back_to_ancilla_when_blank():
+    data = _map_rod_to_cc(_MINIMAL_ROD, age_category='')
+    assert data['age_category'] == 'ancilla'
+
+
+def test_falls_back_to_ancilla_when_unrecognized():
+    data = _map_rod_to_cc(_MINIMAL_ROD, age_category='ghoul')
+    assert data['age_category'] == 'ancilla'
+
+
+def test_default_parameter_is_ancilla_for_backward_compatibility():
+    data = _map_rod_to_cc(_MINIMAL_ROD)
+    assert data['age_category'] == 'ancilla'


### PR DESCRIPTION
## Summary

Reported: all Realm of Darkness JSON sheet imports were landing as Ancilla regardless of the character's actual age category.

Root cause: `_map_rod_to_cc()` in `app/blueprints/player.py` hardcoded `'age_category': 'ancilla'` with a comment claiming "existing characters are treated as ancilla." That's wrong for any Mortal, Fledgling, or Neonate character re-importing their sheet — they'd get silently promoted to Ancilla in their living sheet data.

`import_sheet()` already has the roster `DbCharacter` row (`char_row`) with the real `age_category` set at character-approval time (via the bot's `/lasombra approve`, one of `Mortal`/`Fledgling`/`Neonate`/`Ancilla`). This just threads that through instead of hardcoding.

## Changes
- `_map_rod_to_cc()` now takes an `age_category` param (validated against the known roster values, falling back to `'ancilla'` only if blank/unrecognized — same as previous behavior, just no longer unconditional).
- `import_sheet()` passes `char_row.age_category.lower()` through.
- New `tests/test_rod_sheet_import.py`.

## Test plan
- [x] `pytest` — 157 passed.
- [x] `ruff check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)