### PR TITLE
Gate sendableRoleIds on view access, not just the raw Send Messages bit

### DIFF
--- a/apps/bot/src/__tests__/permissionRemediationVisibilityAudit.test.ts
+++ b/apps/bot/src/__tests__/permissionRemediationVisibilityAudit.test.ts
@@ -196,6 +196,27 @@ describe('permissionRemediation/visibilityAudit', () => {
     expect(row.sendableRoleIds).toEqual(['moderator-role']);
   });
 
+  it('never reports a role as able to post in a channel it cannot view', async () => {
+    // Regression test (flagged in review of #325): a private channel denies
+    // View Channel to @everyone and never touches Send Messages at all. Send
+    // Messages alone resolves to "allowed" (nothing denies it), but nobody
+    // without View Channel can actually post — Discord has no path to send a
+    // message in a channel you can't open. sendableRoleIds must reflect that.
+    const channel = makeChannel({
+      permissionOverwrites: {
+        cache: makeFakeCollection([makeOverwrite(EVERYONE_ID, 0, 0n, VIEW_CHANNEL)]),
+      },
+    });
+    const guild = makeGuild({ channels: [channel] });
+
+    const report = await auditVisibility(guild as never, { modLogChannelIds: [] });
+
+    const row = report.rows[0];
+    expect(row.visibleToEveryone).toBe(false);
+    expect(row.sendableToEveryone).toBe(false);
+    expect(row.sendableRoleIds).toEqual([]);
+  });
+
   it('falls back to the category-level overwrite for Send Messages, same as View Channel', async () => {
     const category = makeChannel({
       id: 'cat-1',

--- a/apps/bot/src/scripts/permissionRemediation/types.ts
+++ b/apps/bot/src/scripts/permissionRemediation/types.ts
@@ -137,7 +137,7 @@ export type ChannelVisibilityRow = {
   categoryName: string | null;
   visibleRoleIds: string[];
   visibleToEveryone: boolean;
-  /** Roles that resolve to Send Messages true — a subset of visibleRoleIds in the common case. */
+  /** Roles that can both view the channel and resolve to Send Messages true — always a subset of visibleRoleIds. */
   sendableRoleIds: string[];
   sendableToEveryone: boolean;
 };

--- a/apps/bot/src/scripts/permissionRemediation/visibilityAudit.ts
+++ b/apps/bot/src/scripts/permissionRemediation/visibilityAudit.ts
@@ -94,10 +94,16 @@ export async function auditVisibility(guild: Guild, options: VisibilityAuditOpti
     const visibleRoleIds: string[] = [];
     const sendableRoleIds: string[] = [];
     for (const roleId of roleIds) {
-      if (resolvePermission(roleId, guild.id, channelOws, categoryOws, VIEW_CHANNEL)) {
+      const canView = resolvePermission(roleId, guild.id, channelOws, categoryOws, VIEW_CHANNEL);
+      if (canView) {
         visibleRoleIds.push(roleId);
       }
-      if (resolvePermission(roleId, guild.id, channelOws, categoryOws, SEND_MESSAGES)) {
+      // Send Messages only matters if the role can also see the channel — Discord
+      // has no path to post in a channel you can't view, regardless of how the
+      // Send Messages bit itself resolves (e.g. a private channel that denies
+      // View Channel to @everyone but never touches Send Messages would otherwise
+      // report @everyone as able to post in a channel it can't even open).
+      if (canView && resolvePermission(roleId, guild.id, channelOws, categoryOws, SEND_MESSAGES)) {
         sendableRoleIds.push(roleId);
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #325, fixing a real bug flagged in review right after merge: when a private channel denies View Channel to `@everyone` and never touches Send Messages, the audit still resolved `sendableRoleIds`/`sendableToEveryone` from the Send Messages bit alone. Discord has no path to post in a channel you can't see, so the posting-gap report could claim `can post: @everyone` for a channel that's actually fully private.

- `sendableRoleIds` is now the intersection of "can view" and "Send Messages resolves true" — always a subset of `visibleRoleIds`, never a superset.
- Fixing this before it misleads anything: this is the exact report we're about to use to decide the real `#announcements`/`#news-feed`/etc. overwrite fixes, so a role that can't even see a channel showing up as "can post" there would have been a bad input to that decision.

## Checklist

- [x] Tests added/updated (1 new regression test reproducing the exact scenario: `@everyone` denied View Channel, Send Messages untouched — `sendableRoleIds` must stay empty)
- [ ] `./venv/bin/pytest -q` passes locally (no Python/web changes in this PR)
- [ ] Docs updated (not applicable — internal audit bugfix, no new env vars or user-facing config)
- [x] No secrets/tokens included in code, logs, or screenshots

## Validation

- `npm run lint && npm run format:check && npm run typecheck && npm run build && npm run test` in `apps/bot` — all pass, 151/151 tests (up from 150).

## Risks / Rollback

- Known risks: none — report-only audit change, narrows an already-new field (`sendableRoleIds`) rather than widening it, so nothing downstream that reads it can start doing something it wasn't already doing.
- Rollback plan: revert this commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129V5Kt7zKu5Vjsxm958Q35)_