### PR TITLE
Hide retired/deceased characters from player dashboard by default

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -45,6 +45,15 @@ def my_characters():
     """Player landing page showing their linked characters."""
     discord_id = get_player_discord_id()
     my_chars = db_service.get_characters_by_discord_id(discord_id)
+    has_linked_chars = bool(my_chars)
+
+    # Retired/deceased characters are hidden by default so a player's
+    # dashboard doesn't accumulate every character they've ever played.
+    # ?show=all reveals them again — nothing is deleted either way.
+    show_retired = request.args.get('show') == 'all'
+    retired_count = sum(1 for c in my_chars if not c.active)
+    if not show_retired:
+        my_chars = [c for c in my_chars if c.active]
 
     # Fetch open periods for the banner
     all_periods = db_service.get_all_periods()
@@ -91,13 +100,15 @@ def my_characters():
             my_characters=my_chars,
             all_characters=all_characters,
             show_all=True,
+            show_retired=show_retired,
+            retired_count=retired_count,
             open_periods=open_periods,
             calendar=calendar,
             pending_drafts=pending_drafts,
             chars_with_sheet=chars_with_sheet,
         )
 
-    if not my_chars and not pending_drafts:
+    if not has_linked_chars and not pending_drafts:
         # No linked characters and no drafts — show linking flow
         return redirect(url_for('player.link_character'))
 
@@ -107,6 +118,8 @@ def my_characters():
         my_characters=my_chars,
         all_characters=None,
         show_all=False,
+        show_retired=show_retired,
+        retired_count=retired_count,
         open_periods=open_periods,
         calendar=calendar,
         pending_drafts=pending_drafts,

--- a/apps/web/app/templates/player/my_characters.html
+++ b/apps/web/app/templates/player/my_characters.html
@@ -62,10 +62,21 @@
         {% endif %}
 
         {% if my_characters %}
-        <h6 class="text-muted mb-2">Your Characters</h6>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h6 class="text-muted mb-0">Your Characters</h6>
+            {% if show_retired %}
+            <a href="{{ url_for('player.my_characters') }}" class="small text-muted text-decoration-none">
+                <i class="bi bi-eye-slash"></i> Hide retired
+            </a>
+            {% elif retired_count %}
+            <a href="{{ url_for('player.my_characters', show='all') }}" class="small text-muted text-decoration-none">
+                <i class="bi bi-eye"></i> Show {{ retired_count }} retired/deceased
+            </a>
+            {% endif %}
+        </div>
         <div class="list-group mb-4">
             {% for char in my_characters %}
-            <div class="list-group-item d-flex justify-content-between align-items-center has-clan-color clan-{{ char.clan | lower | replace(' ', '-') }}">
+            <div class="list-group-item d-flex justify-content-between align-items-center has-clan-color clan-{{ char.clan | lower | replace(' ', '-') }}{% if not char.active %} opacity-75{% endif %}">
                 <a href="{{ url_for('player.character', name=char.character_name) }}"
                    class="d-flex align-items-center gap-2 flex-grow-1 text-decoration-none">
                     {% if char.clan %}
@@ -77,6 +88,11 @@
                         <strong>{{ char.character_name }}</strong>
                         {% if char.clan %}
                         <span class="clan-badge clan-{{ char.clan | lower | replace(' ', '-') }} ms-2">{{ char.clan }}</span>
+                        {% endif %}
+                        {% if char.status == 'retired' %}
+                        <span class="badge bg-secondary ms-2">Retired</span>
+                        {% elif char.status == 'deceased' %}
+                        <span class="badge bg-dark ms-2">Deceased</span>
                         {% endif %}
                     </div>
                 </a>
@@ -96,6 +112,12 @@
         <div class="text-center mb-4">
             <a href="{{ url_for('player.link_character') }}" class="btn btn-sm btn-outline-secondary">
                 <i class="bi bi-link-45deg"></i> Link another character
+            </a>
+        </div>
+        {% elif retired_count %}
+        <div class="d-flex justify-content-end mb-2">
+            <a href="{{ url_for('player.my_characters', show='all') }}" class="small text-muted text-decoration-none">
+                <i class="bi bi-eye"></i> Show {{ retired_count }} retired/deceased
             </a>
         </div>
         {% else %}

