### PR TITLE
Switch Discord alerting to quiet-until-threshold, add bulk error dismiss

### DIFF
--- a/apps/web/app/__init__.py
+++ b/apps/web/app/__init__.py
@@ -253,7 +253,7 @@ def create_app():
         if isinstance(exc, HTTPException):
             return exc
         from .db import AppLogEntry, db as _db
-        from .discord_alert import send_alert, send_escalation_alert, check_escalation, dashboard_link
+        from .discord_alert import send_escalation_alert, check_escalation, dashboard_link
         message = f'{type(exc).__name__}: {exc}'
         tb = _traceback.format_exc()
         path = request.path if request else ''
@@ -274,23 +274,23 @@ def create_app():
             _db.session.commit()
         except Exception:
             pass
-        # Short excerpt for the alert itself — full traceback lives in AppLogEntry,
-        # linked below. Last few lines are usually the actual failing statement.
-        tb_excerpt = '\n'.join(tb.strip().splitlines()[-6:])
+        # Stays quiet below discord_alert.ESCALATION_THRESHOLD occurrences of
+        # this exact exception+route — the AppLogEntry row above is already
+        # visible to any staff on /audit/errors regardless.
         webhook_url = app.config.get('DISCORD_WEBHOOK_URL', '')
-        link = dashboard_link(app.config.get('DISCORD_REDIRECT_URI', ''),
-                               source='web', level='error', event='unhandled_exception')
-        send_alert(
-            webhook_url,
-            source='web', level='error', event='unhandled_exception', message=message,
-            details=f'{path}\n{tb_excerpt}' if path else tb_excerpt,
-            link=link,
-            dedupe_key=dedupe_key,
-        )
         if webhook_url:
             count = check_escalation(dedupe_key)
             if count:
-                send_escalation_alert(webhook_url, dedupe_key, count, message, link)
+                # Short excerpt — full traceback lives in AppLogEntry, linked below.
+                # Last few lines are usually the actual failing statement.
+                tb_excerpt = '\n'.join(tb.strip().splitlines()[-6:])
+                link = dashboard_link(app.config.get('DISCORD_REDIRECT_URI', ''),
+                                       source='web', level='error', event='unhandled_exception')
+                send_escalation_alert(
+                    webhook_url, dedupe_key, count, message,
+                    details=f'{path}\n{tb_excerpt}' if path else tb_excerpt,
+                    link=link,
+                )
         # Re-raise so Flask's default 500 handling still applies
         raise exc
 

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1316,9 +1316,12 @@ def bot_log():
         # Some bot events recur per-character/per-channel (e.g. a review
         # notifier that can't resolve a cubby channel). Deduping on event
         # name alone would let the first character's occurrences suppress
-        # every other distinct character hitting the same event.
+        # every other distinct character hitting the same event. Events with
+        # no subject (e.g. wiki_sync_scheduled_failed) fall back to plain
+        # event-level grouping — never leave dedupe_key empty, or these lose
+        # escalation tracking entirely (check_escalation treats '' as "skip").
         subject = str(context.get('characterName') or context.get('channelName') or '')
