### PR TITLE
Show role names in --full-matrix visibility report

### DIFF
--- a/apps/bot/src/__tests__/permissionRemediationReportFormat.test.ts
+++ b/apps/bot/src/__tests__/permissionRemediationReportFormat.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { formatVisibilityAudit } from '../scripts/permissionRemediation/reportFormat';
+import type { VisibilityAuditReport } from '../scripts/permissionRemediation/types';
+
+function makeReport(overrides: Partial<VisibilityAuditReport> = {}): VisibilityAuditReport {
+  return {
+    rows: [],
+    assertions: [],
+    roleNames: {},
+    ...overrides,
+  };
+}
+
+describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix', () => {
+  it('groups channels by category name, sorted alphabetically', () => {
+    const report = makeReport({
+      rows: [
+        {
+          channelId: 'c1',
+          channelName: 'a-channel',
+          parentId: 'cat-z',
+          categoryName: 'Zeta',
+          visibleRoleIds: [],
+          visibleToEveryone: true,
+        },
+        {
+          channelId: 'c2',
+          channelName: 'b-channel',
+          parentId: 'cat-a',
+          categoryName: 'Alpha',
+          visibleRoleIds: [],
+          visibleToEveryone: true,
+        },
+      ],
+    });
+
+    const lines = formatVisibilityAudit(report, { fullMatrix: true }).join('\n');
+    expect(lines.indexOf('-- Alpha --')).toBeLessThan(lines.indexOf('-- Zeta --'));
+  });
+
+  it('shows a compact tag for channels visible to @everyone with no role list', () => {
+    const report = makeReport({
+      rows: [
+        {
+          channelId: 'c1',
+          channelName: 'general',
+          parentId: null,
+          categoryName: 'Public',
+          visibleRoleIds: ['guild-1', 'role-a'],
+          visibleToEveryone: true,
+        },
+      ],
+      roleNames: { 'guild-1': '@everyone', 'role-a': 'Storyteller' },
+    });
+
+    const lines = formatVisibilityAudit(report, { fullMatrix: true });
+    expect(lines).toContain('  #general [visible to @everyone]');
+    expect(lines.some((l) => l.includes('Storyteller'))).toBe(false);
+  });
+
+  it('lists role names (sorted), not IDs, for restricted channels', () => {
+    const report = makeReport({
+      rows: [
+        {
+          channelId: 'c1',
+          channelName: 'staff-general',
+          parentId: 'cat-1',
+          categoryName: 'Staff',
+          visibleRoleIds: ['role-mod', 'role-admin'],
+          visibleToEveryone: false,
+        },
+      ],
+      roleNames: { 'role-mod': 'Moderator', 'role-admin': 'Administrator' },
+    });
+
+    const lines = formatVisibilityAudit(report, { fullMatrix: true });
+    expect(lines).toContain('  #staff-general — Administrator, Moderator');
+  });
+
+  it('flags a channel with zero visible roles', () => {
+    const report = makeReport({
+      rows: [
+        {
+          channelId: 'c1',
+          channelName: 'chapters',
+          parentId: 'cat-1',
+          categoryName: 'Archive',
+          visibleRoleIds: [],
+          visibleToEveryone: false,
+        },
+      ],
+    });
+
+    const lines = formatVisibilityAudit(report, { fullMatrix: true });
+    expect(lines).toContain('  #chapters — (no roles — nobody can see this)');
+  });
+
+  it('buckets channels with no category under "(no category)"', () => {
+    const report = makeReport({
+      rows: [
+        {
+          channelId: 'c1',
+          channelName: 'orphan-channel',
+          parentId: null,
+          categoryName: null,
+          visibleRoleIds: [],
+          visibleToEveryone: true,
+        },
+      ],
+    });
+
+    const lines = formatVisibilityAudit(report, { fullMatrix: true });
+    expect(lines).toContain('-- (no category) --');
+  });
+
+  it('omits the full matrix section when fullMatrix is not requested', () => {
+    const report = makeReport({
+      rows: [
+        {
+          channelId: 'c1',
+          channelName: 'general',
+          parentId: null,
+          categoryName: 'Public',
+          visibleRoleIds: [],
+          visibleToEveryone: true,
+        },
+      ],
+    });
+
+    const lines = formatVisibilityAudit(report).join('\n');
+    expect(lines).not.toContain('Full channel visibility matrix');
+  });
+});

