### PR TITLE
Resolve Send Messages, not just View Channel, in the visibility audit

### DIFF
--- a/apps/bot/src/__tests__/permissionRemediationReportFormat.test.ts
+++ b/apps/bot/src/__tests__/permissionRemediationReportFormat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { formatVisibilityAudit } from '../scripts/permissionRemediation/reportFormat';
-import type { VisibilityAuditReport } from '../scripts/permissionRemediation/types';
+import type { ChannelVisibilityRow, VisibilityAuditReport } from '../scripts/permissionRemediation/types';
 
 function makeReport(overrides: Partial<VisibilityAuditReport> = {}): VisibilityAuditReport {
   return {
@@ -11,26 +11,27 @@ function makeReport(overrides: Partial<VisibilityAuditReport> = {}): VisibilityA
   };
 }
 
+/** Defaults sendable = visible, matching the common case where anyone who can view can also post. */
+function makeRow(overrides: Partial<ChannelVisibilityRow> & Pick<ChannelVisibilityRow, 'channelId' | 'channelName'>): ChannelVisibilityRow {
+  const visibleRoleIds = overrides.visibleRoleIds ?? [];
+  const visibleToEveryone = overrides.visibleToEveryone ?? false;
+  return {
+    parentId: null,
+    categoryName: null,
+    visibleRoleIds,
+    visibleToEveryone,
+    sendableRoleIds: visibleRoleIds,
+    sendableToEveryone: visibleToEveryone,
+    ...overrides,
+  };
+}
+
 describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix', () => {
   it('groups channels by category name, sorted alphabetically', () => {
     const report = makeReport({
       rows: [
-        {
-          channelId: 'c1',
-          channelName: 'a-channel',
-          parentId: 'cat-z',
-          categoryName: 'Zeta',
-          visibleRoleIds: [],
-          visibleToEveryone: true,
-        },
-        {
-          channelId: 'c2',
-          channelName: 'b-channel',
-          parentId: 'cat-a',
-          categoryName: 'Alpha',
-          visibleRoleIds: [],
-          visibleToEveryone: true,
-        },
+        makeRow({ channelId: 'c1', channelName: 'a-channel', parentId: 'cat-z', categoryName: 'Zeta', visibleToEveryone: true }),
+        makeRow({ channelId: 'c2', channelName: 'b-channel', parentId: 'cat-a', categoryName: 'Alpha', visibleToEveryone: true }),
       ],
     });
 
@@ -41,14 +42,13 @@ describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix',
   it('shows a compact tag for channels visible to @everyone with no role list', () => {
     const report = makeReport({
       rows: [
-        {
+        makeRow({
           channelId: 'c1',
           channelName: 'general',
-          parentId: null,
           categoryName: 'Public',
           visibleRoleIds: ['guild-1', 'role-a'],
           visibleToEveryone: true,
-        },
+        }),
       ],
       roleNames: { 'guild-1': '@everyone', 'role-a': 'Storyteller' },
     });
@@ -61,14 +61,13 @@ describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix',
   it('lists role names (sorted), not IDs, for restricted channels', () => {
     const report = makeReport({
       rows: [
-        {
+        makeRow({
           channelId: 'c1',
           channelName: 'staff-general',
           parentId: 'cat-1',
           categoryName: 'Staff',
           visibleRoleIds: ['role-mod', 'role-admin'],
-          visibleToEveryone: false,
-        },
+        }),
       ],
       roleNames: { 'role-mod': 'Moderator', 'role-admin': 'Administrator' },
     });
@@ -79,16 +78,7 @@ describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix',
 
   it('flags a channel with zero visible roles', () => {
     const report = makeReport({
-      rows: [
-        {
-          channelId: 'c1',
-          channelName: 'chapters',
-          parentId: 'cat-1',
-          categoryName: 'Archive',
-          visibleRoleIds: [],
-          visibleToEveryone: false,
-        },
-      ],
+      rows: [makeRow({ channelId: 'c1', channelName: 'chapters', parentId: 'cat-1', categoryName: 'Archive' })],
     });
 
     const lines = formatVisibilityAudit(report, { fullMatrix: true });
@@ -97,16 +87,7 @@ describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix',
 
   it('buckets channels with no category under "(no category)"', () => {
     const report = makeReport({
-      rows: [
-        {
-          channelId: 'c1',
-          channelName: 'orphan-channel',
-          parentId: null,
-          categoryName: null,
-          visibleRoleIds: [],
-          visibleToEveryone: true,
-        },
-      ],
+      rows: [makeRow({ channelId: 'c1', channelName: 'orphan-channel', visibleToEveryone: true })],
     });
 
     const lines = formatVisibilityAudit(report, { fullMatrix: true });
@@ -115,19 +96,79 @@ describe('permissionRemediation/reportFormat formatVisibilityAudit full matrix',
 
   it('omits the full matrix section when fullMatrix is not requested', () => {
     const report = makeReport({
-      rows: [
-        {
-          channelId: 'c1',
-          channelName: 'general',
-          parentId: null,
-          categoryName: 'Public',
-          visibleRoleIds: [],
-          visibleToEveryone: true,
-        },
-      ],
+      rows: [makeRow({ channelId: 'c1', channelName: 'general', categoryName: 'Public', visibleToEveryone: true })],
     });
 
     const lines = formatVisibilityAudit(report).join('\n');
     expect(lines).not.toContain('Full channel visibility matrix');
+  });
+});
+
+describe('permissionRemediation/reportFormat formatVisibilityAudit posting gaps', () => {
+  it('flags a channel visible to @everyone but postable only by specific roles', () => {
+    const report = makeReport({
+      rows: [
+        makeRow({
+          channelId: 'c1',
+          channelName: 'announcements',
+          categoryName: 'Info',
+          visibleRoleIds: ['guild-1'],
+          visibleToEveryone: true,
+          sendableRoleIds: ['role-mod'],
+          sendableToEveryone: false,
+        }),
+      ],
+      roleNames: { 'guild-1': '@everyone', 'role-mod': 'Moderator' },
+    });
+
+    const lines = formatVisibilityAudit(report);
+    expect(lines).toContain('Posting narrower than viewing (1 channels — some roles can see but not post):');
+    expect(lines).toContain('  #announcements — can view: @everyone; can post: Moderator');
+  });
+
+  it('is shown even when fullMatrix is not requested', () => {
+    const report = makeReport({
+      rows: [
+        makeRow({
+          channelId: 'c1',
+          channelName: 'announcements',
+          visibleRoleIds: ['guild-1'],
+          visibleToEveryone: true,
+          sendableRoleIds: [],
+          sendableToEveryone: false,
+        }),
+      ],
+      roleNames: { 'guild-1': '@everyone' },
+    });
+
+    const lines = formatVisibilityAudit(report);
+    expect(lines.some((l) => l.startsWith('Posting narrower than viewing'))).toBe(true);
+    expect(lines).toContain('  #announcements — can view: @everyone; can post: (nobody)');
+  });
+
+  it('omits a channel entirely when everyone who can view can also post', () => {
+    const report = makeReport({
+      rows: [
+        makeRow({
+          channelId: 'c1',
+          channelName: 'general',
+          visibleRoleIds: ['guild-1'],
+          visibleToEveryone: true,
+        }),
+      ],
+      roleNames: { 'guild-1': '@everyone' },
+    });
+
+    const lines = formatVisibilityAudit(report);
+    expect(lines.some((l) => l.startsWith('Posting narrower than viewing'))).toBe(false);
+  });
+
+  it('omits the section header entirely when there are no gaps', () => {
+    const report = makeReport({
+      rows: [makeRow({ channelId: 'c1', channelName: 'general', visibleToEveryone: true })],
+    });
+
+    const lines = formatVisibilityAudit(report).join('\n');
+    expect(lines).not.toContain('Posting narrower than viewing');
   });
 });

--- a/apps/bot/src/__tests__/permissionRemediationVisibilityAudit.test.ts
+++ b/apps/bot/src/__tests__/permissionRemediationVisibilityAudit.test.ts
@@ -5,6 +5,7 @@ import { makeFakeCollection } from './testUtils/fakeCollection';
 
 const EVERYONE_ID = 'guild-1';
 const VIEW_CHANNEL = 1024n; // 1n << 10n
+const SEND_MESSAGES = 2048n; // 1n << 11n
 
 function makeOverwrite(id: string, type: 0 | 1, allow: bigint, deny: bigint) {
   return { id, type, allow: { bitfield: allow }, deny: { bitfield: deny } };
@@ -172,5 +173,43 @@ describe('permissionRemediation/visibilityAudit', () => {
     const row = report.rows.find((r) => r.channelId === 'chan-1');
     expect(row?.visibleToEveryone).toBe(false);
     expect(row?.visibleRoleIds).toContain('storyteller-role');
+  });
+
+  it('resolves Send Messages independently from View Channel (broadcast-channel pattern)', async () => {
+    // @everyone can view but only Moderator can post — the "read-only
+    // announcement channel" pattern found across the real server.
+    const channel = makeChannel({
+      permissionOverwrites: {
+        cache: makeFakeCollection([
+          makeOverwrite(EVERYONE_ID, 0, 0n, SEND_MESSAGES),
+          makeOverwrite('moderator-role', 0, VIEW_CHANNEL | SEND_MESSAGES, 0n),
+        ]),
+      },
+    });
+    const guild = makeGuild({ channels: [channel], roleIds: [EVERYONE_ID, 'moderator-role'] });
+
+    const report = await auditVisibility(guild as never, { modLogChannelIds: [] });
+
+    const row = report.rows[0];
+    expect(row.visibleToEveryone).toBe(true);
+    expect(row.sendableToEveryone).toBe(false);
+    expect(row.sendableRoleIds).toEqual(['moderator-role']);
+  });
+
+  it('falls back to the category-level overwrite for Send Messages, same as View Channel', async () => {
+    const category = makeChannel({
+      id: 'cat-1',
+      type: ChannelType.GuildCategory,
+      permissionOverwrites: {
+        cache: makeFakeCollection([makeOverwrite('storyteller-role', 0, SEND_MESSAGES, 0n)]),
+      },
+    });
+    const child = makeChannel({ id: 'chan-1', parentId: 'cat-1' });
+    const guild = makeGuild({ channels: [category, child], roleIds: [EVERYONE_ID, 'storyteller-role'] });
+
+    const report = await auditVisibility(guild as never, { modLogChannelIds: [] });
+
+    const row = report.rows.find((r) => r.channelId === 'chan-1');
+    expect(row?.sendableRoleIds).toContain('storyteller-role');
   });
 });

--- a/apps/bot/src/scripts/permissionRemediation/reportFormat.ts
+++ b/apps/bot/src/scripts/permissionRemediation/reportFormat.ts
@@ -71,6 +71,22 @@ export function formatVisibilityAudit(report: VisibilityAuditReport, { fullMatri
     }
   }
 
+  const postingGaps = report.rows.filter(
+    (row) => row.visibleRoleIds.filter((id) => !row.sendableRoleIds.includes(id)).length > 0,
+  );
+  if (postingGaps.length > 0) {
+    lines.push('', `Posting narrower than viewing (${postingGaps.length} channels — some roles can see but not post):`);
+    for (const row of postingGaps) {
+      const viewLabel = row.visibleToEveryone
+        ? '@everyone'
+        : row.visibleRoleIds.map((id) => report.roleNames[id] ?? id).sort((a, b) => a.localeCompare(b)).join(', ') || '(nobody)';
+      const postLabel = row.sendableToEveryone
+        ? '@everyone'
+        : row.sendableRoleIds.map((id) => report.roleNames[id] ?? id).sort((a, b) => a.localeCompare(b)).join(', ') || '(nobody)';
+      lines.push(`  #${row.channelName} — can view: ${viewLabel}; can post: ${postLabel}`);
+    }
+  }
+
   if (fullMatrix) {
     lines.push('', `Full channel visibility matrix (${report.rows.length} channels), grouped by category:`);
     const byCategory = new Map<string, ChannelVisibilityRow[]>();

--- a/apps/bot/src/scripts/permissionRemediation/types.ts
+++ b/apps/bot/src/scripts/permissionRemediation/types.ts
@@ -137,6 +137,9 @@ export type ChannelVisibilityRow = {
   categoryName: string | null;
   visibleRoleIds: string[];
   visibleToEveryone: boolean;
+  /** Roles that resolve to Send Messages true — a subset of visibleRoleIds in the common case. */
+  sendableRoleIds: string[];
+  sendableToEveryone: boolean;
 };
 
 export type VisibilityAssertion = { label: string; channelId: string; ok: boolean; detail: string };

--- a/apps/bot/src/scripts/permissionRemediation/visibilityAudit.ts
+++ b/apps/bot/src/scripts/permissionRemediation/visibilityAudit.ts
@@ -9,6 +9,7 @@ import type {
 } from './types';
 
 const VIEW_CHANNEL = 1n << 10n;
+const SEND_MESSAGES = 1n << 11n;
 
 function findRoleOverwrite(overwrites: OverwriteSnapshotEntry[], id: string): OverwriteSnapshotEntry | undefined {
   return overwrites.find((o) => o.type === 0 && o.id === id);
@@ -30,48 +31,51 @@ function effectiveOverwrite(
   return findRoleOverwrite(channelOws, entityId) ?? findRoleOverwrite(categoryOws, entityId);
 }
 
-/** Applies one overwrite's deny-then-allow on top of the running tri-state. */
-function applyOverwrite(state: boolean | null, ow: OverwriteSnapshotEntry | undefined): boolean | null {
+/** Applies one overwrite's deny-then-allow on top of the running tri-state, for a single permission bit. */
+function applyOverwrite(state: boolean | null, ow: OverwriteSnapshotEntry | undefined, bit: bigint): boolean | null {
   if (!ow) return state;
   let next = state;
-  if (BigInt(ow.deny) & VIEW_CHANNEL) next = false;
-  if (BigInt(ow.allow) & VIEW_CHANNEL) next = true;
+  if (BigInt(ow.deny) & bit) next = false;
+  if (BigInt(ow.allow) & bit) next = true;
   return next;
 }
 
 /**
- * Resolves whether someone holding only `@everyone` + one specific role can
- * view a channel. Matches Discord's real resolution order: the `@everyone`
- * overwrite sets a baseline, then the role's own overwrite is applied ON TOP
- * of it — so an explicit role-level allow correctly overrides an
- * `@everyone`-level deny (a very common "deny @everyone, allow staff roles"
- * pattern). An earlier version of this function OR'd all deny/allow bits
+ * Resolves whether someone holding only `@everyone` + one specific role has
+ * a given permission bit on a channel. Matches Discord's real resolution
+ * order: the `@everyone` overwrite sets a baseline, then the role's own
+ * overwrite is applied ON TOP of it — so an explicit role-level allow
+ * correctly overrides an `@everyone`-level deny (a very common "deny
+ * @everyone, allow staff roles" pattern). An earlier version of this
+ * function (when it only handled View Channel) OR'd all deny/allow bits
  * together and let any deny win regardless of source, which made staff-only
  * channels incorrectly report as visible to nobody.
  */
-function resolveViewChannel(
+function resolvePermission(
   roleId: string,
   everyoneId: string,
   channelOws: OverwriteSnapshotEntry[],
   categoryOws: OverwriteSnapshotEntry[],
+  bit: bigint,
 ): boolean {
   let state: boolean | null = null;
-  state = applyOverwrite(state, effectiveOverwrite(everyoneId, channelOws, categoryOws));
+  state = applyOverwrite(state, effectiveOverwrite(everyoneId, channelOws, categoryOws), bit);
   if (roleId !== everyoneId) {
-    state = applyOverwrite(state, effectiveOverwrite(roleId, channelOws, categoryOws));
+    state = applyOverwrite(state, effectiveOverwrite(roleId, channelOws, categoryOws), bit);
   }
-  // Nothing set anywhere means Discord shows the channel by default.
+  // Nothing set anywhere means Discord grants the permission by default.
   return state ?? true;
 }
 
 /**
- * Report-only: computes effective View Channel visibility per role per
- * channel, plus two concrete config-driven assertions (mod-log channels
- * hidden from @everyone; the honeypot bait channel hidden from the verified
- * member role, if configured). Never mutates anything. Does not account for
- * member-level (per-user) overwrites — a channel with 0 visible roles may
- * still be visible to a specific member via a member-type overwrite (e.g. a
- * character cubby channel), which this audit doesn't inspect.
+ * Report-only: computes effective View Channel and Send Messages resolution
+ * per role per channel, plus two concrete config-driven assertions (mod-log
+ * channels hidden from @everyone; the honeypot bait channel hidden from the
+ * verified member role, if configured). Never mutates anything. Does not
+ * account for member-level (per-user) overwrites — a channel with 0 visible
+ * roles may still be visible to a specific member via a member-type
+ * overwrite (e.g. a character cubby channel), which this audit doesn't
+ * inspect.
  */
 export async function auditVisibility(guild: Guild, options: VisibilityAuditOptions): Promise<VisibilityAuditReport> {
   const channels = await fetchAllNonThreadChannels(guild);
@@ -88,9 +92,13 @@ export async function auditVisibility(guild: Guild, options: VisibilityAuditOpti
     const categoryOws = category ? category.permissionOverwrites.cache.map(overwriteToSnapshotEntry) : [];
 
     const visibleRoleIds: string[] = [];
+    const sendableRoleIds: string[] = [];
     for (const roleId of roleIds) {
-      if (resolveViewChannel(roleId, guild.id, channelOws, categoryOws)) {
+      if (resolvePermission(roleId, guild.id, channelOws, categoryOws, VIEW_CHANNEL)) {
         visibleRoleIds.push(roleId);
+      }
+      if (resolvePermission(roleId, guild.id, channelOws, categoryOws, SEND_MESSAGES)) {
+        sendableRoleIds.push(roleId);
       }
     }
 
@@ -101,6 +109,8 @@ export async function auditVisibility(guild: Guild, options: VisibilityAuditOpti
       categoryName: category?.name ?? null,
       visibleRoleIds,
       visibleToEveryone: visibleRoleIds.includes(guild.id),
+      sendableRoleIds,
+      sendableToEveryone: sendableRoleIds.includes(guild.id),
     });
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #324's access-map work. While reviewing the real `--full-matrix` output with the server owner, several "read-only announcement channel" candidates came up (`#announcements`, `#news-feed`, `#camarilla-decrees`, etc.) where the fix under discussion is "grant MentionEveryone to the roles that should be able to post here" — but the visibility audit only ever resolved **View Channel**, so there was no way to check whether a role could actually post before deciding to grant it mass-mention rights on that channel.

- Generalized the audit's permission resolver (`resolveViewChannel` → `resolvePermission`) to take any permission bit, preserving the exact same `@everyone`-baseline-then-role-overwrite-on-top resolution order (and per-entity category fallback) already validated in #323/#324 — no change to View Channel behavior.
- `auditVisibility` now also resolves **Send Messages** per role per channel. `ChannelVisibilityRow` gains `sendableRoleIds` / `sendableToEveryone`.
- `formatVisibilityAudit` gains a new "Posting narrower than viewing" section, shown unconditionally (not gated behind `--full-matrix`, since it's pre-filtered to only channels where posting rights are a strict subset of viewing rights) — this surfaces the "read-only broadcast channel" pattern across the *whole* server, not just the handful found by hand.

## Checklist

- [x] Tests added/updated where appropriate (2 new `visibilityAudit` tests for Send Messages resolution + category fallback; `reportFormat` tests updated for the extended row shape plus 4 new tests for the posting-gap section)
- [ ] `./venv/bin/pytest -q` passes locally (no Python/web changes in this PR)
- [ ] Docs updated (not applicable — internal audit/report change, no new env vars or user-facing config)
- [x] No secrets/tokens included in code, logs, or screenshots

## Validation

- `npm run lint && npm run format:check && npm run typecheck && npm run build && npm run test` in `apps/bot` — all pass, 150/150 tests (up from 144).

## Risks / Rollback

- Known risks: none — report-only audit change, `auditVisibility`'s return type only grew new fields, nothing downstream breaks (the wizard's embed and the CLI both just format the report unchanged aside from the new section).
- Rollback plan: revert this commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129V5Kt7zKu5Vjsxm958Q35)_