-        dedupe_key = f'bot:{event}:{subject}' if subject else ''
+        dedupe_key = f'bot:{event}:{subject}' if subject else f'bot:{event}'
         db.session.add(AppLogEntry(
             ts=ts, source='bot', level=level, event=event,
             message=msg[:2000], details=details[:4000], created_at=now,
@@ -1331,16 +1334,26 @@ def bot_log():
         # A batch can carry several rows sharing one dedupe_key (all committed
         # together, same timestamp) — checking each individually would see the
         # same final count every time and fire the same escalation once per
-        # row. Check each distinct key once; last row's context wins for the
+        # row. Aggregate to one check per distinct key, telling
+        # check_escalation how many new rows this batch added for that key so
+        # it can detect crossing a threshold multiple even when the batch
+        # doesn't land exactly on one (prior count 4 + this batch's 2 = 6,
+        # still past the 5-occurrence mark). Last row's context wins for the
         # "most recent" framing in the alert.
         by_key = {}
         for dedupe_key, msg, details, link in pending_escalation_checks:
-            if dedupe_key:
-                by_key[dedupe_key] = (msg, details, link)
-        for dedupe_key, (msg, details, link) in by_key.items():
-            count = check_escalation(dedupe_key)
+            entry = by_key.setdefault(dedupe_key, {'n': 0})
+            entry['n'] += 1
+            entry['msg'] = msg
+            entry['details'] = details
+            entry['link'] = link
+        for dedupe_key, info in by_key.items():
+            count = check_escalation(dedupe_key, new_occurrences=info['n'])
             if count:
-                send_escalation_alert(webhook_url, dedupe_key, count, msg, details=details, link=link)
+                send_escalation_alert(
+                    webhook_url, dedupe_key, count, info['msg'],
+                    details=info['details'], link=info['link'],
+                )
     # Prune to 500 most recent entries
     cutoff_query = db.session.query(AppLogEntry.id).order_by(AppLogEntry.created_at.desc()).offset(500).limit(1).scalar()
     if cutoff_query:

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1290,7 +1290,7 @@ def bot_log():
     """Bot forwards its warn/error log entries here for persistent storage."""
     from datetime import datetime, timezone
     from app.db import AppLogEntry, db
-    from app.discord_alert import send_alert, send_escalation_alert, check_escalation, dashboard_link
+    from app.discord_alert import send_escalation_alert, check_escalation, dashboard_link
     from flask import current_app
     entries = request.get_json(silent=True) or []
     if not isinstance(entries, list):
@@ -1298,7 +1298,9 @@ def bot_log():
     now = datetime.now(timezone.utc)
     webhook_url = current_app.config.get('DISCORD_WEBHOOK_URL', '')
     redirect_uri = current_app.config.get('DISCORD_REDIRECT_URI', '')
-    pending_escalation_checks = []  # (dedupe_key, message, link)
+    # (dedupe_key, message, details, link) — checked for escalation after
+    # commit, once each row's own count is stable to query.
+    pending_escalation_checks = []
     for raw in entries[:100]:
         if not isinstance(raw, dict):
             continue
@@ -1313,8 +1315,8 @@ def bot_log():
         details = _json.dumps(context, ensure_ascii=False) if context else ''
         # Some bot events recur per-character/per-channel (e.g. a review
         # notifier that can't resolve a cubby channel). Deduping on event
-        # name alone would let the first character's alert suppress every
-        # other distinct character hitting the same event for 15 minutes.
+        # name alone would let the first character's occurrences suppress
+        # every other distinct character hitting the same event.
         subject = str(context.get('characterName') or context.get('channelName') or '')
         dedupe_key = f'bot:{event}:{subject}' if subject else ''
         db.session.add(AppLogEntry(
@@ -1323,15 +1325,22 @@ def bot_log():
             dedupe_key=dedupe_key,
         ))
         link = dashboard_link(redirect_uri, 'bot', level, event)
-        send_alert(webhook_url, source='bot', level=level, event=event, message=msg,
-                   details=details, link=link, dedupe_key=dedupe_key)
-        pending_escalation_checks.append((dedupe_key, msg, link))
+        pending_escalation_checks.append((dedupe_key, msg, details, link))
     db.session.commit()
     if webhook_url:
-        for dedupe_key, msg, link in pending_escalation_checks:
+        # A batch can carry several rows sharing one dedupe_key (all committed
+        # together, same timestamp) — checking each individually would see the
+        # same final count every time and fire the same escalation once per
+        # row. Check each distinct key once; last row's context wins for the
+        # "most recent" framing in the alert.
+        by_key = {}
+        for dedupe_key, msg, details, link in pending_escalation_checks:
+            if dedupe_key:
+                by_key[dedupe_key] = (msg, details, link)
+        for dedupe_key, (msg, details, link) in by_key.items():
             count = check_escalation(dedupe_key)
             if count:
-                send_escalation_alert(webhook_url, dedupe_key, count, msg, link)
+                send_escalation_alert(webhook_url, dedupe_key, count, msg, details=details, link=link)
     # Prune to 500 most recent entries
     cutoff_query = db.session.query(AppLogEntry.id).order_by(AppLogEntry.created_at.desc()).offset(500).limit(1).scalar()
     if cutoff_query:

--- a/apps/web/app/blueprints/audit.py
+++ b/apps/web/app/blueprints/audit.py
@@ -135,6 +135,28 @@ def dismiss_error(entry_id: int):
     return jsonify({'ok': True})
 
 
+@bp.route('/errors/bulk-dismiss', methods=['POST'])
+@require_staff
+def bulk_dismiss_errors():
+    """Dismiss many error entries at once (checkbox selection on /audit/errors)."""
+    from app.db import AppLogEntry, db
+    body = request.get_json(silent=True) or {}
+    raw_ids = body.get('ids')
+    if not isinstance(raw_ids, list) or not raw_ids:
+        return jsonify({'error': 'ids must be a non-empty array'}), 400
+    try:
+        entry_ids = [int(i) for i in raw_ids]
+    except (TypeError, ValueError):
+        return jsonify({'error': 'ids must be integers'}), 400
+    updated = (
+        AppLogEntry.query
+        .filter(AppLogEntry.id.in_(entry_ids))
+        .update({'dismissed': True}, synchronize_session=False)
+    )
+    db.session.commit()
+    return jsonify({'ok': True, 'count': updated})
+
+
 @bp.route('/errors')
 @require_staff
 def errors():

--- a/apps/web/app/discord_alert.py
+++ b/apps/web/app/discord_alert.py
@@ -46,17 +46,24 @@ def dashboard_link(redirect_uri: str, source: str, level: str, event: str) -> st
     return f'{base}/audit/errors?{query}'
 
 
-def check_escalation(dedupe_key: str) -> int | None:
+def check_escalation(dedupe_key: str, new_occurrences: int = 1) -> int | None:
     """Count AppLogEntry rows sharing *dedupe_key* within ESCALATION_WINDOW_HOURS.
 
-    Returns the count if it just crossed a multiple of ESCALATION_THRESHOLD
-    (5, 10, 15, ...), else None. Call this once per newly-inserted row, after
-    it's committed, so each integer count is checked exactly once.
+    *new_occurrences* is how many of those rows this call is responsible for
+    (default 1, for the common one-row-at-a-time callers). Batched callers
+    that coalesce several new rows sharing a dedupe_key into a single check
+    (e.g. /api/bot-log) must pass the real count — otherwise a batch that
+    jumps the total past a threshold multiple without landing exactly on it
+    (prior count 4 + 2 new rows = 6) would silently miss the alert forever,
+    since 6 % 5 != 0.
+
+    Returns the current total count if adding *new_occurrences* just crossed
+    at least one multiple of ESCALATION_THRESHOLD, else None.
 
     Best-effort: returns None on any failure (e.g. the DB itself is the
     thing that's down) rather than raising into the caller's error handler.
     """
-    if not dedupe_key:
+    if not dedupe_key or new_occurrences <= 0:
         return None
     try:
         from .db import AppLogEntry
@@ -68,7 +75,8 @@ def check_escalation(dedupe_key: str) -> int | None:
     except Exception as exc:
         logger.warning('escalation_check_failed: %s', exc)
         return None
-    if count and count % ESCALATION_THRESHOLD == 0:
+    prior = max(count - new_occurrences, 0)
+    if count // ESCALATION_THRESHOLD > prior // ESCALATION_THRESHOLD:
         return count
     return None
 

--- a/apps/web/app/discord_alert.py
+++ b/apps/web/app/discord_alert.py
@@ -1,7 +1,13 @@
-"""Discord webhook alerting for persistent app errors.
+"""Discord webhook alerting for recurring app errors.
 
-Fires a push notification to a staff Discord channel when a genuine error
-is recorded in AppLogEntry (unhandled web exceptions, bot-reported errors).
+Stays quiet below ESCALATION_THRESHOLD occurrences of the same specific
+issue (same dedupe_key) within ESCALATION_WINDOW_HOURS — every warn/error
+is still persisted to AppLogEntry (visible to any staff on /audit/errors)
+so nothing is lost, but a one-off or self-correcting blip you already
+recognize doesn't alarm other staff who don't. Only once a dedupe_key
+crosses the threshold does a single Discord alert fire, and it re-fires
+every subsequent ESCALATION_THRESHOLD occurrences (10, 15, ...) so an
+ongoing pattern stays visible without paging per-occurrence.
 
 Deliberately NOT wired into the fire-and-forget Sheets sync retry path —
 those failures are covered by the nightly reconciliation job and paging
@@ -11,8 +17,6 @@ someone for something that fixes itself overnight is just noise.
 from __future__ import annotations
 
 import logging
-import threading
-import time
 from datetime import datetime, timedelta
 from urllib.parse import quote, urlparse
 
@@ -20,30 +24,10 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-# Avoid spamming the channel if the same thing errors repeatedly in a loop.
-_RATE_LIMIT_SECONDS = 15 * 60
-_last_sent: dict[str, float] = {}
-_lock = threading.Lock()
-
-# A single recurring thing (same dedupe_key) that crosses this many
-# occurrences within this window gets a distinct "may not be
-# self-correcting" escalation, on top of (not instead of) the normal
-# rate-limited per-occurrence alert.
+# A recurring thing (same dedupe_key) doesn't page anyone until it crosses
+# this many occurrences within this window.
 ESCALATION_THRESHOLD = 5
 ESCALATION_WINDOW_HOURS = 24
-
-
-def _should_send(event: str) -> bool:
-    now = time.monotonic()
-    with _lock:
-        # time.monotonic() is only guaranteed non-decreasing, not guaranteed to
-        # start far from zero — a fresh process/VM can have low uptime, so 0.0
-        # as the "never sent" default can make a brand-new event look recent.
-        last = _last_sent.get(event, float('-inf'))
-        if now - last < _RATE_LIMIT_SECONDS:
-            return False
-        _last_sent[event] = now
-        return True
 
 
 def dashboard_link(redirect_uri: str, source: str, level: str, event: str) -> str:
@@ -60,31 +44,6 @@ def dashboard_link(redirect_uri: str, source: str, level: str, event: str) -> st
     base = f'{parsed.scheme}://{parsed.netloc}'
     query = f'source={quote(source)}&level={quote(level)}&event={quote(event)}'
     return f'{base}/audit/errors?{query}'
-
-
-def send_alert(webhook_url: str, source: str, level: str, event: str, message: str,
-                details: str = '', link: str = '', dedupe_key: str = '') -> None:
-    """Best-effort Discord webhook post for a persistent app error. Never raises.
-
-    Rate-limited per *dedupe_key* (default: source:event). Callers whose event
-    name is constant across distinct failures (e.g. the web handler's
-    'unhandled_exception') should pass a more specific dedupe_key — otherwise
-    the first occurrence suppresses alerts for every later, unrelated one.
-    """
-    if not webhook_url:
-        return
-    if not _should_send(dedupe_key or f'{source}:{event}'):
-        return
-    try:
-        emoji = '\U0001f534' if level == 'error' else '\U0001f7e1'  # red / yellow circle
-        content = f'{emoji} **{source}** error — `{event}`\n{message[:800]}'
-        if details.strip():
-            content += f'\n```\n{details.strip()[:500]}\n```'
-        if link:
-            content += f'\n🔗 <{link}>'
-        requests.post(webhook_url, json={'content': content[:2000]}, timeout=5)
-    except Exception as exc:
-        logger.warning('discord_alert_failed: %s', exc)
 
 
 def check_escalation(dedupe_key: str) -> int | None:
@@ -114,21 +73,23 @@ def check_escalation(dedupe_key: str) -> int | None:
     return None
 
 
-def send_escalation_alert(webhook_url: str, dedupe_key: str, count: int, message: str, link: str = '') -> None:
+def send_escalation_alert(webhook_url: str, dedupe_key: str, count: int, message: str,
+                           details: str = '', link: str = '') -> None:
     """Best-effort Discord webhook post flagging a recurring issue. Never raises.
 
-    Deliberately bypasses the normal rate limiter — check_escalation() above
-    already only returns non-None at threshold multiples, so this can't fire
-    more often than every ESCALATION_THRESHOLD occurrences.
+    This is the only alert path — nothing posts below ESCALATION_THRESHOLD,
+    so by the time this fires it's an established pattern, not a blip.
     """
     if not webhook_url:
         return
     try:
         content = (
             f'⚠️ **Recurring issue** — `{dedupe_key}` has happened '
-            f'**{count} times** in the last {ESCALATION_WINDOW_HOURS}h and may not be self-correcting.\n'
+            f'**{count} times** in the last {ESCALATION_WINDOW_HOURS}h.\n'
             f'Most recent: {message[:500]}'
         )
+        if details.strip():
+            content += f'\n```\n{details.strip()[:500]}\n```'
         if link:
             content += f'\n🔗 <{link}>'
         requests.post(webhook_url, json={'content': content[:2000]}, timeout=5)

--- a/apps/web/app/templates/audit/errors.html
+++ b/apps/web/app/templates/audit/errors.html
@@ -95,10 +95,20 @@
 {% endif %}
 
 {% if entries %}
+<div id="bulk-dismiss-bar" class="d-none align-items-center gap-2 mb-2">
+    <span id="bulk-dismiss-count" class="text-muted small"></span>
+    <button id="bulk-dismiss-btn" class="btn btn-sm btn-outline-danger">
+        <i class="bi bi-check2-all"></i> Dismiss selected
+    </button>
+    <button id="bulk-clear-btn" class="btn btn-sm btn-outline-secondary">Clear selection</button>
+</div>
 <div class="table-responsive">
     <table class="table table-hover align-middle">
         <thead>
             <tr>
+                <th style="width: 34px;">
+                    <input type="checkbox" class="form-check-input" id="select-all-errors" title="Select all">
+                </th>
                 <th style="width: 160px;">Time (Eastern)</th>
                 <th style="width: 55px;">Src</th>
                 <th style="width: 60px;">Level</th>
@@ -110,6 +120,9 @@
         <tbody>
             {% for entry in entries %}
             <tr id="log-row-{{ entry.id }}">
+                <td>
+                    <input type="checkbox" class="form-check-input error-select" value="{{ entry.id }}">
+                </td>
                 <td class="text-muted small text-nowrap">{{ entry.timestamp | to_eastern }}</td>
                 <td><span class="badge bg-secondary">{{ entry.source }}</span></td>
                 <td>
@@ -148,8 +161,13 @@
 {% endif %}
 
 <script>
-  // Auto-refresh every 30s so new bot log entries appear without manual reload
-  setTimeout(() => location.reload(), 30000);
+  // Auto-refresh every 30s so new bot log entries appear without manual
+  // reload — but not while the user has rows checked, mid-review.
+  setTimeout(() => {
+    if (!document.querySelector('.error-select:checked')) location.reload();
+  }, 30000);
+
+  const csrfToken = () => document.querySelector('meta[name="csrf-token"]')?.content ?? '';
 
   document.addEventListener('click', function(e) {
     const btn = e.target.closest('.dismiss-btn');
@@ -157,8 +175,7 @@
     const id = btn.dataset.id;
     const url = btn.dataset.url;
     btn.disabled = true;
-    const csrf = document.querySelector('meta[name="csrf-token"]')?.content ?? '';
-    fetch(url, { method: 'POST', headers: { 'X-CSRFToken': csrf } })
+    fetch(url, { method: 'POST', headers: { 'X-CSRFToken': csrfToken() } })
       .then(r => r.json())
       .then(data => {
         if (data.ok) {
@@ -170,5 +187,69 @@
       })
       .catch(() => { btn.disabled = false; });
   });
+
+  (function () {
+    const selectAll = document.getElementById('select-all-errors');
+    const bar = document.getElementById('bulk-dismiss-bar');
+    const countEl = document.getElementById('bulk-dismiss-count');
+    const dismissBtn = document.getElementById('bulk-dismiss-btn');
+    const clearBtn = document.getElementById('bulk-clear-btn');
+    if (!selectAll || !bar) return;  // no rows on this page
+
+    function checkboxes() {
+      return Array.from(document.querySelectorAll('.error-select'));
+    }
+
+    function updateBar() {
+      const checked = checkboxes().filter((c) => c.checked);
+      if (checked.length > 0) {
+        bar.classList.remove('d-none');
+        bar.classList.add('d-flex');
+        countEl.textContent = checked.length + ' selected';
+      } else {
+        bar.classList.add('d-none');
+        bar.classList.remove('d-flex');
+      }
+      selectAll.checked = checked.length > 0 && checked.length === checkboxes().length;
+      selectAll.indeterminate = checked.length > 0 && checked.length < checkboxes().length;
+    }
+
+    selectAll.addEventListener('change', function () {
+      checkboxes().forEach((c) => { c.checked = selectAll.checked; });
+      updateBar();
+    });
+
+    document.addEventListener('change', function (e) {
+      if (e.target.classList.contains('error-select')) updateBar();
+    });
+
+    clearBtn.addEventListener('click', function () {
+      checkboxes().forEach((c) => { c.checked = false; });
+      updateBar();
+    });
+
+    dismissBtn.addEventListener('click', function () {
+      const ids = checkboxes().filter((c) => c.checked).map((c) => parseInt(c.value, 10));
+      if (ids.length === 0) return;
+      dismissBtn.disabled = true;
+      fetch('{{ url_for("audit.bulk_dismiss_errors") }}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken() },
+        body: JSON.stringify({ ids: ids }),
+      })
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.ok) {
+            ids.forEach((id) => {
+              const row = document.getElementById('log-row-' + id);
+              if (row) row.remove();
+            });
+            updateBar();
+          }
+          dismissBtn.disabled = false;
+        })
+        .catch(() => { dismissBtn.disabled = false; });
+    });
+  })();
 </script>
 {% endblock %}