--- a/apps/bot/src/scripts/permissionRemediation/reportFormat.ts
+++ b/apps/bot/src/scripts/permissionRemediation/reportFormat.ts
@@ -1,4 +1,5 @@
 import type {
+  ChannelVisibilityRow,
   CombinedApplyResult,
   CombinedAuditReport,
   MentionAuditReport,
@@ -71,9 +72,27 @@ export function formatVisibilityAudit(report: VisibilityAuditReport, { fullMatri
   }
 
   if (fullMatrix) {
-    lines.push('', `Full channel visibility matrix (${report.rows.length} channels):`);
+    lines.push('', `Full channel visibility matrix (${report.rows.length} channels), grouped by category:`);
+    const byCategory = new Map<string, ChannelVisibilityRow[]>();
     for (const row of report.rows) {
-      lines.push(`  #${row.channelName}${row.visibleToEveryone ? ' [visible to @everyone]' : ''} — ${row.visibleRoleIds.length} role(s) can view`);
+      const key = row.categoryName ?? '(no category)';
+      const list = byCategory.get(key) ?? [];
+      list.push(row);
+      byCategory.set(key, list);
+    }
+    const categoryNames = [...byCategory.keys()].sort((a, b) => a.localeCompare(b));
+    for (const categoryName of categoryNames) {
+      lines.push('', `-- ${categoryName} --`);
+      for (const row of byCategory.get(categoryName) ?? []) {
+        if (row.visibleToEveryone) {
+          lines.push(`  #${row.channelName} [visible to @everyone]`);
+          continue;
+        }
+        const names = row.visibleRoleIds
+          .map((id) => report.roleNames[id] ?? id)
+          .sort((a, b) => a.localeCompare(b));
+        lines.push(`  #${row.channelName} — ${names.length === 0 ? '(no roles — nobody can see this)' : names.join(', ')}`);
+      }
     }
   }
 

--- a/apps/bot/src/scripts/permissionRemediation/types.ts
+++ b/apps/bot/src/scripts/permissionRemediation/types.ts
@@ -134,13 +134,19 @@ export type ChannelVisibilityRow = {
   channelId: string;
   channelName: string;
   parentId: string | null;
+  categoryName: string | null;
   visibleRoleIds: string[];
   visibleToEveryone: boolean;
 };
 
 export type VisibilityAssertion = { label: string; channelId: string; ok: boolean; detail: string };
 
-export type VisibilityAuditReport = { rows: ChannelVisibilityRow[]; assertions: VisibilityAssertion[] };
+export type VisibilityAuditReport = {
+  rows: ChannelVisibilityRow[];
+  assertions: VisibilityAssertion[];
+  /** roleId -> role name, for rendering visibleRoleIds without a second lookup. */
+  roleNames: Record<string, string>;
+};
 
 export type VisibilityAuditOptions = {
   verifiedMemberRoleId?: string;

--- a/apps/bot/src/scripts/permissionRemediation/visibilityAudit.ts
+++ b/apps/bot/src/scripts/permissionRemediation/visibilityAudit.ts
@@ -98,9 +98,15 @@ export async function auditVisibility(guild: Guild, options: VisibilityAuditOpti
       channelId: channel.id,
       channelName: channel.name,
       parentId,
+      categoryName: category?.name ?? null,
       visibleRoleIds,
       visibleToEveryone: visibleRoleIds.includes(guild.id),
     });
+  }
+
+  const roleNames: Record<string, string> = {};
+  for (const role of guild.roles.cache.values()) {
+    roleNames[role.id] = role.id === guild.id ? '@everyone' : role.name;
   }
 
   const assertions: VisibilityAssertion[] = [];
@@ -132,5 +138,5 @@ export async function auditVisibility(guild: Guild, options: VisibilityAuditOpti
     }
   }
 
-  return { rows, assertions };
+  return { rows, assertions, roleNames };
 }


### PR DESCRIPTION
## Summary

Follow-up to #323's visibility precedence fix. Ran `npm run ops:permissions -- --full-matrix` against the real production server to validate the fix — it worked (staff channels correctly show their staff roles instead of "0 roles") — but surfaced that the report only shows **counts** ("5 role(s) can view"), which isn't enough to actually build a permission map. You need to know *which* roles.

- `ChannelVisibilityRow` gains `categoryName`; `VisibilityAuditReport` gains a `roleNames` (id → name) map, populated in `auditVisibility`.
- `formatVisibilityAudit`'s `--full-matrix` output now groups channels by category (alphabetical, matching how the channel list reads in Discord) and lists the actual role names for restricted channels instead of a bare count. Channels visible to `@everyone` keep the compact `[visible to @everyone]` tag rather than enumerating every role.

## Checklist

- [x] Tests added/updated where appropriate (`permissionRemediationReportFormat.test.ts`, 6 new tests covering category grouping/sorting, role-name listing, the "@everyone" compact case, the zero-roles case, and the uncategorized-channel bucket)
- [ ] `./venv/bin/pytest -q` passes locally (no Python/web changes in this PR)
- [ ] Docs updated (not applicable — internal report formatting only, no new env vars or user-facing config)
- [x] No secrets/tokens included in code, logs, or screenshots

## Validation

- Steps used to verify behavior:
  1. `npm run lint && npm run format:check && npm run typecheck && npm run build && npm run test` in `apps/bot` — all pass, 144/144 tests (up from 138).
  2. Confirmed the new report shape by running the existing test suite plus the new formatter tests against representative rows (grouped-by-category, `@everyone`-visible, restricted-with-roles, zero-roles, no-category).

## Risks / Rollback

- Known risks: none — report-only formatting change, `auditVisibility`'s return type only grew new fields, nothing consumes it in a way that would break (the wizard's embed just calls `formatCombinedAudit` unchanged).
- Rollback plan: revert this commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_0129V5Kt7zKu5Vjsxm958Q35)_