--- a/apps/web/tests/test_player_hides_retired_characters.py
+++ b/apps/web/tests/test_player_hides_retired_characters.py
@@ -1,0 +1,113 @@
+"""Retired/deceased characters are hidden from a player's /player dashboard
+by default; ?show=all reveals them again. Nothing is ever deleted."""
+
+import os
+
+from flask import Blueprint, Flask
+from flask_wtf.csrf import CSRFProtect
+
+from app.blueprints import player as player_module
+from app.db import DbCharacter, db
+from app.db_service import DBService
+
+_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), '..', 'app', 'templates')
+_STATIC_DIR = os.path.join(os.path.dirname(__file__), '..', 'app', 'static')
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__, template_folder=_TEMPLATES_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test'
+    app.config['ALLOWED_DISCORD_IDS'] = set()
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    player_module.db_service = DBService(sheets_client=None)
+    app.register_blueprint(player_module.bp, url_prefix='/player')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _player_client(app, discord_id='111'):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['discord_id'] = discord_id
+    return client
+
+
+def _seed(app, discord_id='111'):
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='Alice Active',
+            player_discord=discord_id,
+            active=True,
+            status='active',
+        ))
+        db.session.add(DbCharacter(
+            character_name='Rusty Retired',
+            player_discord=discord_id,
+            active=False,
+            status='retired',
+        ))
+        db.session.commit()
+
+
+def test_retired_character_hidden_by_default():
+    app = _app()
+    _seed(app)
+    client = _player_client(app)
+
+    resp = client.get('/player/')
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Alice Active' in body
+    assert 'Rusty Retired' not in body
+    assert 'Show 1 retired/deceased' in body
+
+
+def test_show_all_reveals_retired_character():
+    app = _app()
+    _seed(app)
+    client = _player_client(app)
+
+    resp = client.get('/player/?show=all')
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Alice Active' in body
+    assert 'Rusty Retired' in body
+    assert 'Retired' in body  # status badge
+    assert 'Hide retired' in body
+
+
+def test_player_with_only_retired_characters_sees_reveal_link_not_link_flow():
+    app = _app()
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='Only Retired',
+            player_discord='222',
+            active=False,
+            status='retired',
+        ))
+        db.session.commit()
+    client = _player_client(app, discord_id='222')
+
+    resp = client.get('/player/')
+
+    # Must NOT redirect to the "link a character" flow — the player does
+    # have a linked character, it's just hidden by default.
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Only Retired' not in body
+    assert 'Show 1 retired/deceased' in body


### PR DESCRIPTION
## Summary

Players had no way to remove or even distinguish a retired/deceased character on `/player` — it showed up identically to an active character forever, with no status badge and no hide option.

- Retired/deceased characters are now filtered out of the "Your Characters" list by default. Nothing is deleted or touched in the DB — this is purely a display filter.
- A "Show N retired/deceased" link reveals them again (`?show=all`); a "Hide retired" link switches back. Mirrors the existing `?show=active/inactive/all` pattern `roster.py` already uses for staff — no new DB column, no migration.
- Revealed retired/deceased characters now get a status badge ("Retired"/"Deceased") — there wasn't one before at all, even when visible.
- Fixed an edge case: a player whose *only* characters are retired/deceased no longer gets incorrectly redirected to the "link a character" flow (they do have linked characters, just hidden) — they see the reveal link instead.

## Checklist

- [x] Tests added/updated where appropriate (`test_player_hides_retired_characters.py`, 3 new tests)
- [x] `./venv/bin/pytest -q` passes locally (183/183)
- [ ] Docs updated (no docs reference this behavior; UI is self-explanatory via the toggle link/badges)
- [x] No secrets/tokens included in code, logs, or screenshots

## Validation

- Steps used to verify behavior:
  1. `./venv/bin/pytest -q` — 183 passed, including the 3 new tests covering: default-hidden, `?show=all` reveal with badges, and the only-retired-characters redirect-flow edge case.
  2. Verified the Jinja template change compiles (`Environment().get_template(...)`) and that the existing `{% else %}` "no characters linked" branch is unaffected.

## Risks / Rollback

- Known risks: none — purely additive filtering + UI, no schema change, no data mutation. The one behavior change (redirect condition now checks "has any linked character" instead of "has any *visible* character") is a bug fix, not a new risk.
- Rollback plan: revert this commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_0129V5Kt7zKu5Vjsxm958Q35)_