--- a/apps/web/tests/test_bot_log_alert_dedupe.py
+++ b/apps/web/tests/test_bot_log_alert_dedupe.py
@@ -1,10 +1,10 @@
-"""POST /api/bot-log must not let one character's alert suppress another's.
+"""POST /api/bot-log must count occurrences per-subject, not per-event.
 
-Regression: the Discord alert rate limiter dedupes per key. Bot events that
-recur per-character (e.g. a review notifier that can't resolve a cubby
-channel) need a key that includes the subject, or the first character's
-alert silently swallows every other distinct character's alert for 15
-minutes.
+Regression: escalation counts by dedupe_key. Bot events that recur
+per-character (e.g. a review notifier that can't resolve a cubby channel)
+need a key that includes the subject, or one character's occurrences would
+count toward — and could trigger escalation on behalf of — a different,
+unrelated character hitting the same event name.
 """
 
 from unittest.mock import patch
@@ -13,7 +13,7 @@ from flask import Flask
 
 from app.blueprints.api import bp as api_bp
 from app.db import db
-from app import discord_alert
+from app.discord_alert import ESCALATION_THRESHOLD
 
 
 def _app():
@@ -32,33 +32,35 @@ def _app():
     return app
 
 
-def test_distinct_characters_both_alert_within_rate_limit_window():
+def _entry(character_name: str, i: int) -> dict:
+    return {
+        'level': 'error', 'event': 'review_notifier_channel_missing',
+        'error': 'no channel', 'characterName': character_name,
+        'eventKey': f'claim:{i}:approved:{i}',
+    }
+
+
+def test_stays_quiet_below_threshold_for_each_character():
     app = _app()
-    discord_alert._last_sent.clear()
-    payload = [
-        {'level': 'error', 'event': 'review_notifier_channel_missing',
-         'error': 'no channel', 'characterName': 'Emmet Brown', 'eventKey': 'claim:1:approved:1'},
-        {'level': 'error', 'event': 'review_notifier_channel_missing',
-         'error': 'no channel', 'characterName': 'Aliyah', 'eventKey': 'claim:2:approved:2'},
-    ]
+    payload = [_entry('Emmet Brown', i) for i in range(ESCALATION_THRESHOLD - 1)]
+    payload += [_entry('Aliyah', i) for i in range(ESCALATION_THRESHOLD - 1)]
     with app.test_client() as client, patch('app.discord_alert.requests.post') as mock_post:
         res = client.post('/api/bot-log', json=payload,
                            headers={'Authorization': 'Bearer write-token'})
     assert res.status_code == 200
-    assert mock_post.call_count == 2
+    mock_post.assert_not_called()
 
 
-def test_same_character_repeated_event_is_still_rate_limited():
+def test_one_characters_occurrences_dont_trigger_escalation_for_another():
     app = _app()
-    discord_alert._last_sent.clear()
-    payload = [
-        {'level': 'error', 'event': 'review_notifier_channel_missing',
-         'error': 'no channel', 'characterName': 'Emmet Brown', 'eventKey': 'claim:1:approved:1'},
-        {'level': 'error', 'event': 'review_notifier_channel_missing',
-         'error': 'no channel', 'characterName': 'Emmet Brown', 'eventKey': 'claim:3:approved:3'},
-    ]
+    # Emmet Brown crosses the threshold; Aliyah only has one occurrence.
+    payload = [_entry('Emmet Brown', i) for i in range(ESCALATION_THRESHOLD)]
+    payload += [_entry('Aliyah', 0)]
     with app.test_client() as client, patch('app.discord_alert.requests.post') as mock_post:
         res = client.post('/api/bot-log', json=payload,
                            headers={'Authorization': 'Bearer write-token'})
     assert res.status_code == 200
-    assert mock_post.call_count == 1
+    mock_post.assert_called_once()
+    content = mock_post.call_args.kwargs['json']['content']
+    assert 'Emmet Brown' in content  # the dedupe_key that crossed the threshold
+    assert 'Aliyah' not in content

--- a/apps/web/tests/test_bot_log_alert_dedupe.py
+++ b/apps/web/tests/test_bot_log_alert_dedupe.py
@@ -64,3 +64,42 @@ def test_one_characters_occurrences_dont_trigger_escalation_for_another():
     content = mock_post.call_args.kwargs['json']['content']
     assert 'Emmet Brown' in content  # the dedupe_key that crossed the threshold
     assert 'Aliyah' not in content
+
+
+def test_a_batch_jumping_past_the_threshold_still_fires_once():
+    """Codex P1: prior count 4 (from an earlier POST), this batch adds 2 more
+    (total 6) — the batch never lands exactly on 5, but must still alert."""
+    app = _app()
+    client = app.test_client()
+    first_batch = [_entry('Emmet Brown', i) for i in range(ESCALATION_THRESHOLD - 1)]
+    with patch('app.discord_alert.requests.post') as mock_post:
+        res = client.post('/api/bot-log', json=first_batch,
+                           headers={'Authorization': 'Bearer write-token'})
+        assert res.status_code == 200
+        mock_post.assert_not_called()
+
+        second_batch = [_entry('Emmet Brown', 10), _entry('Emmet Brown', 11)]
+        res = client.post('/api/bot-log', json=second_batch,
+                           headers={'Authorization': 'Bearer write-token'})
+        assert res.status_code == 200
+        mock_post.assert_called_once()
+        content = mock_post.call_args.kwargs['json']['content']
+        assert '6 times' in content
+
+
+def test_subjectless_events_still_escalate():
+    """Codex P2: events with no characterName/channelName (e.g.
+    wiki_sync_scheduled_failed) must not lose escalation tracking entirely."""
+    app = _app()
+    payload = [
+        {'level': 'error', 'event': 'wiki_sync_scheduled_failed',
+         'error': 'sync failed', 'eventKey': f'sync:{i}'}
+        for i in range(ESCALATION_THRESHOLD)
+    ]
+    with app.test_client() as client, patch('app.discord_alert.requests.post') as mock_post:
+        res = client.post('/api/bot-log', json=payload,
+                           headers={'Authorization': 'Bearer write-token'})
+    assert res.status_code == 200
+    mock_post.assert_called_once()
+    content = mock_post.call_args.kwargs['json']['content']
+    assert 'wiki_sync_scheduled_failed' in content

--- a/apps/web/tests/test_bulk_dismiss_errors.py
+++ b/apps/web/tests/test_bulk_dismiss_errors.py
@@ -1,0 +1,90 @@
+"""Tests for POST /audit/errors/bulk-dismiss."""
+
+from flask import Blueprint, Flask
+
+from app.blueprints.audit import bp as audit_bp
+from app.db import AppLogEntry, db
+
+# require_staff redirects unauthenticated requests to 'dashboard.login'. See
+# tests/test_sheet_import_approval.py for why a minimal stand-in is used
+# instead of the real dashboard blueprint (module-level limiter.limit()).
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test'
+    db.init_app(app)
+    app.register_blueprint(audit_bp, url_prefix='/audit')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _staff_client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+    return client
+
+
+def _seed(app, n):
+    with app.app_context():
+        ids = []
+        for i in range(n):
+            entry = AppLogEntry(ts='x', source='bot', level='error', event=f'e{i}', message='x')
+            db.session.add(entry)
+            db.session.flush()
+            ids.append(entry.id)
+        db.session.commit()
+        return ids
+
+
+def test_requires_staff():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post('/audit/errors/bulk-dismiss', json={'ids': [1]})
+    assert res.status_code == 302
+
+
+def test_dismisses_only_the_given_ids():
+    app = _app()
+    ids = _seed(app, 3)
+    client = _staff_client(app)
+    res = client.post('/audit/errors/bulk-dismiss', json={'ids': [ids[0], ids[1]]})
+    assert res.status_code == 200
+    assert res.get_json() == {'ok': True, 'count': 2}
+    with app.app_context():
+        assert db.session.get(AppLogEntry, ids[0]).dismissed is True
+        assert db.session.get(AppLogEntry, ids[1]).dismissed is True
+        assert db.session.get(AppLogEntry, ids[2]).dismissed is False
+
+
+def test_rejects_empty_ids():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/bulk-dismiss', json={'ids': []})
+    assert res.status_code == 400
+
+
+def test_rejects_missing_ids():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/bulk-dismiss', json={})
+    assert res.status_code == 400
+
+
+def test_rejects_non_integer_ids():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/bulk-dismiss', json={'ids': ['not-a-number']})
+    assert res.status_code == 400

--- a/apps/web/tests/test_discord_alert.py
+++ b/apps/web/tests/test_discord_alert.py
@@ -1,101 +1,12 @@
-"""Tests for the Discord webhook error-alert helper."""
+"""Tests for the Discord dashboard-link helper.
 
-from unittest.mock import patch
+send_alert() (immediate per-occurrence posting) was removed — alerting is
+now escalation-only (see test_discord_escalation.py). This file only
+covers what's left: dashboard_link(), still used to build the deep link
+included in escalation alerts.
+"""
 
 from app import discord_alert
-
-
-def _reset_rate_limit():
-    discord_alert._last_sent.clear()
-
-
-def test_send_alert_skips_when_no_webhook_url():
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert('', source='web', level='error', event='boom', message='x')
-    mock_post.assert_not_called()
-
-
-def test_send_alert_posts_when_configured():
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert(
-            'https://discord.com/api/webhooks/test',
-            source='web', level='error', event='unhandled_exception', message='ValueError: bad',
-        )
-    mock_post.assert_called_once()
-    _, kwargs = mock_post.call_args
-    assert 'unhandled_exception' in kwargs['json']['content']
-    assert 'ValueError: bad' in kwargs['json']['content']
-
-
-def test_send_alert_is_rate_limited_per_event():
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert('https://x', source='web', level='error', event='same', message='first')
-        discord_alert.send_alert('https://x', source='web', level='error', event='same', message='second')
-    mock_post.assert_called_once()
-
-
-def test_send_alert_dedupe_key_overrides_source_event_grouping():
-    """A constant event name (e.g. the web handler's 'unhandled_exception') must not
-    suppress alerts for a distinct failure when a more specific dedupe_key is given."""
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert(
-            'https://x', source='web', level='error', event='unhandled_exception', message='first',
-            dedupe_key='web:unhandled_exception:ValueError:/a',
-        )
-        discord_alert.send_alert(
-            'https://x', source='web', level='error', event='unhandled_exception', message='second',
-            dedupe_key='web:unhandled_exception:KeyError:/b',
-        )
-    assert mock_post.call_count == 2
-
-
-def test_send_alert_not_suppressed_on_low_process_uptime():
-    """Regression: time.monotonic() isn't guaranteed to start far from zero —
-    a freshly-booted CI VM can have low uptime. A brand-new event must not be
-    treated as 'already sent' just because now - 0.0 < the rate limit window."""
-    _reset_rate_limit()
-    with patch('app.discord_alert.time.monotonic', return_value=5.0), \
-         patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert('https://x', source='web', level='error', event='boom', message='x')
-    mock_post.assert_called_once()
-
-
-def test_send_alert_same_dedupe_key_still_rate_limited():
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert(
-            'https://x', source='web', level='error', event='unhandled_exception', message='first',
-            dedupe_key='web:unhandled_exception:ValueError:/a',
-        )
-        discord_alert.send_alert(
-            'https://x', source='web', level='error', event='unhandled_exception', message='second',
-            dedupe_key='web:unhandled_exception:ValueError:/a',
-        )
-    mock_post.assert_called_once()
-
-
-def test_send_alert_never_raises_on_request_failure():
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post', side_effect=RuntimeError('network down')):
-        discord_alert.send_alert('https://x', source='web', level='error', event='boom', message='x')
-
-
-def test_send_alert_includes_details_and_link():
-    _reset_rate_limit()
-    with patch('app.discord_alert.requests.post') as mock_post:
-        discord_alert.send_alert(
-            'https://x', source='web', level='error', event='unhandled_exception',
-            message='ValueError: bad',
-            details='/wiki/characters\nTraceback (most recent call last):\n  raise ValueError',
-            link='https://mcbn.jkomg.us/audit/errors?source=web&level=error&event=unhandled_exception',
-        )
-    content = mock_post.call_args.kwargs['json']['content']
-    assert 'Traceback' in content
-    assert 'https://mcbn.jkomg.us/audit/errors' in content
 
 
 def test_dashboard_link_builds_filtered_url_from_redirect_uri():

--- a/apps/web/tests/test_discord_escalation.py
+++ b/apps/web/tests/test_discord_escalation.py
@@ -86,6 +86,32 @@ def test_check_escalation_distinct_keys_counted_separately():
         assert discord_alert.check_escalation('bot:x:aliyah') is None
 
 
+def test_check_escalation_new_occurrences_detects_crossing_a_multiple_it_jumped_over():
+    """Codex P1: a batch of several new rows for the same key can push the
+    total past a threshold multiple without landing exactly on it (prior 4 +
+    2 new = 6). Passing the batch size must still catch that crossing."""
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD - 1)  # prior = 4
+        _seed('bot:x:emmet-brown', 2)  # +2 new rows in "one batch" -> total 6
+        assert discord_alert.check_escalation('bot:x:emmet-brown', new_occurrences=2) == 6
+
+
+def test_check_escalation_new_occurrences_no_crossing_stays_quiet():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', 1)
+        _seed('bot:x:emmet-brown', 2)  # total 3, still below threshold
+        assert discord_alert.check_escalation('bot:x:emmet-brown', new_occurrences=2) is None
+
+
+def test_check_escalation_new_occurrences_default_matches_single_row_behavior():
+    app = _app()
+    with app.app_context():
+        _seed('bot:x:emmet-brown', discord_alert.ESCALATION_THRESHOLD)
+        assert discord_alert.check_escalation('bot:x:emmet-brown') == discord_alert.ESCALATION_THRESHOLD
+
+
 def test_send_escalation_alert_posts_and_mentions_count():
     with patch('app.discord_alert.requests.post') as mock_post:
         discord_alert.send_escalation_alert('https://x', 'bot:x:emmet-brown', 5, 'no channel found')

--- a/apps/web/tests/test_discord_escalation.py
+++ b/apps/web/tests/test_discord_escalation.py
@@ -1,6 +1,8 @@
-"""Tests for occurrence-count escalation alerts (a recurring issue that
-crosses ESCALATION_THRESHOLD within ESCALATION_WINDOW_HOURS gets a distinct
-'may not be self-correcting' message, on top of the normal per-occurrence one).
+"""Tests for occurrence-count escalation alerts — the only alerting path.
+
+Nothing posts to Discord below ESCALATION_THRESHOLD occurrences of the same
+dedupe_key within ESCALATION_WINDOW_HOURS; every warn/error is still
+persisted to AppLogEntry regardless, visible on /audit/errors.
 """
 
 from datetime import datetime, timedelta
@@ -102,3 +104,15 @@ def test_send_escalation_alert_skips_when_no_webhook_url():
 def test_send_escalation_alert_never_raises_on_request_failure():
     with patch('app.discord_alert.requests.post', side_effect=RuntimeError('down')):
         discord_alert.send_escalation_alert('https://x', 'bot:x:emmet-brown', 5, 'no channel found')
+
+
+def test_send_escalation_alert_includes_details_and_link():
+    with patch('app.discord_alert.requests.post') as mock_post:
+        discord_alert.send_escalation_alert(
+            'https://x', 'web:unhandled_exception:ValueError:/wiki', 5, 'ValueError: bad',
+            details='/wiki/characters\nTraceback (most recent call last):\n  raise ValueError',
+            link='https://mcbn.jkomg.us/audit/errors?source=web',
+        )
+    content = mock_post.call_args.kwargs['json']['content']
+    assert 'Traceback' in content
+    assert 'https://mcbn.jkomg.us/audit/errors' in content


### PR DESCRIPTION
## Summary

Two follow-ups requested after the alerting shipped in #314/#318 started generating more Discord traffic than intended.

### 1. Alerting: quiet until it's actually a pattern
Previous behavior: post every occurrence (rate-limited to 1 per 15 min per specific issue) **plus** an extra escalation ping every 5th occurrence. Turns out that's not what was wanted — other staff can see the same `#botbot-channel` and don't have the context to know a given error is transient, so pinging them for everything just trains people to ignore the channel.

Removed the per-occurrence `send_alert()` path entirely (and the now-dead rate limiter it relied on — nothing calls it anymore). Every warn/error is still persisted to `AppLogEntry` regardless, visible to any staff on `/audit/errors`. Discord only hears about it once a `dedupe_key` crosses `ESCALATION_THRESHOLD` (5) within `ESCALATION_WINDOW_HOURS` (24h), and again every 5 occurrences after that.

**Found and fixed a real bug while rewiring this**: `bot_log()` checked escalation once per row in a batch. A single batch with ≥5 rows sharing a `dedupe_key` (all committed together with the same timestamp) saw the same final count on every check and fired the same escalation once per row instead of once. Caught by my own test for the new behavior. Now dedupes to one check per distinct key per batch.

### 2. Bulk-ack on `/audit/errors`
Checkboxes per row, a header select-all (with indeterminate state), and a "Dismiss selected" bar — backed by a new `POST /audit/errors/bulk-dismiss` endpoint. Auto-refresh (every 30s) now pauses while any row is checked, so an in-progress selection doesn't vanish mid-review.

## Test plan
- [x] `pytest` — 175 passed, including rewritten `test_discord_escalation.py`/`test_bot_log_alert_dedupe.py` (now covering the batch-dedup fix) and new `test_bulk_dismiss_errors.py`.
- [x] `ruff check` — clean.
- [x] Manual end-to-end verification against a throwaway local SQLite DB (**not** the production Turso DB `apps/web/.env` points at): seeded real error entries, confirmed checkboxes/select-all/CSRF render correctly, sent the exact bulk-dismiss request the JS makes, confirmed only the selected rows got dismissed and disappeared on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)