### PR TITLE
Correspondence commands + dev-bot testing + per-command kill switches

### DIFF
--- a/.github/workflows/deploy-web-dev.yml
+++ b/.github/workflows/deploy-web-dev.yml
@@ -99,7 +99,7 @@ jobs:
             --update-secrets "DISCORD_CLIENT_SECRET=mcbn-dev-discord-client-secret:latest" \
             --update-secrets "ALLOWED_DISCORD_IDS=mcbn-discord-allowed-ids:latest" \
             --update-secrets "SETTINGS_ADMIN_DISCORD_IDS=mcbn-settings-admin-ids:latest" \
-            --update-secrets "WEB_APP_API_TOKEN=mcbn-web-app-api-token:latest" \
+            --update-secrets "WEB_APP_API_TOKEN=mcbn-web-app-api-token-dev:latest" \
             --update-secrets "WEB_APP_API_READ_TOKEN=mcbn-web-app-api-read-token:latest" \
             --update-secrets "WEB_APP_API_WRITE_TOKEN=mcbn-web-app-api-write-token:latest" \
             --update-secrets "DATABASE_URL=mcbn-dev-database-url:latest" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ The `docker-and-docs-hygiene` job validates all compose files and smoke-starts t
 - `docs/ENV_AND_SECRETS.md` — env and secrets flow
 - `docs/RUN_WEB_DOCKER.md` — web Docker runbook
 - `docs/RUN_BOT_DOCKER.md` — bot Docker runbook with audit log instructions
+- `docs/RUN_BOT_DEV.md` — running a second, dev-only bot against a test Discord server + dev web dashboard
 - `docs/INSTALL_LITE.md` / `docs/INSTALL_REGULAR.md` — install guides
 - `docs/RELEASE_2026-03-13_TURSO_DB_MIGRATION.md` — Turso DB migration release notes
 - `docs/RELEASE_2026-03-16_BOT_HEALTH_AND_FIXES.md` — bot health monitoring, cubby monitor fix, sidebar pin, Docker ARM64 fixes

--- a/apps/bot/.env.dev.example
+++ b/apps/bot/.env.dev.example
@@ -25,8 +25,16 @@ TEST_GUILD_ID=
 # Point at the dev web dashboard, NOT production, so nothing here touches
 # real player/character/boon data.
 WEB_APP_BASE_URL=
-WEB_APP_API_READ_TOKEN=
-WEB_APP_API_WRITE_TOKEN=
+#
+# API auth: pick any random secret (e.g. `openssl rand -hex 32`) and set the
+# SAME value here and as WEB_APP_API_TOKEN in the dev web app's own .env —
+# it's a shared secret you invent, not something issued anywhere. The legacy
+# token below grants both read and write on its own; only bother with the
+# separate WEB_APP_API_READ_TOKEN/WEB_APP_API_WRITE_TOKEN if you specifically
+# want scoped tokens (not needed for a dev setup).
+WEB_APP_API_TOKEN=
+# WEB_APP_API_READ_TOKEN=
+# WEB_APP_API_WRITE_TOKEN=
 
 # Filled in by `npm run ops:setup-test-channels` — paste its output here.
 CORRESPONDENCE_DELIVERY_CHANNEL_ID=

--- a/apps/bot/.env.dev.example
+++ b/apps/bot/.env.dev.example
@@ -1,0 +1,37 @@
+# Dev-bot environment overlay — for testing Correspondence commands (and
+# anything else) against a separate test Discord server and the dev web
+# dashboard, without touching production data.
+#
+# Setup:
+#   1. cp .env.dev.example .env.dev
+#   2. Fill in the values below.
+#   3. Run: npm run ops:setup-test-channels   (creates the 6 correspondence
+#      test channels and prints their IDs — paste into this file)
+#   4. Run: npm run dev:test-guild
+#
+# This is NOT a full .env — copy any other vars you need (staff role IDs,
+# feature flags, etc.) from .env.example. See docs/RUN_BOT_DEV.md.
+
+# The dev bot's own Discord application token (separate from production
+# Lasombra) and application/client ID.
+BOT_TOKEN=
+CLIENT_ID=
+
+# TEST_GUILD_ID makes command registration guild-scoped instead of global —
+# changes apply instantly instead of taking up to an hour to propagate.
+# This is also the guild the bot will actually run in.
+TEST_GUILD_ID=
+
+# Point at the dev web dashboard, NOT production, so nothing here touches
+# real player/character/boon data.
+WEB_APP_BASE_URL=
+WEB_APP_API_READ_TOKEN=
+WEB_APP_API_WRITE_TOKEN=
+
+# Filled in by `npm run ops:setup-test-channels` — paste its output here.
+CORRESPONDENCE_DELIVERY_CHANNEL_ID=
+CORRESPONDENCE_CONTACT_CHANNEL_ID=
+CORRESPONDENCE_PRESTATION_CHANNEL_ID=
+CORRESPONDENCE_SOCIAL_CHANNEL_ID=
+CORRESPONDENCE_COBWEB_CHANNEL_ID=
+CORRESPONDENCE_RUMOR_CHANNEL_ID=

--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -271,3 +271,16 @@ VERIFIED_MEMBER_ROLE_ID=
 # Directory for gitignored JSON snapshots written before every apply/rollback
 # run. Defaults to apps/bot/permission-snapshots/ if unset.
 PERMISSION_SNAPSHOT_DIR=
+
+# ---------------------------------------------------------------------------
+# Correspondence category — bot-mediated IC posting commands
+# ---------------------------------------------------------------------------
+# Each command posts to its configured channel regardless of where it was
+# invoked. If a channel ID is unset, that command replies with an ephemeral
+# "not configured" error instead of posting somewhere unintended.
+CORRESPONDENCE_DELIVERY_CHANNEL_ID=
+CORRESPONDENCE_CONTACT_CHANNEL_ID=
+CORRESPONDENCE_PRESTATION_CHANNEL_ID=
+CORRESPONDENCE_SOCIAL_CHANNEL_ID=
+CORRESPONDENCE_COBWEB_CHANNEL_ID=
+CORRESPONDENCE_RUMOR_CHANNEL_ID=

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -10,6 +10,8 @@
     "lint": "node scripts/lint.mjs",
     "format:check": "node scripts/format-check.mjs",
     "ops:permissions": "tsx src/scripts/permissionRemediation/cli.ts",
+    "ops:setup-test-channels": "tsx src/scripts/setupTestChannels.ts",
+    "dev:test-guild": "DOTENV_CONFIG_PATH=.env.dev tsx src/index.ts",
     "ops:check-adapter": "bash scripts/check-adapter.sh",
     "ops:deploy-local": "bash scripts/deploy-local.sh",
     "ops:docker:up": "docker compose -f docker-compose.yml up -d --build",

--- a/apps/bot/src/__tests__/adapterCorrespondence.test.ts
+++ b/apps/bot/src/__tests__/adapterCorrespondence.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebAppAdapter } from '../services/adapter';
+
+function fetchOk(body: unknown, status = 200) {
+  return vi.fn(async () => ({ ok: true, status, json: async () => body }));
+}
+
+function fetchErr(status: number, error: string) {
+  return vi.fn(async () => ({ ok: false, status, json: async () => ({ error }) }));
+}
+
+const requester = { requesterDiscordId: '111111111111111111', requesterDiscordName: 'alice' };
+
+describe('WebAppAdapter boon methods', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('createBoon posts to /api/boons and returns the boon on success', async () => {
+    const fetchMock = fetchOk({
+      ok: true,
+      boon: {
+        id: 1, creditor_character_name: 'Alice', debtor_character_name: 'Marcus',
+        tier: 'minor', reason: 'test', status: 'owed', created_at: null, resolved_at: null,
+      },
+    }, 201);
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.createBoon(requester, {
+      creditorCharacterName: 'Alice', debtorCharacterName: 'Marcus', tier: 'minor', reason: 'test',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:5001/api/boons');
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-Request-Nonce']).toBeTruthy();
+    expect(result.ok).toBe(true);
+    expect(result.boon?.id).toBe(1);
+  });
+
+  it('createBoon surfaces the API error message on failure', async () => {
+    vi.stubGlobal('fetch', fetchErr(400, 'tier must be one of trivial, minor, major, life') as unknown as typeof fetch);
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.createBoon(requester, {
+      creditorCharacterName: 'Alice', debtorCharacterName: 'Marcus', tier: 'huge' as never, reason: '',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('tier must be one of');
+  });
+
+  it('getBoonsForCharacter returns null on 404', async () => {
+    vi.stubGlobal('fetch', fetchErr(404, 'No active character found') as unknown as typeof fetch);
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.getBoonsForCharacter('999');
+    expect(result).toBeNull();
+  });
+
+  it('actOnBoonRepay posts to the repay-action endpoint', async () => {
+    const fetchMock = fetchOk({ ok: true, boon: { id: 1, status: 'repayment_offered' } });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.actOnBoonRepay(1, requester);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:5001/api/boons/1/repay-action');
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('WebAppAdapter contact-thread methods', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('createContactThread posts recipients and returns participants', async () => {
+    const fetchMock = fetchOk({
+      ok: true, thread_id: 7,
+      participants: [{ character_name: 'Alice', discord_id: '1' }, { character_name: 'Marcus', discord_id: '2' }],
+    }, 201);
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.createContactThread(requester, {
+      senderCharacterName: 'Alice', recipientCharacterNames: ['Marcus'], body: 'hi',
+    });
+
+    expect(result.threadId).toBe(7);
+    expect(result.participants).toHaveLength(2);
+  });
+
+  it('getContactThreadsForCharacter returns thread list', async () => {
+    const fetchMock = fetchOk({
+      character_name: 'Alice',
+      threads: [{ id: 7, participant_names: ['Alice', 'Marcus'], last_message_at: null, message_count: 1 }],
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.getContactThreadsForCharacter('111111111111111111');
+
+    expect(result?.threads).toHaveLength(1);
+  });
+
+  it('replyToContactThread returns the other participants to notify', async () => {
+    const fetchMock = fetchOk({
+      ok: true,
+      other_participants: [{ character_name: 'Alice', discord_id: '1' }],
+    }, 201);
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.replyToContactThread(7, requester, { senderCharacterName: 'Marcus', body: 'omw' });
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:5001/api/contact-threads/7/messages');
+    expect(result.otherParticipants).toEqual([{ character_name: 'Alice', discord_id: '1' }]);
+  });
+
+  it('reports unreachable API without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch);
+    const adapter = new WebAppAdapter('http://127.0.0.1:5001', 'token');
+    const result = await adapter.createBoon(requester, {
+      creditorCharacterName: 'Alice', debtorCharacterName: 'Marcus', tier: 'minor', reason: '',
+    });
+    expect(result).toEqual({ ok: false, message: 'Unable to reach web app API.' });
+  });
+});

--- a/apps/bot/src/__tests__/characterOwnership.test.ts
+++ b/apps/bot/src/__tests__/characterOwnership.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveOwnedCharacter } from '../services/characterOwnership';
+
+function makeAdapter(characters: Array<{ name: string; discordId: string | null }>) {
+  return { getActiveRosterWithIds: vi.fn().mockResolvedValue({ characters }) };
+}
+
+describe('resolveOwnedCharacter', () => {
+  it('auto-resolves when the user owns exactly one active character', async () => {
+    const adapter = makeAdapter([
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Marcus', discordId: 'user-2' },
+    ]);
+
+    const result = await resolveOwnedCharacter(adapter as never, 'user-1');
+    expect(result).toEqual({ ok: true, characterName: 'Alice' });
+  });
+
+  it('errors when the user owns no active character', async () => {
+    const adapter = makeAdapter([{ name: 'Marcus', discordId: 'user-2' }]);
+
+    const result = await resolveOwnedCharacter(adapter as never, 'user-1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errorMessage).toContain('No linked active character');
+  });
+
+  it('requires the character option when the user owns more than one', async () => {
+    const adapter = makeAdapter([
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Elena', discordId: 'user-1' },
+    ]);
+
+    const result = await resolveOwnedCharacter(adapter as never, 'user-1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errorMessage).toContain('multiple linked characters');
+  });
+
+  it('resolves the requested character when specified and owned (case-insensitive)', async () => {
+    const adapter = makeAdapter([
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Elena', discordId: 'user-1' },
+    ]);
+
+    const result = await resolveOwnedCharacter(adapter as never, 'user-1', 'elena');
+    expect(result).toEqual({ ok: true, characterName: 'Elena' });
+  });
+
+  it('rejects a requested character the user does not own', async () => {
+    const adapter = makeAdapter([
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Marcus', discordId: 'user-2' },
+    ]);
+
+    const result = await resolveOwnedCharacter(adapter as never, 'user-1', 'Marcus');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errorMessage).toContain('"Marcus"');
+  });
+});

--- a/apps/bot/src/__tests__/cobweb.test.ts
+++ b/apps/bot/src/__tests__/cobweb.test.ts
@@ -80,7 +80,7 @@ describe('/cobweb', () => {
     expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
     const embed = modalInteraction._channel.send.mock.calls[0][0].embeds[0];
     expect(embed.data.title).toBe('🕸️ A Whisper in the Web');
-    expect(embed.data.description).toBe('Can you hear me?');
+    expect(embed.data.description).toBe('**From:** *Cassandra*\n\n*"Can you hear me?"*');
     // Ownership resolution only ever checked clan-agnostic roster data — no
     // discipline field is referenced anywhere in this command.
     expect(adapter.getActiveRosterWithIds).toHaveBeenCalled();

--- a/apps/bot/src/__tests__/cobweb.test.ts
+++ b/apps/bot/src/__tests__/cobweb.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  correspondenceCobwebChannelId: 'cobweb-channel-1',
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import { autocomplete, execute, handleCobwebModal } from '../commands/cobweb';
+
+function makeAdapter() {
+  return {
+    getActiveRosterWithIds: vi.fn().mockResolvedValue({
+      characters: [
+        { name: 'Cassandra', discordId: 'user-1' },
+        { name: 'Marcus', discordId: 'user-2' },
+      ],
+    }),
+  };
+}
+
+function makeChatInteraction(userId = 'user-1') {
+  return {
+    user: { id: userId },
+    options: { getString: () => null },
+    reply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeModalInteraction(customId: string, message: string, userId = 'user-1') {
+  const channel = { isTextBased: () => true, send: vi.fn().mockResolvedValue(undefined) };
+  return {
+    customId,
+    user: { id: userId },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    fields: { getTextInputValue: () => message },
+    client: { channels: { fetch: vi.fn().mockResolvedValue(channel) } },
+    _channel: channel,
+  };
+}
+
+beforeEach(() => {
+  mockConfig.correspondenceCobwebChannelId = 'cobweb-channel-1';
+});
+
+describe('/cobweb', () => {
+  it('rejects when the channel is not configured', async () => {
+    mockConfig.correspondenceCobwebChannelId = '';
+    const interaction = makeChatInteraction('user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('not configured') }));
+  });
+
+  it('rejects a user with no linked active character', async () => {
+    const interaction = makeChatInteraction('user-99');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No linked active character') }));
+  });
+
+  it('opens the whisper modal for a valid sender', async () => {
+    const interaction = makeChatInteraction('user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts the whisper embed with no discipline check performed anywhere', async () => {
+    const cmdInteraction = makeChatInteraction('user-1');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction('cobweb:whisper', 'Can you hear me?', 'user-1');
+    const handled = await handleCobwebModal(modalInteraction as never);
+
+    expect(handled).toBe(true);
+    expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
+    const embed = modalInteraction._channel.send.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toBe('🕸️ A Whisper in the Web');
+    expect(embed.data.description).toBe('Can you hear me?');
+    // Ownership resolution only ever checked clan-agnostic roster data — no
+    // discipline field is referenced anywhere in this command.
+    expect(adapter.getActiveRosterWithIds).toHaveBeenCalled();
+  });
+
+  it('reports session expiry when there is no pending whisper', async () => {
+    const interaction = makeModalInteraction('cobweb:whisper', 'x', 'never-started');
+    const handled = await handleCobwebModal(interaction as never);
+    expect(handled).toBe(true);
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
+  });
+});
+
+describe('/cobweb autocomplete', () => {
+  it('suggests only the invoker\'s own characters', async () => {
+    const interaction = {
+      user: { id: 'user-1' },
+      options: { getFocused: () => ({ name: 'character', value: '' }) },
+      respond: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string }>;
+    expect(responded.map((c) => c.name)).toEqual(['Cassandra']);
+  });
+});

--- a/apps/bot/src/__tests__/commandGating.test.ts
+++ b/apps/bot/src/__tests__/commandGating.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildDisableTokens, isAnyTokenDisabled } from '../services/commandGating';
+
+describe('buildDisableTokens', () => {
+  it('returns just the command name when there is no subcommand', () => {
+    expect(buildDisableTokens('ping', null, null)).toEqual(['ping']);
+  });
+
+  it('returns the leaf + command name for a flat subcommand', () => {
+    expect(buildDisableTokens('xp', null, 'submit')).toEqual(['xp.submit', 'xp']);
+  });
+
+  it('returns the leaf + command name for a subcommand-group subcommand', () => {
+    expect(buildDisableTokens('lasombra', 'permissions', 'apply')).toEqual([
+      'lasombra.permissions.apply',
+      'lasombra',
+    ]);
+  });
+});
+
+describe('isAnyTokenDisabled', () => {
+  it('is false when nothing in the disabled set matches', () => {
+    const disabled = new Set(['cobweb']);
+    expect(isAnyTokenDisabled(buildDisableTokens('xp', null, 'submit'), disabled)).toBe(false);
+  });
+
+  it('is true when the specific leaf token is disabled', () => {
+    const disabled = new Set(['xp.submit']);
+    expect(isAnyTokenDisabled(buildDisableTokens('xp', null, 'submit'), disabled)).toBe(true);
+    expect(isAnyTokenDisabled(buildDisableTokens('xp', null, 'summary'), disabled)).toBe(false);
+  });
+
+  it('cascades: disabling the whole command disables every subcommand', () => {
+    const disabled = new Set(['xp']);
+    expect(isAnyTokenDisabled(buildDisableTokens('xp', null, 'submit'), disabled)).toBe(true);
+    expect(isAnyTokenDisabled(buildDisableTokens('xp', null, 'summary'), disabled)).toBe(true);
+    expect(isAnyTokenDisabled(buildDisableTokens('xp', null, null), disabled)).toBe(true);
+  });
+
+  it('cascades through a subcommand group when the whole command is disabled', () => {
+    const disabled = new Set(['lasombra']);
+    expect(isAnyTokenDisabled(buildDisableTokens('lasombra', 'permissions', 'apply'), disabled)).toBe(true);
+  });
+
+  it('a command with no subcommands is disabled only by its own bare token', () => {
+    const disabled = new Set(['ping']);
+    expect(isAnyTokenDisabled(buildDisableTokens('ping', null, null), disabled)).toBe(true);
+    expect(isAnyTokenDisabled(buildDisableTokens('cobweb', null, null), disabled)).toBe(false);
+  });
+});

--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -68,6 +68,7 @@ function baseBotConfig(overrides: Partial<BotConfigResponse> = {}): BotConfigRes
     mentionBreakerModLogChannelId: null,
     verifiedMemberRoleId: null,
     staffDiscordIds: null,
+    disabledCommands: null,
     ...overrides,
   };
 }

--- a/apps/bot/src/__tests__/contact.test.ts
+++ b/apps/bot/src/__tests__/contact.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  correspondenceContactChannelId: 'contact-channel-1',
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import { autocomplete, execute, handleContactSendModal, handleContactReplyModal } from '../commands/contact';
+
+function makeRoster() {
+  return {
+    characters: [
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Marcus', discordId: 'user-2' },
+      { name: 'Elena', discordId: 'user-3' },
+    ],
+  };
+}
+
+function makeAdapter(overrides: Record<string, unknown> = {}) {
+  return {
+    getActiveRosterWithIds: vi.fn().mockResolvedValue(makeRoster()),
+    createContactThread: vi.fn().mockResolvedValue({
+      ok: true,
+      threadId: 7,
+      participants: [
+        { character_name: 'Alice', discord_id: '111' },
+        { character_name: 'Marcus', discord_id: '222' },
+      ],
+    }),
+    getContactThreadsForCharacter: vi.fn().mockResolvedValue({
+      character_name: 'Alice',
+      threads: [{ id: 7, participant_names: ['Alice', 'Marcus'], last_message_at: null, message_count: 2 }],
+    }),
+    replyToContactThread: vi.fn().mockResolvedValue({
+      ok: true,
+      otherParticipants: [{ character_name: 'Alice', discord_id: '111' }],
+    }),
+    ...overrides,
+  };
+}
+
+function makeChatInteraction(sub: string, options: Record<string, string | null>, userId = 'user-1') {
+  return {
+    user: { id: userId, username: `user-${userId}` },
+    options: {
+      getSubcommand: () => sub,
+      getString: (key: string) => options[key] ?? null,
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeAutocompleteInteraction(focusedName: string, value: string, extraOptions: Record<string, string> = {}, userId = 'user-1') {
+  return {
+    user: { id: userId },
+    options: {
+      getFocused: () => ({ name: focusedName, value }),
+      getString: (key: string) => extraOptions[key] ?? null,
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  mockConfig.correspondenceContactChannelId = 'contact-channel-1';
+});
+
+describe('/contact send', () => {
+  it('rejects when the channel is not configured', async () => {
+    mockConfig.correspondenceContactChannelId = '';
+    const interaction = makeChatInteraction('send', { to: 'Marcus' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('not configured') }));
+  });
+
+  it('rejects when the only recipient resolves to the sender', async () => {
+    const interaction = makeChatInteraction('send', { to: 'Alice' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining("can't text yourself") }));
+  });
+
+  it('opens the message modal for a valid group text, deduping recipients', async () => {
+    const interaction = makeChatInteraction('send', { to: 'Marcus', also_to: 'Elena, Marcus' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('/contact reply', () => {
+  it('rejects a malformed thread value', async () => {
+    const interaction = makeChatInteraction('reply', { thread: 'not-a-number' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('autocomplete list') }));
+  });
+
+  it('opens the reply modal for a valid thread id', async () => {
+    const interaction = makeChatInteraction('reply', { thread: '7' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('/contact autocomplete', () => {
+  it('lists open threads via getContactThreadsForCharacter for "thread"', async () => {
+    const interaction = makeAutocompleteInteraction('thread', '');
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    expect(adapter.getContactThreadsForCharacter).toHaveBeenCalledWith('user-1', undefined);
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ value: string }>;
+    expect(responded).toEqual([{ name: 'Alice, Marcus — 2 messages', value: '7' }]);
+  });
+
+  it('passes an already-filled character option through to the thread lookup', async () => {
+    const interaction = makeAutocompleteInteraction('thread', '', { character: 'Elena' });
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    expect(adapter.getContactThreadsForCharacter).toHaveBeenCalledWith('user-1', 'Elena');
+  });
+});
+
+describe('/contact modal submits', () => {
+  function makeModalInteraction(customId: string, userId = 'user-1') {
+    const channel = { isTextBased: () => true, send: vi.fn().mockResolvedValue(undefined) };
+    return {
+      customId,
+      user: { id: userId, username: `user-${userId}` },
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      fields: { getTextInputValue: () => 'Meet me tonight.' },
+      client: { channels: { fetch: vi.fn().mockResolvedValue(channel) } },
+      _channel: channel,
+    };
+  }
+
+  it('send: posts an embed mentioning only the recipients, not the sender', async () => {
+    const sendInteraction = makeChatInteraction('send', { to: 'Marcus' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(sendInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction('contact:send', 'user-1');
+    const handled = await handleContactSendModal(modalInteraction as never, { adapter } as never);
+
+    expect(handled).toBe(true);
+    expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
+    const sendArgs = modalInteraction._channel.send.mock.calls[0][0];
+    expect(sendArgs.content).toBe('<@222>');
+    expect(sendArgs.embeds[0].data.title).toBe('📱 Incoming Message');
+  });
+
+  it('reply: posts an embed and confirms without needing a recipient list', async () => {
+    const replyInteraction = makeChatInteraction('reply', { thread: '7' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(replyInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction('contact:reply', 'user-1');
+    const handled = await handleContactReplyModal(modalInteraction as never, { adapter } as never);
+
+    expect(handled).toBe(true);
+    expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
+    expect(modalInteraction.editReply).toHaveBeenCalledWith('Reply sent.');
+  });
+
+  it('reply: reports session expiry when there is no pending reply', async () => {
+    const modalInteraction = makeModalInteraction('contact:reply', 'never-started');
+    const adapter = makeAdapter();
+    const handled = await handleContactReplyModal(modalInteraction as never, { adapter } as never);
+    expect(handled).toBe(true);
+    expect(modalInteraction.editReply).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
+  });
+
+  it('send: surfaces the API error message when the thread cannot be created', async () => {
+    const sendInteraction = makeChatInteraction('send', { to: 'Marcus' }, 'user-1');
+    const adapter = makeAdapter({
+      createContactThread: vi.fn().mockResolvedValue({ ok: false, message: 'No active character found named "Marcus"' }),
+    });
+    await execute(sendInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction('contact:send', 'user-1');
+    await handleContactSendModal(modalInteraction as never, { adapter } as never);
+
+    expect(modalInteraction.editReply).toHaveBeenCalledWith(expect.stringContaining('No active character found'));
+    expect(modalInteraction._channel.send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/bot/src/__tests__/contact.test.ts
+++ b/apps/bot/src/__tests__/contact.test.ts
@@ -6,7 +6,13 @@ const mockConfig = vi.hoisted(() => ({
 
 vi.mock('../config', () => ({ config: mockConfig }));
 
-import { autocomplete, execute, handleContactSendModal, handleContactReplyModal } from '../commands/contact';
+import {
+  autocomplete,
+  execute,
+  handleContactSendModal,
+  handleContactReplyModal,
+  handleContactReplyButton,
+} from '../commands/contact';
 
 function makeRoster() {
   return {
@@ -152,7 +158,7 @@ describe('/contact modal submits', () => {
     expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
     const sendArgs = modalInteraction._channel.send.mock.calls[0][0];
     expect(sendArgs.content).toBe('<@222>');
-    expect(sendArgs.embeds[0].data.title).toBe('📱 Incoming Message');
+    expect(sendArgs.embeds[0].data.title).toBe('📲 New Text Message');
   });
 
   it('reply: posts an embed and confirms without needing a recipient list', async () => {
@@ -188,5 +194,84 @@ describe('/contact modal submits', () => {
 
     expect(modalInteraction.editReply).toHaveBeenCalledWith(expect.stringContaining('No active character found'));
     expect(modalInteraction._channel.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('/contact reply button', () => {
+  function makeButtonInteraction(customId: string, userId = 'user-1') {
+    return {
+      customId,
+      user: { id: userId, username: `user-${userId}` },
+      reply: vi.fn().mockResolvedValue(undefined),
+      showModal: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('opens the reply modal directly when the user owns exactly one active character', async () => {
+    const interaction = makeButtonInteraction('contact:reply-btn:7', 'user-1');
+    const adapter = makeAdapter();
+
+    const handled = await handleContactReplyButton(interaction as never, { adapter } as never);
+
+    expect(handled).toBe(true);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('picks the right character when the user owns several but only one is in this thread', async () => {
+    const roster = {
+      characters: [
+        { name: 'Marcus', discordId: 'user-multi' },
+        { name: 'Other Guy', discordId: 'user-multi' },
+      ],
+    };
+    const adapter = makeAdapter({
+      getActiveRosterWithIds: vi.fn().mockResolvedValue(roster),
+      getContactThreadsForCharacter: vi.fn().mockImplementation((_discordId: string, characterName?: string) => {
+        if (characterName === 'Marcus') {
+          return Promise.resolve({ character_name: 'Marcus', threads: [{ id: 7, participant_names: [], last_message_at: null, message_count: 1 }] });
+        }
+        return Promise.resolve({ character_name: characterName, threads: [] });
+      }),
+    });
+
+    const interaction = makeButtonInteraction('contact:reply-btn:7', 'user-multi');
+    const handled = await handleContactReplyButton(interaction as never, { adapter } as never);
+
+    expect(handled).toBe(true);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('asks for the character option when more than one owned character is in this thread', async () => {
+    const roster = {
+      characters: [
+        { name: 'Marcus', discordId: 'user-multi' },
+        { name: 'Other Guy', discordId: 'user-multi' },
+      ],
+    };
+    const adapter = makeAdapter({
+      getActiveRosterWithIds: vi.fn().mockResolvedValue(roster),
+      getContactThreadsForCharacter: vi.fn().mockResolvedValue({
+        character_name: 'x',
+        threads: [{ id: 7, participant_names: [], last_message_at: null, message_count: 1 }],
+      }),
+    });
+
+    const interaction = makeButtonInteraction('contact:reply-btn:7', 'user-multi');
+    const handled = await handleContactReplyButton(interaction as never, { adapter } as never);
+
+    expect(handled).toBe(true);
+    expect(interaction.showModal).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('More than one of your characters') }),
+    );
+  });
+
+  it('ignores button clicks for other custom ids', async () => {
+    const interaction = makeButtonInteraction('some:other:button', 'user-1');
+    const adapter = makeAdapter();
+    const handled = await handleContactReplyButton(interaction as never, { adapter } as never);
+    expect(handled).toBe(false);
   });
 });

--- a/apps/bot/src/__tests__/delivery.test.ts
+++ b/apps/bot/src/__tests__/delivery.test.ts
@@ -146,30 +146,34 @@ describe('/deliver modal submit', () => {
 
   it('ignores modals with a different customId', async () => {
     const interaction = makeModalInteraction('some:other:modal', 'text');
-    const handled = await handleDeliveryModal(interaction as never);
+    const adapter = makeAdapter();
+    const handled = await handleDeliveryModal(interaction as never, { adapter } as never);
     expect(handled).toBe(false);
   });
 
   it('reports session expiry when there is no pending delivery', async () => {
     const interaction = makeModalInteraction('deliver:letter', 'text', 'never-started-a-delivery');
-    const handled = await handleDeliveryModal(interaction as never);
+    const adapter = makeAdapter();
+    const handled = await handleDeliveryModal(interaction as never, { adapter } as never);
     expect(handled).toBe(true);
     expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
   });
 
-  it('posts the letter embed and confirms delivery after a successful /deliver execute', async () => {
+  it('posts the letter embed, @-mentions the recipient, and confirms delivery after a successful /deliver execute', async () => {
     const cmdInteraction = makeChatInteraction({ to: 'Elena', character: null }, 'user-2');
     const adapter = makeAdapter();
     await execute(cmdInteraction as never, { adapter } as never);
 
     const modalInteraction = makeModalInteraction('deliver:letter', 'The night grows long.', 'user-2');
-    const handled = await handleDeliveryModal(modalInteraction as never);
+    const handled = await handleDeliveryModal(modalInteraction as never, { adapter } as never);
 
     expect(handled).toBe(true);
     expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
-    const sentEmbed = modalInteraction._channel.send.mock.calls[0][0].embeds[0];
-    expect(sentEmbed.data.title).toBe('📜 A Letter Arrives');
-    expect(sentEmbed.data.description).toBe('The night grows long.');
+    const sendArgs = modalInteraction._channel.send.mock.calls[0][0];
+    expect(sendArgs.content).toBe('<@user-1>');
+    const sentEmbed = sendArgs.embeds[0];
+    expect(sentEmbed.data.title).toBe('✉️ A Letter Arrives');
+    expect(sentEmbed.data.description).toBe('**To:** Elena\n**From:** Marcus\n\nThe night grows long.');
     expect(modalInteraction.editReply).toHaveBeenCalledWith(expect.stringContaining('delivered to **Elena**'));
   });
 });

--- a/apps/bot/src/__tests__/delivery.test.ts
+++ b/apps/bot/src/__tests__/delivery.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  correspondenceDeliveryChannelId: 'delivery-channel-1',
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import { autocomplete, execute, handleDeliveryModal } from '../commands/delivery';
+
+function makeRoster() {
+  return {
+    characters: [
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Marcus', discordId: 'user-2' },
+      { name: 'Elena', discordId: 'user-1' },
+    ],
+  };
+}
+
+function makeAdapter(overrides: Record<string, unknown> = {}) {
+  return {
+    getActiveRosterWithIds: vi.fn().mockResolvedValue(makeRoster()),
+    ...overrides,
+  };
+}
+
+function makeChatInteraction(options: Record<string, string | null>, userId = 'user-1') {
+  return {
+    user: { id: userId },
+    options: {
+      getString: (key: string) => options[key] ?? null,
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeAutocompleteInteraction(focusedName: string, value: string, userId = 'user-1') {
+  return {
+    user: { id: userId },
+    options: {
+      getFocused: () => ({ name: focusedName, value }),
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  mockConfig.correspondenceDeliveryChannelId = 'delivery-channel-1';
+});
+
+describe('/deliver execute', () => {
+  it('rejects when the delivery channel is not configured', async () => {
+    mockConfig.correspondenceDeliveryChannelId = '';
+    const interaction = makeChatInteraction({ to: 'Marcus', character: null });
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('not configured') }),
+    );
+    expect(interaction.showModal).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown recipient', async () => {
+    const interaction = makeChatInteraction({ to: 'Nobody', character: 'Alice' });
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Unknown character') }),
+    );
+  });
+
+  it('rejects delivering a letter to yourself', async () => {
+    const interaction = makeChatInteraction({ to: 'Alice', character: 'Alice' }, 'user-1');
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining("can't deliver a letter to yourself") }),
+    );
+  });
+
+  it('requires disambiguation when the sender has multiple characters and none is specified', async () => {
+    const interaction = makeChatInteraction({ to: 'Marcus', character: null }, 'user-1');
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('multiple linked characters') }),
+    );
+  });
+
+  it('opens the letter modal for a valid single-character sender and recipient', async () => {
+    const interaction = makeChatInteraction({ to: 'Elena', character: null }, 'user-2');
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+});
+
+describe('/deliver autocomplete', () => {
+  it('suggests all active characters for "to"', async () => {
+    const interaction = makeAutocompleteInteraction('to', 'e');
+    const adapter = makeAdapter();
+
+    await autocomplete(interaction as never, { adapter } as never);
+
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string }>;
+    expect(responded.map((c) => c.name).sort()).toEqual(['Alice', 'Elena']);
+  });
+
+  it('suggests only the invoker\'s own characters for "character"', async () => {
+    const interaction = makeAutocompleteInteraction('character', '', 'user-1');
+    const adapter = makeAdapter();
+
+    await autocomplete(interaction as never, { adapter } as never);
+
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string }>;
+    expect(responded.map((c) => c.name).sort()).toEqual(['Alice', 'Elena']);
+  });
+});
+
+describe('/deliver modal submit', () => {
+  function makeModalInteraction(customId: string, letterText: string, userId = 'user-2') {
+    const channel = { isTextBased: () => true, send: vi.fn().mockResolvedValue(undefined) };
+    return {
+      customId,
+      user: { id: userId },
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      fields: { getTextInputValue: () => letterText },
+      client: { channels: { fetch: vi.fn().mockResolvedValue(channel) } },
+      _channel: channel,
+    };
+  }
+
+  it('ignores modals with a different customId', async () => {
+    const interaction = makeModalInteraction('some:other:modal', 'text');
+    const handled = await handleDeliveryModal(interaction as never);
+    expect(handled).toBe(false);
+  });
+
+  it('reports session expiry when there is no pending delivery', async () => {
+    const interaction = makeModalInteraction('deliver:letter', 'text', 'never-started-a-delivery');
+    const handled = await handleDeliveryModal(interaction as never);
+    expect(handled).toBe(true);
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
+  });
+
+  it('posts the letter embed and confirms delivery after a successful /deliver execute', async () => {
+    const cmdInteraction = makeChatInteraction({ to: 'Elena', character: null }, 'user-2');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction('deliver:letter', 'The night grows long.', 'user-2');
+    const handled = await handleDeliveryModal(modalInteraction as never);
+
+    expect(handled).toBe(true);
+    expect(modalInteraction._channel.send).toHaveBeenCalledTimes(1);
+    const sentEmbed = modalInteraction._channel.send.mock.calls[0][0].embeds[0];
+    expect(sentEmbed.data.title).toBe('📜 A Letter Arrives');
+    expect(sentEmbed.data.description).toBe('The night grows long.');
+    expect(modalInteraction.editReply).toHaveBeenCalledWith(expect.stringContaining('delivered to **Elena**'));
+  });
+});

--- a/apps/bot/src/__tests__/post.test.ts
+++ b/apps/bot/src/__tests__/post.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  correspondenceSocialChannelId: 'social-channel-1',
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import { autocomplete, execute, handlePostModal } from '../commands/post';
+
+function makeAdapter() {
+  return {
+    getActiveRosterWithIds: vi.fn().mockResolvedValue({
+      characters: [
+        { name: 'Alice', discordId: 'user-1' },
+        { name: 'Elena', discordId: 'user-1' },
+        { name: 'Marcus', discordId: 'user-2' },
+      ],
+    }),
+  };
+}
+
+function makeChatInteraction(options: Record<string, string | null>, userId = 'user-2') {
+  return {
+    user: { id: userId },
+    options: { getString: (key: string) => options[key] ?? null },
+    reply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeModalInteraction(customId: string, handle: string, content: string, userId = 'user-2') {
+  const channel = { isTextBased: () => true, send: vi.fn().mockResolvedValue(undefined) };
+  return {
+    customId,
+    user: { id: userId },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    fields: { getTextInputValue: (key: string) => (key === 'handle' ? handle : content) },
+    client: { channels: { fetch: vi.fn().mockResolvedValue(channel) } },
+    _channel: channel,
+  };
+}
+
+beforeEach(() => {
+  mockConfig.correspondenceSocialChannelId = 'social-channel-1';
+});
+
+describe('/post', () => {
+  it('rejects when the channel is not configured', async () => {
+    mockConfig.correspondenceSocialChannelId = '';
+    const interaction = makeChatInteraction({}, 'user-2');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('not configured') }));
+  });
+
+  it('opens the post modal for a single-character sender', async () => {
+    const interaction = makeChatInteraction({}, 'user-2');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the typed handle when provided, else the character name', async () => {
+    const cmdInteraction = makeChatInteraction({}, 'user-2');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const withHandle = makeModalInteraction('post:social', 'MidnightMarcus', 'Feeling thirsty tonight.', 'user-2');
+    await handlePostModal(withHandle as never);
+    expect(withHandle._channel.send).toHaveBeenCalledTimes(1);
+    expect(withHandle._channel.send.mock.calls[0][0].embeds[0].data.title).toBe('📱 @MidnightMarcus');
+
+    await execute(cmdInteraction as never, { adapter } as never);
+    const withoutHandle = makeModalInteraction('post:social', '', 'Feeling thirsty tonight.', 'user-2');
+    await handlePostModal(withoutHandle as never);
+    expect(withoutHandle._channel.send.mock.calls[0][0].embeds[0].data.title).toBe('📱 @Marcus');
+  });
+
+  it('reports session expiry when there is no pending post', async () => {
+    const interaction = makeModalInteraction('post:social', '', 'x', 'never-started');
+    const handled = await handlePostModal(interaction as never);
+    expect(handled).toBe(true);
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
+  });
+});
+
+describe('/post autocomplete', () => {
+  it('suggests only the invoker\'s own characters', async () => {
+    const interaction = {
+      user: { id: 'user-1' },
+      options: { getFocused: () => ({ name: 'character', value: '' }) },
+      respond: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string }>;
+    expect(responded.map((c) => c.name).sort()).toEqual(['Alice', 'Elena']);
+  });
+});

--- a/apps/bot/src/__tests__/prestation.test.ts
+++ b/apps/bot/src/__tests__/prestation.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  correspondencePrestationChannelId: 'prestation-channel-1',
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import { autocomplete, execute } from '../commands/prestation';
+
+function makeRoster() {
+  return {
+    characters: [
+      { name: 'Alice', discordId: 'user-1' },
+      { name: 'Marcus', discordId: 'user-2' },
+    ],
+  };
+}
+
+function makeAdapter(overrides: Record<string, unknown> = {}) {
+  return {
+    getActiveRosterWithIds: vi.fn().mockResolvedValue(makeRoster()),
+    createBoon: vi.fn().mockResolvedValue({
+      ok: true,
+      boon: { id: 5, creditor_character_name: 'Alice', debtor_character_name: 'Marcus', tier: 'minor', reason: 'test', status: 'owed' },
+    }),
+    getBoonsForCharacter: vi.fn().mockResolvedValue({
+      character_name: 'Alice',
+      boons: [
+        { id: 5, direction: 'owed_to_me', counterparty_name: 'Marcus', tier: 'minor', reason: 'test', status: 'owed' },
+        { id: 6, direction: 'i_owe', counterparty_name: 'Marcus', tier: 'major', reason: '', status: 'repayment_offered' },
+      ],
+    }),
+    actOnBoonRepay: vi.fn().mockResolvedValue({
+      ok: true,
+      boon: { id: 5, creditor_character_name: 'Alice', debtor_character_name: 'Marcus', tier: 'minor', status: 'repayment_offered' },
+    }),
+    ...overrides,
+  };
+}
+
+function makeChannel() {
+  return { isTextBased: () => true, send: vi.fn().mockResolvedValue(undefined) };
+}
+
+function makeChatInteraction(sub: string, options: Record<string, string | null>, userId = 'user-1') {
+  const channel = makeChannel();
+  return {
+    user: { id: userId, username: `user-${userId}` },
+    options: {
+      getSubcommand: () => sub,
+      getString: (key: string) => options[key] ?? null,
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    client: { channels: { fetch: vi.fn().mockResolvedValue(channel) } },
+    _channel: channel,
+  };
+}
+
+function makeAutocompleteInteraction(focusedName: string, value: string, extraOptions: Record<string, string> = {}, userId = 'user-1') {
+  return {
+    user: { id: userId },
+    options: {
+      getFocused: () => ({ name: focusedName, value }),
+      getString: (key: string) => extraOptions[key] ?? null,
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  mockConfig.correspondencePrestationChannelId = 'prestation-channel-1';
+});
+
+describe('/prestation owe', () => {
+  it('rejects when the channel is not configured', async () => {
+    mockConfig.correspondencePrestationChannelId = '';
+    const interaction = makeChatInteraction('owe', { debtor: 'Marcus', tier: 'minor', reason: 'x' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('not configured') }));
+  });
+
+  it('rejects a self-owed boon', async () => {
+    const interaction = makeChatInteraction('owe', { debtor: 'Alice', tier: 'minor', reason: 'x' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining("can't owe a boon to themself") }));
+  });
+
+  it('creates the boon and posts a public embed', async () => {
+    const interaction = makeChatInteraction('owe', { debtor: 'Marcus', tier: 'minor', reason: 'Covered a shift' }, 'user-1');
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(adapter.createBoon).toHaveBeenCalledWith(
+      { requesterDiscordId: 'user-1', requesterDiscordName: 'user-user-1' },
+      { creditorCharacterName: 'Alice', debtorCharacterName: 'Marcus', tier: 'minor', reason: 'Covered a shift' },
+    );
+    expect(interaction._channel.send).toHaveBeenCalledTimes(1);
+    const embed = interaction._channel.send.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toBe('🩸 Boon Owed');
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Boon #5 recorded'));
+  });
+
+  it('surfaces the API error message when creation fails', async () => {
+    const interaction = makeChatInteraction('owe', { debtor: 'Marcus', tier: 'minor', reason: 'x' }, 'user-1');
+    const adapter = makeAdapter({ createBoon: vi.fn().mockResolvedValue({ ok: false, message: 'A character cannot owe a boon to themself' }) });
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Could not record the boon'));
+    expect(interaction._channel.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('/prestation status', () => {
+  it('shows both directions in one ephemeral embed', async () => {
+    const interaction = makeChatInteraction('status', {}, 'user-1');
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+    const fields = embed.data.fields as Array<{ name: string; value: string }>;
+    expect(fields.find((f) => f.name === 'Owed to you')?.value).toContain('#5');
+    expect(fields.find((f) => f.name === 'You owe')?.value).toContain('#6');
+  });
+});
+
+describe('/prestation repay', () => {
+  it('rejects a malformed boon id', async () => {
+    const interaction = makeChatInteraction('repay', { boon_id: 'nope' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('autocomplete list') }));
+  });
+
+  it('posts the propose-repayment summary when status is repayment_offered', async () => {
+    const interaction = makeChatInteraction('repay', { boon_id: '5' }, 'user-2');
+    const adapter = makeAdapter();
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction._channel.send).toHaveBeenCalledWith({
+      content: '🔸 Repayment of Boon #5 proposed by Marcus — awaiting confirmation from Alice.',
+    });
+  });
+
+  it('posts the repaid summary when status is repaid', async () => {
+    const interaction = makeChatInteraction('repay', { boon_id: '5' }, 'user-1');
+    const adapter = makeAdapter({
+      actOnBoonRepay: vi.fn().mockResolvedValue({
+        ok: true,
+        boon: { id: 5, creditor_character_name: 'Alice', debtor_character_name: 'Marcus', status: 'repaid' },
+      }),
+    });
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction._channel.send).toHaveBeenCalledWith({
+      content: '✅ Boon #5 repaid — Alice ↔ Marcus.',
+    });
+  });
+
+  it('surfaces a 409-style rejection message without posting to the channel', async () => {
+    const interaction = makeChatInteraction('repay', { boon_id: '5' }, 'user-1');
+    const adapter = makeAdapter({
+      actOnBoonRepay: vi.fn().mockResolvedValue({ ok: false, message: 'Only the debtor can propose repayment of an owed boon' }),
+    });
+
+    await execute(interaction as never, { adapter } as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Only the debtor can propose'));
+    expect(interaction._channel.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('/prestation autocomplete', () => {
+  it('lists open boons for boon_id with a human-readable label', async () => {
+    const interaction = makeAutocompleteInteraction('boon_id', '');
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string; value: string }>;
+    expect(responded).toEqual([
+      { name: '#5 — Minor owed by Marcus (owed)', value: '5' },
+      { name: '#6 — Major owed to Marcus (repayment_offered)', value: '6' },
+    ]);
+  });
+
+  it('suggests active roster characters for "debtor"', async () => {
+    const interaction = makeAutocompleteInteraction('debtor', 'm');
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string }>;
+    expect(responded.map((c) => c.name)).toEqual(['Marcus']);
+  });
+});

--- a/apps/bot/src/__tests__/prestation.test.ts
+++ b/apps/bot/src/__tests__/prestation.test.ts
@@ -101,8 +101,9 @@ describe('/prestation owe', () => {
       { creditorCharacterName: 'Alice', debtorCharacterName: 'Marcus', tier: 'minor', reason: 'Covered a shift' },
     );
     expect(interaction._channel.send).toHaveBeenCalledTimes(1);
-    const embed = interaction._channel.send.mock.calls[0][0].embeds[0];
-    expect(embed.data.title).toBe('🩸 Boon Owed');
+    const sendArgs = interaction._channel.send.mock.calls[0][0];
+    expect(sendArgs.content).toBe('<@user-2>');
+    expect(sendArgs.embeds[0].data.title).toBe('🩸 Boon Owed');
     expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Boon #5 recorded'));
   });
 

--- a/apps/bot/src/__tests__/rumor.test.ts
+++ b/apps/bot/src/__tests__/rumor.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  correspondenceRumorChannelId: 'rumor-channel-1',
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import { autocomplete, execute, handleRumorModal } from '../commands/rumor';
+
+function makeAdapter() {
+  return {
+    getActiveRosterWithIds: vi.fn().mockResolvedValue({
+      characters: [
+        { name: 'Alice', discordId: '111111111111111111' },
+        { name: 'Marcus', discordId: null },
+      ],
+    }),
+  };
+}
+
+function makeChatInteraction(options: Record<string, string | null>, userId = 'user-1') {
+  return {
+    user: { id: userId },
+    options: { getString: (key: string) => options[key] ?? null },
+    reply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeModalInteraction(fields: Record<string, string>, userId = 'user-1') {
+  const channel = { isTextBased: () => true, send: vi.fn().mockResolvedValue(undefined) };
+  return {
+    customId: 'rumor:submit',
+    user: { id: userId },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    fields: { getTextInputValue: (key: string) => fields[key] ?? '' },
+    client: { channels: { fetch: vi.fn().mockResolvedValue(channel) } },
+    _channel: channel,
+  };
+}
+
+beforeEach(() => {
+  mockConfig.correspondenceRumorChannelId = 'rumor-channel-1';
+});
+
+describe('/rumor', () => {
+  it('rejects when the channel is not configured', async () => {
+    mockConfig.correspondenceRumorChannelId = '';
+    const interaction = makeChatInteraction({ discovery: 'Streets' });
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('not configured') }));
+  });
+
+  it('rejects an unknown source-character', async () => {
+    const interaction = makeChatInteraction({ discovery: 'Streets', 'source-character': 'Nobody' });
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Unknown character') }));
+  });
+
+  it('opens the modal when discovery alone is provided', async () => {
+    const interaction = makeChatInteraction({ discovery: 'Streets' });
+    const adapter = makeAdapter();
+    await execute(interaction as never, { adapter } as never);
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports session expiry when there is no pending rumor', async () => {
+    const interaction = makeModalInteraction({ rumor_text: 'x', roll: 'x' }, 'never-started');
+    const handled = await handleRumorModal(interaction as never);
+    expect(handled).toBe(true);
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('Session expired'));
+  });
+
+  it('reproduces the exact template byte-for-byte, with Location omitted when blank', async () => {
+    const cmdInteraction = makeChatInteraction({ discovery: 'Kindred' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction(
+      {
+        rumor_text: 'The Prince is dead.',
+        location: '',
+        point_of_contact: 'DC 6',
+        roll: 'Resolve + Investigation DC 6',
+      },
+      'user-1',
+    );
+    const handled = await handleRumorModal(modalInteraction as never);
+
+    expect(handled).toBe(true);
+    const posted = modalInteraction._channel.send.mock.calls[0][0].content as string;
+    expect(posted).toBe(
+      [
+        '**Rumor**: ||The Prince is dead.||',
+        '**Point of Discovery**: Kindred',
+        '**Point of Contact**: DC 6',
+        '**Roll**: Resolve + Investigation DC 6',
+        '',
+        'If you want to maintain a rumor, let us know during downtime and we will not delete it!',
+      ].join('\n'),
+    );
+    expect(modalInteraction.editReply).toHaveBeenCalledWith('Rumor posted.');
+  });
+
+  it('includes the Location line when provided', async () => {
+    const cmdInteraction = makeChatInteraction({ discovery: 'Underworld' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction(
+      { rumor_text: 'Something stirs beneath the city.', location: 'The Sewers', point_of_contact: 'DC 4', roll: 'Wits + Streetwise DC 4' },
+      'user-1',
+    );
+    await handleRumorModal(modalInteraction as never);
+
+    const posted = modalInteraction._channel.send.mock.calls[0][0].content as string;
+    expect(posted).toContain('**Location (Optional)**: The Sewers\n');
+    expect(posted.split('\n').indexOf('**Location (Optional)**: The Sewers')).toBe(2);
+  });
+
+  it('uses a real mention for Point of Contact when a source-character with a linked Discord account is set and the field is left blank', async () => {
+    const cmdInteraction = makeChatInteraction({ discovery: 'High Society', 'source-character': 'Alice' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction(
+      { rumor_text: 'Alice was seen near the docks.', point_of_contact: '', roll: 'Manipulation + Subterfuge DC 5' },
+      'user-1',
+    );
+    await handleRumorModal(modalInteraction as never);
+
+    const posted = modalInteraction._channel.send.mock.calls[0][0].content as string;
+    expect(posted).toContain('**Point of Contact**: <@111111111111111111>');
+  });
+
+  it('prefers typed Point of Contact text over the source-character mention when both are given', async () => {
+    const cmdInteraction = makeChatInteraction({ discovery: 'Streets', 'source-character': 'Alice' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction(
+      { rumor_text: 'x', point_of_contact: 'DC 8 instead', roll: 'y' },
+      'user-1',
+    );
+    await handleRumorModal(modalInteraction as never);
+
+    const posted = modalInteraction._channel.send.mock.calls[0][0].content as string;
+    expect(posted).toContain('**Point of Contact**: DC 8 instead');
+  });
+
+  it('spoiler-wraps only the rumor text, not the other fields', async () => {
+    const cmdInteraction = makeChatInteraction({ discovery: 'Streets' }, 'user-1');
+    const adapter = makeAdapter();
+    await execute(cmdInteraction as never, { adapter } as never);
+
+    const modalInteraction = makeModalInteraction(
+      { rumor_text: 'secret info', location: 'no spoiler here', point_of_contact: 'no spoiler here either', roll: 'no spoiler on roll' },
+      'user-1',
+    );
+    await handleRumorModal(modalInteraction as never);
+
+    const posted = modalInteraction._channel.send.mock.calls[0][0].content as string;
+    expect(posted).toContain('||secret info||');
+    expect(posted).not.toContain('||no spoiler');
+  });
+});
+
+describe('/rumor autocomplete', () => {
+  it('suggests all active characters for source-character', async () => {
+    const interaction = {
+      user: { id: 'user-1' },
+      options: { getFocused: () => ({ name: 'source-character', value: '' }) },
+      respond: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter = makeAdapter();
+    await autocomplete(interaction as never, { adapter } as never);
+    const responded = interaction.respond.mock.calls[0][0] as Array<{ name: string }>;
+    expect(responded.map((c) => c.name)).toEqual(['Alice', 'Marcus']);
+  });
+});

--- a/apps/bot/src/commands/cobweb.ts
+++ b/apps/bot/src/commands/cobweb.ts
@@ -1,0 +1,136 @@
+/**
+ * /cobweb — Malkavian Cobweb discipline telepathic message to
+ * #reach-out-and-touch-mind. Trust-based: no mechanical discipline check
+ * (the bot has no discipline data — only clan is exposed to it today).
+ * Broadcast, not 1:1 — no target option.
+ */
+import {
+  ActionRowBuilder,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  SlashCommandBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { config } from '../config';
+import { errorToMessage } from '../logger';
+import { resolveOwnedCharacter } from '../services/characterOwnership';
+
+const _COBWEB_PURPLE = 0x4b0082;
+const MODAL_ID = 'cobweb:whisper';
+
+const pendingWhispers = new Map<string, string>();
+
+export const name = 'cobweb';
+
+export const data = new SlashCommandBuilder()
+  .setName('cobweb')
+  .setDescription('Send a telepathic Cobweb message to #reach-out-and-touch-mind.')
+  .addStringOption((o) =>
+    o
+      .setName('character')
+      .setDescription('Your character (only needed if you have multiple)')
+      .setRequired(false)
+      .setAutocomplete(true),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'character') {
+    await interaction.respond([]);
+    return;
+  }
+  const query = focused.value.toLowerCase();
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const choices = roster.characters
+      .filter((c) => c.discordId === interaction.user.id)
+      .map((c) => c.name)
+      .filter((n) => query === '' || n.toLowerCase().includes(query))
+      .slice(0, 25)
+      .map((n) => ({ name: n, value: n }));
+    await interaction.respond(choices);
+  } catch {
+    await interaction.respond([]);
+  }
+}
+
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondenceCobwebChannelId) {
+    await interaction.reply({
+      content: 'The Cobweb channel is not configured yet — ask a staff member to set `CORRESPONDENCE_COBWEB_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  pendingWhispers.set(interaction.user.id, ownership.characterName);
+
+  const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('Reach Out and Touch Mind');
+  const messageInput = new TextInputBuilder()
+    .setCustomId('message')
+    .setLabel('Telepathic message')
+    .setStyle(TextInputStyle.Paragraph)
+    .setPlaceholder('What do they hear?')
+    .setMaxLength(1500)
+    .setRequired(true);
+  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
+  await interaction.showModal(modal);
+}
+
+export async function handleCobwebModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+  if (interaction.customId !== MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const senderCharacterName = pendingWhispers.get(interaction.user.id);
+  pendingWhispers.delete(interaction.user.id);
+  if (!senderCharacterName) {
+    await interaction.editReply('Session expired — run `/cobweb` again.');
+    return true;
+  }
+
+  const message = interaction.fields.getTextInputValue('message').trim();
+
+  let channel: TextChannel;
+  try {
+    const fetched = await interaction.client.channels.fetch(config.correspondenceCobwebChannelId);
+    if (!fetched || !fetched.isTextBased() || !('send' in fetched)) {
+      await interaction.editReply('Could not find the Cobweb channel. Ask staff to check the configured channel ID.');
+      return true;
+    }
+    channel = fetched as TextChannel;
+  } catch (err) {
+    await interaction.editReply(`Could not reach the Cobweb channel: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle('🕸️ A Whisper in the Web')
+    .setColor(_COBWEB_PURPLE)
+    .addFields({ name: 'From', value: senderCharacterName, inline: true })
+    .setDescription(message)
+    .setFooter({ text: 'Received only by those attuned — trust-based, no mechanical verification.' });
+
+  try {
+    await channel.send({ embeds: [embed] });
+  } catch (err) {
+    await interaction.editReply(`Could not send: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  await interaction.editReply('Sent.');
+  return true;
+}

--- a/apps/bot/src/commands/cobweb.ts
+++ b/apps/bot/src/commands/cobweb.ts
@@ -7,6 +7,8 @@
 import {
   ActionRowBuilder,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
   EmbedBuilder,
   ModalBuilder,
@@ -14,6 +16,7 @@ import {
   SlashCommandBuilder,
   TextInputBuilder,
   TextInputStyle,
+  type ButtonInteraction,
   type TextChannel,
 } from 'discord.js';
 import type { CommandContext } from '../discord';
@@ -23,6 +26,7 @@ import { resolveOwnedCharacter } from '../services/characterOwnership';
 
 const _COBWEB_PURPLE = 0x4b0082;
 const MODAL_ID = 'cobweb:whisper';
+const REPLY_BUTTON_ID = 'cobweb:reply-btn';
 
 const pendingWhispers = new Map<string, string>();
 
@@ -77,7 +81,10 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
   }
 
   pendingWhispers.set(interaction.user.id, ownership.characterName);
+  await interaction.showModal(buildWhisperModal());
+}
 
+function buildWhisperModal(): ModalBuilder {
   const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('Reach Out and Touch Mind');
   const messageInput = new TextInputBuilder()
     .setCustomId('message')
@@ -87,7 +94,29 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
     .setMaxLength(1500)
     .setRequired(true);
   modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
-  await interaction.showModal(modal);
+  return modal;
+}
+
+/**
+ * Handles the 🕸️ Whisper Back button attached to posted whispers. Cobweb is
+ * broadcast, not 1:1 — there's no specific reply target, so this just jumps
+ * straight to a fresh whisper instead of requiring `/cobweb` again.
+ */
+export async function handleCobwebReplyButton(interaction: ButtonInteraction, ctx: CommandContext): Promise<boolean> {
+  if (interaction.customId !== REPLY_BUTTON_ID) return false;
+
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id);
+  if (!ownership.ok) {
+    await interaction.reply({
+      content: `${ownership.errorMessage} Or use \`/cobweb\` and pass the \`character\` option directly.`,
+      ephemeral: true,
+    });
+    return true;
+  }
+
+  pendingWhispers.set(interaction.user.id, ownership.characterName);
+  await interaction.showModal(buildWhisperModal());
+  return true;
 }
 
 export async function handleCobwebModal(interaction: ModalSubmitInteraction): Promise<boolean> {
@@ -120,12 +149,19 @@ export async function handleCobwebModal(interaction: ModalSubmitInteraction): Pr
   const embed = new EmbedBuilder()
     .setTitle('🕸️ A Whisper in the Web')
     .setColor(_COBWEB_PURPLE)
-    .addFields({ name: 'From', value: senderCharacterName, inline: true })
-    .setDescription(message)
-    .setFooter({ text: 'Received only by those attuned — trust-based, no mechanical verification.' });
+    .setDescription(`**From:** *${senderCharacterName}*\n\n*"${message}"*`)
+    .setFooter({ text: '🧠 Heard only by those attuned — trust-based, no mechanical verification.' })
+    .setTimestamp();
+
+  const replyButton = new ButtonBuilder()
+    .setCustomId(REPLY_BUTTON_ID)
+    .setLabel('Whisper Back')
+    .setEmoji('🕸️')
+    .setStyle(ButtonStyle.Secondary);
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(replyButton);
 
   try {
-    await channel.send({ embeds: [embed] });
+    await channel.send({ embeds: [embed], components: [row] });
   } catch (err) {
     await interaction.editReply(`Could not send: ${errorToMessage(err)}`);
     return true;

--- a/apps/bot/src/commands/contact.ts
+++ b/apps/bot/src/commands/contact.ts
@@ -7,6 +7,8 @@
 import {
   ActionRowBuilder,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
   EmbedBuilder,
   ModalBuilder,
@@ -14,6 +16,7 @@ import {
   SlashCommandBuilder,
   TextInputBuilder,
   TextInputStyle,
+  type ButtonInteraction,
   type TextChannel,
 } from 'discord.js';
 import type { CommandContext } from '../discord';
@@ -25,6 +28,7 @@ import type { ContactParticipant } from '../services/adapter';
 const _BLUE = 0x4a90d9;
 const SEND_MODAL_ID = 'contact:send';
 const REPLY_MODAL_ID = 'contact:reply';
+const REPLY_BUTTON_PREFIX = 'contact:reply-btn:';
 
 type PendingSend = { senderCharacterName: string; recipientNames: string[] };
 type PendingReply = { senderCharacterName: string; threadId: number };
@@ -216,7 +220,10 @@ async function handleReply(interaction: ChatInputCommandInteraction, ctx: Comman
   }
 
   pendingReplies.set(interaction.user.id, { senderCharacterName: ownership.characterName, threadId });
+  await interaction.showModal(buildReplyModal());
+}
 
+function buildReplyModal(): ModalBuilder {
   const modal = new ModalBuilder().setCustomId(REPLY_MODAL_ID).setTitle('Reply');
   const messageInput = new TextInputBuilder()
     .setCustomId('message')
@@ -226,26 +233,111 @@ async function handleReply(interaction: ChatInputCommandInteraction, ctx: Comman
     .setMaxLength(1500)
     .setRequired(true);
   modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
-  await interaction.showModal(modal);
+  return modal;
 }
 
-function buildContactEmbed(title: string, from: string, body: string, mentions: ContactParticipant[]): {
+/**
+ * Resolves which of a Discord user's owned characters is actually a
+ * participant in the given thread — unlike resolveOwnedCharacter, this
+ * disambiguates using thread membership, not just "do you own exactly one
+ * active character." A player with several characters should still get an
+ * instant reply as long as only one of them is in this specific conversation.
+ */
+async function resolveThreadParticipantCharacter(
+  ctx: CommandContext,
+  discordUserId: string,
+  threadId: number,
+): Promise<{ ok: true; characterName: string } | { ok: false; errorMessage: string }> {
+  const roster = await ctx.adapter.getActiveRosterWithIds();
+  const owned = roster.characters.filter((c) => c.discordId === discordUserId);
+
+  if (owned.length === 0) {
+    return { ok: false, errorMessage: 'No linked active character found. Use the web player page to link one first.' };
+  }
+  if (owned.length === 1) {
+    return { ok: true, characterName: owned[0].name };
+  }
+
+  const matches: string[] = [];
+  for (const character of owned) {
+    const result = await ctx.adapter.getContactThreadsForCharacter(discordUserId, character.name).catch(() => null);
+    if (result?.threads.some((t) => t.id === threadId)) {
+      matches.push(character.name);
+    }
+  }
+
+  if (matches.length === 1) {
+    return { ok: true, characterName: matches[0] };
+  }
+  if (matches.length === 0) {
+    return { ok: false, errorMessage: 'None of your linked characters are part of this conversation.' };
+  }
+  return {
+    ok: false,
+    errorMessage: 'More than one of your characters is in this conversation. Please provide the `character` option.',
+  };
+}
+
+/** Handles the 📲 Reply button attached to posted messages — jumps straight to the reply modal. */
+export async function handleContactReplyButton(interaction: ButtonInteraction, ctx: CommandContext): Promise<boolean> {
+  if (!interaction.customId.startsWith(REPLY_BUTTON_PREFIX)) return false;
+
+  const threadId = Number(interaction.customId.slice(REPLY_BUTTON_PREFIX.length));
+  if (!Number.isInteger(threadId) || threadId <= 0) {
+    await interaction.reply({ content: 'This conversation link looks broken — use `/contact reply` instead.', ephemeral: true });
+    return true;
+  }
+
+  const ownership = await resolveThreadParticipantCharacter(ctx, interaction.user.id, threadId);
+  if (!ownership.ok) {
+    await interaction.reply({
+      content: `${ownership.errorMessage} Or use \`/contact reply\` and pass the \`character\` option directly.`,
+      ephemeral: true,
+    });
+    return true;
+  }
+
+  pendingReplies.set(interaction.user.id, { senderCharacterName: ownership.characterName, threadId });
+  await interaction.showModal(buildReplyModal());
+  return true;
+}
+
+function buildContactEmbed(
+  title: string,
+  from: string,
+  to: string[],
+  body: string,
+  mentions: ContactParticipant[],
+  threadId: number,
+): {
   embed: EmbedBuilder;
   content: string;
+  components: ActionRowBuilder<ButtonBuilder>[];
 } {
+  const quoted = body
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+
   const embed = new EmbedBuilder()
     .setTitle(title)
     .setColor(_BLUE)
-    .addFields({ name: 'From', value: from, inline: true })
-    .setDescription(body)
-    .setFooter({ text: 'Sent via text — in character.' });
+    .setDescription(`**To:** ${to.join(', ')}\n**From:** ${from}\n\n${quoted}`)
+    .setFooter({ text: '🔒 Encrypted line — in character.' })
+    .setTimestamp();
 
   const mentionText = mentions
     .filter((p) => p.discord_id)
     .map((p) => `<@${p.discord_id}>`)
     .join(' ');
 
-  return { embed, content: mentionText };
+  const replyButton = new ButtonBuilder()
+    .setCustomId(`${REPLY_BUTTON_PREFIX}${threadId}`)
+    .setLabel('Reply')
+    .setEmoji('📲')
+    .setStyle(ButtonStyle.Primary);
+
+  return { embed, content: mentionText, components: [new ActionRowBuilder<ButtonBuilder>().addComponents(replyButton)] };
 }
 
 async function fetchContactChannel(interaction: ModalSubmitInteraction): Promise<TextChannel | null> {
@@ -275,7 +367,7 @@ export async function handleContactSendModal(
     { requesterDiscordId: interaction.user.id, requesterDiscordName: interaction.user.username },
     { senderCharacterName: pending.senderCharacterName, recipientCharacterNames: pending.recipientNames, body: message },
   );
-  if (!result.ok || !result.participants) {
+  if (!result.ok || !result.participants || !result.threadId) {
     await interaction.editReply(`Could not send: ${result.message}`);
     return true;
   }
@@ -289,10 +381,17 @@ export async function handleContactSendModal(
   const otherParticipants = result.participants.filter(
     (p) => p.character_name.toLowerCase() !== pending.senderCharacterName.toLowerCase(),
   );
-  const { embed, content } = buildContactEmbed('📱 Incoming Message', pending.senderCharacterName, message, otherParticipants);
+  const { embed, content, components } = buildContactEmbed(
+    '📲 New Text Message',
+    pending.senderCharacterName,
+    otherParticipants.map((p) => p.character_name),
+    message,
+    otherParticipants,
+    result.threadId,
+  );
 
   try {
-    await channel.send({ content: content || undefined, embeds: [embed] });
+    await channel.send({ content: content || undefined, embeds: [embed], components });
   } catch (err) {
     await interaction.editReply(`Could not post the message: ${errorToMessage(err)}`);
     return true;
@@ -335,10 +434,17 @@ export async function handleContactReplyModal(
     return true;
   }
 
-  const { embed, content } = buildContactEmbed('📱 Reply', pending.senderCharacterName, message, result.otherParticipants);
+  const { embed, content, components } = buildContactEmbed(
+    '📲 Reply',
+    pending.senderCharacterName,
+    result.otherParticipants.map((p) => p.character_name),
+    message,
+    result.otherParticipants,
+    pending.threadId,
+  );
 
   try {
-    await channel.send({ content: content || undefined, embeds: [embed] });
+    await channel.send({ content: content || undefined, embeds: [embed], components });
   } catch (err) {
     await interaction.editReply(`Could not post the reply: ${errorToMessage(err)}`);
     return true;

--- a/apps/bot/src/commands/contact.ts
+++ b/apps/bot/src/commands/contact.ts
@@ -1,0 +1,349 @@
+/**
+ * /contact — text messages between characters, posted to #kindred-contact.
+ * Thread-tracked (unlike /deliver): `send` starts a conversation with one or
+ * more recipients, `reply` continues an existing one and notifies every
+ * other participant.
+ */
+import {
+  ActionRowBuilder,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  SlashCommandBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { config } from '../config';
+import { errorToMessage } from '../logger';
+import { resolveOwnedCharacter } from '../services/characterOwnership';
+import type { ContactParticipant } from '../services/adapter';
+
+const _BLUE = 0x4a90d9;
+const SEND_MODAL_ID = 'contact:send';
+const REPLY_MODAL_ID = 'contact:reply';
+
+type PendingSend = { senderCharacterName: string; recipientNames: string[] };
+type PendingReply = { senderCharacterName: string; threadId: number };
+const pendingSends = new Map<string, PendingSend>();
+const pendingReplies = new Map<string, PendingReply>();
+
+export const name = 'contact';
+
+export const data = new SlashCommandBuilder()
+  .setName('contact')
+  .setDescription('Text message another character (or several) through #kindred-contact.')
+  .addSubcommand((s) =>
+    s
+      .setName('send')
+      .setDescription('Start a new conversation.')
+      .addStringOption((o) =>
+        o.setName('to').setDescription('Recipient character').setRequired(true).setAutocomplete(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('also_to')
+          .setDescription('Additional recipients for a group text, comma-separated')
+          .setRequired(false),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Your character (only needed if you have multiple)')
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('reply')
+      .setDescription('Reply to an existing conversation.')
+      .addStringOption((o) =>
+        o.setName('thread').setDescription('Which conversation').setRequired(true).setAutocomplete(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Your character (fill this first if you have multiple, to filter the list)')
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const query = focused.value.toLowerCase();
+
+  if (focused.name === 'to') {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      const choices = roster.characters
+        .map((c) => c.name)
+        .filter((n) => query === '' || n.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((n) => ({ name: n, value: n }));
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  if (focused.name === 'character') {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      const choices = roster.characters
+        .filter((c) => c.discordId === interaction.user.id)
+        .map((c) => c.name)
+        .filter((n) => query === '' || n.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((n) => ({ name: n, value: n }));
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  if (focused.name === 'thread') {
+    const requestedCharacter = interaction.options.getString('character') ?? undefined;
+    try {
+      const result = await ctx.adapter.getContactThreadsForCharacter(interaction.user.id, requestedCharacter);
+      if (!result) {
+        await interaction.respond([]);
+        return;
+      }
+      const choices = result.threads
+        .map((t) => ({
+          name: `${t.participant_names.join(', ')} — ${t.message_count} message${t.message_count === 1 ? '' : 's'}`.slice(0, 100),
+          value: String(t.id),
+        }))
+        .slice(0, 25);
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  await interaction.respond([]);
+}
+
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub === 'send') {
+    await handleSend(interaction, ctx);
+  } else if (sub === 'reply') {
+    await handleReply(interaction, ctx);
+  }
+}
+
+async function handleSend(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondenceContactChannelId) {
+    await interaction.reply({
+      content: 'The contact channel is not configured yet — ask a staff member to set `CORRESPONDENCE_CONTACT_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  const to = interaction.options.getString('to', true).trim();
+  const alsoTo = interaction.options.getString('also_to') ?? '';
+  const extraNames = alsoTo
+    .split(/[,\n]+/)
+    .map((n) => n.trim())
+    .filter(Boolean);
+
+  const seen = new Set<string>([ownership.characterName.toLowerCase()]);
+  const recipientNames: string[] = [];
+  for (const candidate of [to, ...extraNames]) {
+    const key = candidate.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    recipientNames.push(candidate);
+  }
+
+  if (recipientNames.length === 0) {
+    await interaction.reply({ content: "You can't text yourself — add at least one other recipient.", ephemeral: true });
+    return;
+  }
+
+  pendingSends.set(interaction.user.id, { senderCharacterName: ownership.characterName, recipientNames });
+
+  const modal = new ModalBuilder().setCustomId(SEND_MODAL_ID).setTitle('New Message');
+  const messageInput = new TextInputBuilder()
+    .setCustomId('message')
+    .setLabel('Message')
+    .setStyle(TextInputStyle.Paragraph)
+    .setPlaceholder('Type your text...')
+    .setMaxLength(1500)
+    .setRequired(true);
+  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
+  await interaction.showModal(modal);
+}
+
+async function handleReply(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondenceContactChannelId) {
+    await interaction.reply({
+      content: 'The contact channel is not configured yet — ask a staff member to set `CORRESPONDENCE_CONTACT_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  const threadRaw = interaction.options.getString('thread', true).trim();
+  const threadId = Number(threadRaw);
+  if (!Number.isInteger(threadId) || threadId <= 0) {
+    await interaction.reply({ content: 'Pick a conversation from the autocomplete list.', ephemeral: true });
+    return;
+  }
+
+  pendingReplies.set(interaction.user.id, { senderCharacterName: ownership.characterName, threadId });
+
+  const modal = new ModalBuilder().setCustomId(REPLY_MODAL_ID).setTitle('Reply');
+  const messageInput = new TextInputBuilder()
+    .setCustomId('message')
+    .setLabel('Message')
+    .setStyle(TextInputStyle.Paragraph)
+    .setPlaceholder('Type your reply...')
+    .setMaxLength(1500)
+    .setRequired(true);
+  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
+  await interaction.showModal(modal);
+}
+
+function buildContactEmbed(title: string, from: string, body: string, mentions: ContactParticipant[]): {
+  embed: EmbedBuilder;
+  content: string;
+} {
+  const embed = new EmbedBuilder()
+    .setTitle(title)
+    .setColor(_BLUE)
+    .addFields({ name: 'From', value: from, inline: true })
+    .setDescription(body)
+    .setFooter({ text: 'Sent via text — in character.' });
+
+  const mentionText = mentions
+    .filter((p) => p.discord_id)
+    .map((p) => `<@${p.discord_id}>`)
+    .join(' ');
+
+  return { embed, content: mentionText };
+}
+
+async function fetchContactChannel(interaction: ModalSubmitInteraction): Promise<TextChannel | null> {
+  const fetched = await interaction.client.channels.fetch(config.correspondenceContactChannelId).catch(() => null);
+  if (!fetched || !fetched.isTextBased() || !('send' in fetched)) return null;
+  return fetched as TextChannel;
+}
+
+export async function handleContactSendModal(
+  interaction: ModalSubmitInteraction,
+  ctx: CommandContext,
+): Promise<boolean> {
+  if (interaction.customId !== SEND_MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const pending = pendingSends.get(interaction.user.id);
+  pendingSends.delete(interaction.user.id);
+  if (!pending) {
+    await interaction.editReply('Session expired — run `/contact send` again.');
+    return true;
+  }
+
+  const message = interaction.fields.getTextInputValue('message').trim();
+
+  const result = await ctx.adapter.createContactThread(
+    { requesterDiscordId: interaction.user.id, requesterDiscordName: interaction.user.username },
+    { senderCharacterName: pending.senderCharacterName, recipientCharacterNames: pending.recipientNames, body: message },
+  );
+  if (!result.ok || !result.participants) {
+    await interaction.editReply(`Could not send: ${result.message}`);
+    return true;
+  }
+
+  const channel = await fetchContactChannel(interaction);
+  if (!channel) {
+    await interaction.editReply('Could not find the contact channel. Ask staff to check the configured channel ID.');
+    return true;
+  }
+
+  const otherParticipants = result.participants.filter(
+    (p) => p.character_name.toLowerCase() !== pending.senderCharacterName.toLowerCase(),
+  );
+  const { embed, content } = buildContactEmbed('📱 Incoming Message', pending.senderCharacterName, message, otherParticipants);
+
+  try {
+    await channel.send({ content: content || undefined, embeds: [embed] });
+  } catch (err) {
+    await interaction.editReply(`Could not post the message: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  await interaction.editReply(`Message sent to **${pending.recipientNames.join(', ')}**.`);
+  return true;
+}
+
+export async function handleContactReplyModal(
+  interaction: ModalSubmitInteraction,
+  ctx: CommandContext,
+): Promise<boolean> {
+  if (interaction.customId !== REPLY_MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const pending = pendingReplies.get(interaction.user.id);
+  pendingReplies.delete(interaction.user.id);
+  if (!pending) {
+    await interaction.editReply('Session expired — run `/contact reply` again.');
+    return true;
+  }
+
+  const message = interaction.fields.getTextInputValue('message').trim();
+
+  const result = await ctx.adapter.replyToContactThread(
+    pending.threadId,
+    { requesterDiscordId: interaction.user.id, requesterDiscordName: interaction.user.username },
+    { senderCharacterName: pending.senderCharacterName, body: message },
+  );
+  if (!result.ok || !result.otherParticipants) {
+    await interaction.editReply(`Could not send reply: ${result.message}`);
+    return true;
+  }
+
+  const channel = await fetchContactChannel(interaction);
+  if (!channel) {
+    await interaction.editReply('Could not find the contact channel. Ask staff to check the configured channel ID.');
+    return true;
+  }
+
+  const { embed, content } = buildContactEmbed('📱 Reply', pending.senderCharacterName, message, result.otherParticipants);
+
+  try {
+    await channel.send({ content: content || undefined, embeds: [embed] });
+  } catch (err) {
+    await interaction.editReply(`Could not post the reply: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  await interaction.editReply('Reply sent.');
+  return true;
+}

--- a/apps/bot/src/commands/delivery.ts
+++ b/apps/bot/src/commands/delivery.ts
@@ -5,6 +5,8 @@
 import {
   ActionRowBuilder,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
   EmbedBuilder,
   ModalBuilder,
@@ -12,6 +14,7 @@ import {
   SlashCommandBuilder,
   TextInputBuilder,
   TextInputStyle,
+  type ButtonInteraction,
   type TextChannel,
 } from 'discord.js';
 import type { CommandContext } from '../discord';
@@ -21,6 +24,7 @@ import { resolveOwnedCharacter } from '../services/characterOwnership';
 
 const _GOLD = 0xc8a85b;
 const MODAL_ID = 'deliver:letter';
+const REPLY_BUTTON_PREFIX = 'deliver:reply-btn:';
 
 type PendingDelivery = { senderCharacterName: string; to: string };
 const pendingDeliveries = new Map<string, PendingDelivery>();
@@ -95,7 +99,10 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
   }
 
   pendingDeliveries.set(interaction.user.id, { senderCharacterName: ownership.characterName, to });
+  await interaction.showModal(buildDeliveryModal());
+}
 
+function buildDeliveryModal(): ModalBuilder {
   const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('Deliver a Letter');
   const letterInput = new TextInputBuilder()
     .setCustomId('letter_text')
@@ -105,10 +112,35 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
     .setMaxLength(3900)
     .setRequired(true);
   modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(letterInput));
-  await interaction.showModal(modal);
+  return modal;
 }
 
-export async function handleDeliveryModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+/** Handles the ✉️ Reply button attached to posted letters — replies to the original sender directly. */
+export async function handleDeliveryReplyButton(interaction: ButtonInteraction, ctx: CommandContext): Promise<boolean> {
+  if (!interaction.customId.startsWith(REPLY_BUTTON_PREFIX)) return false;
+
+  const to = decodeURIComponent(interaction.customId.slice(REPLY_BUTTON_PREFIX.length));
+
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id);
+  if (!ownership.ok) {
+    await interaction.reply({
+      content: `${ownership.errorMessage} Or use \`/deliver\` and pass the \`character\` option directly.`,
+      ephemeral: true,
+    });
+    return true;
+  }
+
+  if (to.toLowerCase() === ownership.characterName.toLowerCase()) {
+    await interaction.reply({ content: "You can't deliver a letter to yourself.", ephemeral: true });
+    return true;
+  }
+
+  pendingDeliveries.set(interaction.user.id, { senderCharacterName: ownership.characterName, to });
+  await interaction.showModal(buildDeliveryModal());
+  return true;
+}
+
+export async function handleDeliveryModal(interaction: ModalSubmitInteraction, ctx: CommandContext): Promise<boolean> {
   if (interaction.customId !== MODAL_ID) return false;
 
   await interaction.deferReply({ ephemeral: true });
@@ -136,17 +168,33 @@ export async function handleDeliveryModal(interaction: ModalSubmitInteraction): 
   }
 
   const embed = new EmbedBuilder()
-    .setTitle('📜 A Letter Arrives')
+    .setTitle('✉️ A Letter Arrives')
     .setColor(_GOLD)
-    .addFields(
-      { name: 'From', value: pending.senderCharacterName, inline: true },
-      { name: 'To', value: pending.to, inline: true },
-    )
-    .setDescription(letterText)
-    .setFooter({ text: 'Hand-delivered — in character.' });
+    .setDescription(`**To:** ${pending.to}\n**From:** ${pending.senderCharacterName}\n\n${letterText}`)
+    .setFooter({ text: '🕯️ Hand-delivered, sealed in wax — in character.' })
+    .setTimestamp();
+
+  const replyButton = new ButtonBuilder()
+    .setCustomId(`${REPLY_BUTTON_PREFIX}${encodeURIComponent(pending.senderCharacterName)}`)
+    .setLabel('Reply')
+    .setEmoji('✉️')
+    .setStyle(ButtonStyle.Secondary);
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(replyButton);
+
+  let recipientMention = '';
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const recipientName = pending.to.toLowerCase();
+    const recipientCharacter = roster.characters.find((c) => c.name.toLowerCase() === recipientName);
+    if (recipientCharacter?.discordId) {
+      recipientMention = `<@${recipientCharacter.discordId}>`;
+    }
+  } catch {
+    recipientMention = '';
+  }
 
   try {
-    await channel.send({ embeds: [embed] });
+    await channel.send({ content: recipientMention || undefined, embeds: [embed], components: [row] });
   } catch (err) {
     await interaction.editReply(`Could not post the letter: ${errorToMessage(err)}`);
     return true;

--- a/apps/bot/src/commands/delivery.ts
+++ b/apps/bot/src/commands/delivery.ts
@@ -1,0 +1,157 @@
+/**
+ * /deliver — post a hand-delivered, in-character letter to #kindred-delivery.
+ * One-shot: no reply/threading (unlike /contact).
+ */
+import {
+  ActionRowBuilder,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  SlashCommandBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { config } from '../config';
+import { errorToMessage } from '../logger';
+import { resolveOwnedCharacter } from '../services/characterOwnership';
+
+const _GOLD = 0xc8a85b;
+const MODAL_ID = 'deliver:letter';
+
+type PendingDelivery = { senderCharacterName: string; to: string };
+const pendingDeliveries = new Map<string, PendingDelivery>();
+
+export const name = 'deliver';
+
+export const data = new SlashCommandBuilder()
+  .setName('deliver')
+  .setDescription('Hand-deliver an in-character letter to another character.')
+  .addStringOption((o) =>
+    o
+      .setName('to')
+      .setDescription('Recipient character')
+      .setRequired(true)
+      .setAutocomplete(true),
+  )
+  .addStringOption((o) =>
+    o
+      .setName('character')
+      .setDescription('Your character (only needed if you have multiple)')
+      .setRequired(false)
+      .setAutocomplete(true),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const query = focused.value.toLowerCase();
+
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    let names = roster.characters.map((c) => c.name);
+    if (focused.name === 'character') {
+      names = roster.characters.filter((c) => c.discordId === interaction.user.id).map((c) => c.name);
+    }
+    const choices = names
+      .filter((n) => query === '' || n.toLowerCase().includes(query))
+      .slice(0, 25)
+      .map((n) => ({ name: n, value: n }));
+    await interaction.respond(choices);
+  } catch {
+    await interaction.respond([]);
+  }
+}
+
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondenceDeliveryChannelId) {
+    await interaction.reply({
+      content: 'The delivery channel is not configured yet — ask a staff member to set `CORRESPONDENCE_DELIVERY_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const to = interaction.options.getString('to', true).trim();
+  const requestedCharacter = interaction.options.getString('character');
+
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  const roster = await ctx.adapter.getActiveRosterWithIds();
+  const recipientExists = roster.characters.some((c) => c.name.toLowerCase() === to.toLowerCase());
+  if (!recipientExists) {
+    await interaction.reply({ content: `Unknown character: ${to}`, ephemeral: true });
+    return;
+  }
+  if (to.toLowerCase() === ownership.characterName.toLowerCase()) {
+    await interaction.reply({ content: "You can't deliver a letter to yourself.", ephemeral: true });
+    return;
+  }
+
+  pendingDeliveries.set(interaction.user.id, { senderCharacterName: ownership.characterName, to });
+
+  const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('Deliver a Letter');
+  const letterInput = new TextInputBuilder()
+    .setCustomId('letter_text')
+    .setLabel('Letter')
+    .setStyle(TextInputStyle.Paragraph)
+    .setPlaceholder('Write the letter here...')
+    .setMaxLength(3900)
+    .setRequired(true);
+  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(letterInput));
+  await interaction.showModal(modal);
+}
+
+export async function handleDeliveryModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+  if (interaction.customId !== MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const pending = pendingDeliveries.get(interaction.user.id);
+  pendingDeliveries.delete(interaction.user.id);
+  if (!pending) {
+    await interaction.editReply('Session expired — run `/deliver` again.');
+    return true;
+  }
+
+  const letterText = interaction.fields.getTextInputValue('letter_text').trim();
+
+  let channel: TextChannel;
+  try {
+    const fetched = await interaction.client.channels.fetch(config.correspondenceDeliveryChannelId);
+    if (!fetched || !fetched.isTextBased() || !('send' in fetched)) {
+      await interaction.editReply('Could not find the delivery channel. Ask staff to check the configured channel ID.');
+      return true;
+    }
+    channel = fetched as TextChannel;
+  } catch (err) {
+    await interaction.editReply(`Could not reach the delivery channel: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle('📜 A Letter Arrives')
+    .setColor(_GOLD)
+    .addFields(
+      { name: 'From', value: pending.senderCharacterName, inline: true },
+      { name: 'To', value: pending.to, inline: true },
+    )
+    .setDescription(letterText)
+    .setFooter({ text: 'Hand-delivered — in character.' });
+
+  try {
+    await channel.send({ embeds: [embed] });
+  } catch (err) {
+    await interaction.editReply(`Could not post the letter: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  await interaction.editReply(`Letter delivered to **${pending.to}**.`);
+  return true;
+}

--- a/apps/bot/src/commands/post.ts
+++ b/apps/bot/src/commands/post.ts
@@ -5,6 +5,8 @@
 import {
   ActionRowBuilder,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
   EmbedBuilder,
   ModalBuilder,
@@ -12,6 +14,7 @@ import {
   SlashCommandBuilder,
   TextInputBuilder,
   TextInputStyle,
+  type ButtonInteraction,
   type TextChannel,
 } from 'discord.js';
 import type { CommandContext } from '../discord';
@@ -21,8 +24,9 @@ import { resolveOwnedCharacter } from '../services/characterOwnership';
 
 const _POST_ACCENT = 0x1d9bf0;
 const MODAL_ID = 'post:social';
+const REPLY_BUTTON_PREFIX = 'post:reply-btn:';
 
-type PendingPost = { senderCharacterName: string; handle: string };
+type PendingPost = { senderCharacterName: string; handle: string; replyToHandle?: string };
 const pendingPosts = new Map<string, PendingPost>();
 
 export const name = 'post';
@@ -76,8 +80,11 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
   }
 
   pendingPosts.set(interaction.user.id, { senderCharacterName: ownership.characterName, handle: ownership.characterName });
+  await interaction.showModal(buildPostModal('New Social Media Post'));
+}
 
-  const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('New Social Media Post');
+function buildPostModal(title: string): ModalBuilder {
+  const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle(title);
   const handleInput = new TextInputBuilder()
     .setCustomId('handle')
     .setLabel('Handle (optional)')
@@ -96,7 +103,31 @@ export async function execute(interaction: ChatInputCommandInteraction, ctx: Com
     new ActionRowBuilder<TextInputBuilder>().addComponents(handleInput),
     new ActionRowBuilder<TextInputBuilder>().addComponents(contentInput),
   );
-  await interaction.showModal(modal);
+  return modal;
+}
+
+/** Handles the 💬 Reply button attached to posted posts — opens the post modal, tagging the new post as a reply. */
+export async function handlePostReplyButton(interaction: ButtonInteraction, ctx: CommandContext): Promise<boolean> {
+  if (!interaction.customId.startsWith(REPLY_BUTTON_PREFIX)) return false;
+
+  const replyToHandle = decodeURIComponent(interaction.customId.slice(REPLY_BUTTON_PREFIX.length));
+
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id);
+  if (!ownership.ok) {
+    await interaction.reply({
+      content: `${ownership.errorMessage} Or use \`/post\` and pass the \`character\` option directly.`,
+      ephemeral: true,
+    });
+    return true;
+  }
+
+  pendingPosts.set(interaction.user.id, {
+    senderCharacterName: ownership.characterName,
+    handle: ownership.characterName,
+    replyToHandle,
+  });
+  await interaction.showModal(buildPostModal(`Reply to @${replyToHandle}`.slice(0, 45)));
+  return true;
 }
 
 export async function handlePostModal(interaction: ModalSubmitInteraction): Promise<boolean> {
@@ -128,14 +159,24 @@ export async function handlePostModal(interaction: ModalSubmitInteraction): Prom
     return true;
   }
 
+  const description = pending.replyToHandle ? `↩️ Replying to @${pending.replyToHandle}\n\n${content}` : content;
+
   const embed = new EmbedBuilder()
     .setTitle(`📱 @${handle}`)
     .setColor(_POST_ACCENT)
-    .setDescription(content)
-    .setFooter({ text: `Posted by ${pending.senderCharacterName} — in character.` });
+    .setDescription(description)
+    .setFooter({ text: `Posted by ${pending.senderCharacterName} — in character.` })
+    .setTimestamp();
+
+  const replyButton = new ButtonBuilder()
+    .setCustomId(`${REPLY_BUTTON_PREFIX}${encodeURIComponent(handle)}`)
+    .setLabel('Reply')
+    .setEmoji('💬')
+    .setStyle(ButtonStyle.Secondary);
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(replyButton);
 
   try {
-    await channel.send({ embeds: [embed] });
+    await channel.send({ embeds: [embed], components: [row] });
   } catch (err) {
     await interaction.editReply(`Could not post: ${errorToMessage(err)}`);
     return true;

--- a/apps/bot/src/commands/post.ts
+++ b/apps/bot/src/commands/post.ts
@@ -1,0 +1,146 @@
+/**
+ * /post — in-character social media post to #social-media.
+ * Generic framing (no named in-fiction platform).
+ */
+import {
+  ActionRowBuilder,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  SlashCommandBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { config } from '../config';
+import { errorToMessage } from '../logger';
+import { resolveOwnedCharacter } from '../services/characterOwnership';
+
+const _POST_ACCENT = 0x1d9bf0;
+const MODAL_ID = 'post:social';
+
+type PendingPost = { senderCharacterName: string; handle: string };
+const pendingPosts = new Map<string, PendingPost>();
+
+export const name = 'post';
+
+export const data = new SlashCommandBuilder()
+  .setName('post')
+  .setDescription('Make an in-character social media post to #social-media.')
+  .addStringOption((o) =>
+    o
+      .setName('character')
+      .setDescription('Your character (only needed if you have multiple)')
+      .setRequired(false)
+      .setAutocomplete(true),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'character') {
+    await interaction.respond([]);
+    return;
+  }
+  const query = focused.value.toLowerCase();
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const choices = roster.characters
+      .filter((c) => c.discordId === interaction.user.id)
+      .map((c) => c.name)
+      .filter((n) => query === '' || n.toLowerCase().includes(query))
+      .slice(0, 25)
+      .map((n) => ({ name: n, value: n }));
+    await interaction.respond(choices);
+  } catch {
+    await interaction.respond([]);
+  }
+}
+
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondenceSocialChannelId) {
+    await interaction.reply({
+      content: 'The social media channel is not configured yet — ask a staff member to set `CORRESPONDENCE_SOCIAL_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  pendingPosts.set(interaction.user.id, { senderCharacterName: ownership.characterName, handle: ownership.characterName });
+
+  const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('New Social Media Post');
+  const handleInput = new TextInputBuilder()
+    .setCustomId('handle')
+    .setLabel('Handle (optional)')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('Defaults to your character name')
+    .setMaxLength(50)
+    .setRequired(false);
+  const contentInput = new TextInputBuilder()
+    .setCustomId('content')
+    .setLabel('Post')
+    .setStyle(TextInputStyle.Paragraph)
+    .setPlaceholder("What's happening?")
+    .setMaxLength(500)
+    .setRequired(true);
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(handleInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(contentInput),
+  );
+  await interaction.showModal(modal);
+}
+
+export async function handlePostModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+  if (interaction.customId !== MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const pending = pendingPosts.get(interaction.user.id);
+  pendingPosts.delete(interaction.user.id);
+  if (!pending) {
+    await interaction.editReply('Session expired — run `/post` again.');
+    return true;
+  }
+
+  const handleRaw = interaction.fields.getTextInputValue('handle').trim();
+  const content = interaction.fields.getTextInputValue('content').trim();
+  const handle = handleRaw || pending.handle;
+
+  let channel: TextChannel;
+  try {
+    const fetched = await interaction.client.channels.fetch(config.correspondenceSocialChannelId);
+    if (!fetched || !fetched.isTextBased() || !('send' in fetched)) {
+      await interaction.editReply('Could not find the social media channel. Ask staff to check the configured channel ID.');
+      return true;
+    }
+    channel = fetched as TextChannel;
+  } catch (err) {
+    await interaction.editReply(`Could not reach the social media channel: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle(`📱 @${handle}`)
+    .setColor(_POST_ACCENT)
+    .setDescription(content)
+    .setFooter({ text: `Posted by ${pending.senderCharacterName} — in character.` });
+
+  try {
+    await channel.send({ embeds: [embed] });
+  } catch (err) {
+    await interaction.editReply(`Could not post: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  await interaction.editReply('Posted.');
+  return true;
+}

--- a/apps/bot/src/commands/prestation.ts
+++ b/apps/bot/src/commands/prestation.ts
@@ -1,0 +1,310 @@
+/**
+ * /prestation — boon ledger for #prestation. owe (create), status (list),
+ * repay (advance the two-step debtor-proposes/creditor-confirms lifecycle).
+ */
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { config } from '../config';
+import { errorToMessage } from '../logger';
+import { resolveOwnedCharacter } from '../services/characterOwnership';
+import type { BoonTier } from '../services/adapter';
+
+const _BLOOD = 0x8b1a1a;
+
+const TIER_LABELS: Record<string, string> = {
+  trivial: 'Trivial',
+  minor: 'Minor',
+  major: 'Major',
+  life: 'Life boon',
+};
+const TIER_EMOJI: Record<string, string> = {
+  trivial: '🔹',
+  minor: '🔸',
+  major: '🔶',
+  life: '💠',
+};
+
+function tierBadge(tier: string): string {
+  return `${TIER_EMOJI[tier] ?? '•'} ${TIER_LABELS[tier] ?? tier}`;
+}
+
+export const name = 'prestation';
+
+export const data = new SlashCommandBuilder()
+  .setName('prestation')
+  .setDescription('Track boons owed between characters.')
+  .addSubcommand((s) =>
+    s
+      .setName('owe')
+      .setDescription('Record that another character owes you a boon.')
+      .addStringOption((o) =>
+        o.setName('debtor').setDescription('Who owes the boon').setRequired(true).setAutocomplete(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('tier')
+          .setDescription('Boon tier')
+          .setRequired(true)
+          .addChoices(
+            { name: 'Trivial', value: 'trivial' },
+            { name: 'Minor', value: 'minor' },
+            { name: 'Major', value: 'major' },
+            { name: 'Life boon', value: 'life' },
+          ),
+      )
+      .addStringOption((o) =>
+        o.setName('reason').setDescription('What was the boon for?').setRequired(true).setMaxLength(300),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Your character (only needed if you have multiple)')
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('status')
+      .setDescription('See boons owed to you and boons you owe.')
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Your character (only needed if you have multiple)')
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((s) =>
+    s
+      .setName('repay')
+      .setDescription('Propose or confirm repayment of a boon.')
+      .addStringOption((o) =>
+        o.setName('boon_id').setDescription('Which boon').setRequired(true).setAutocomplete(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName('character')
+          .setDescription('Your character (only needed if you have multiple)')
+          .setRequired(false)
+          .setAutocomplete(true),
+      ),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const query = focused.value.toLowerCase();
+
+  if (focused.name === 'debtor' || focused.name === 'character') {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      let names = roster.characters.map((c) => c.name);
+      if (focused.name === 'character') {
+        names = roster.characters.filter((c) => c.discordId === interaction.user.id).map((c) => c.name);
+      }
+      const choices = names
+        .filter((n) => query === '' || n.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((n) => ({ name: n, value: n }));
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  if (focused.name === 'boon_id') {
+    const requestedCharacter = interaction.options.getString('character') ?? undefined;
+    try {
+      const result = await ctx.adapter.getBoonsForCharacter(interaction.user.id, requestedCharacter);
+      if (!result) {
+        await interaction.respond([]);
+        return;
+      }
+      const choices = result.boons
+        .filter((b) => b.status !== 'repaid')
+        .map((b) => ({
+          name: `#${b.id} — ${TIER_LABELS[b.tier] ?? b.tier} ${b.direction === 'owed_to_me' ? 'owed by' : 'owed to'} ${b.counterparty_name} (${b.status})`.slice(0, 100),
+          value: String(b.id),
+        }))
+        .slice(0, 25);
+      await interaction.respond(choices);
+    } catch {
+      await interaction.respond([]);
+    }
+    return;
+  }
+
+  await interaction.respond([]);
+}
+
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  const sub = interaction.options.getSubcommand();
+  if (sub === 'owe') {
+    await handleOwe(interaction, ctx);
+  } else if (sub === 'status') {
+    await handleStatus(interaction, ctx);
+  } else if (sub === 'repay') {
+    await handleRepay(interaction, ctx);
+  }
+}
+
+async function fetchPrestationChannel(interaction: ChatInputCommandInteraction): Promise<TextChannel | null> {
+  const fetched = await interaction.client.channels.fetch(config.correspondencePrestationChannelId).catch(() => null);
+  if (!fetched || !fetched.isTextBased() || !('send' in fetched)) return null;
+  return fetched as TextChannel;
+}
+
+async function handleOwe(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondencePrestationChannelId) {
+    await interaction.reply({
+      content: 'The prestation channel is not configured yet — ask a staff member to set `CORRESPONDENCE_PRESTATION_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  const debtor = interaction.options.getString('debtor', true).trim();
+  const tier = interaction.options.getString('tier', true) as BoonTier;
+  const reason = interaction.options.getString('reason', true).trim();
+
+  if (debtor.toLowerCase() === ownership.characterName.toLowerCase()) {
+    await interaction.reply({ content: "A character can't owe a boon to themself.", ephemeral: true });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const result = await ctx.adapter.createBoon(
+    { requesterDiscordId: interaction.user.id, requesterDiscordName: interaction.user.username },
+    { creditorCharacterName: ownership.characterName, debtorCharacterName: debtor, tier, reason },
+  );
+  if (!result.ok || !result.boon) {
+    await interaction.editReply(`Could not record the boon: ${result.message}`);
+    return;
+  }
+
+  const channel = await fetchPrestationChannel(interaction);
+  if (!channel) {
+    await interaction.editReply('Boon recorded, but the prestation channel could not be found — ask staff to check the configured channel ID.');
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle('🩸 Boon Owed')
+    .setColor(_BLOOD)
+    .addFields(
+      { name: 'Creditor', value: result.boon.creditor_character_name, inline: true },
+      { name: 'Debtor', value: result.boon.debtor_character_name, inline: true },
+      { name: 'Tier', value: tierBadge(result.boon.tier), inline: true },
+      { name: 'Reason', value: result.boon.reason || '—', inline: false },
+    )
+    .setFooter({ text: `Boon #${result.boon.id} — use /prestation repay to settle.` });
+
+  try {
+    await channel.send({ embeds: [embed] });
+  } catch (err) {
+    await interaction.editReply(`Boon recorded, but could not post to the channel: ${errorToMessage(err)}`);
+    return;
+  }
+
+  await interaction.editReply(`Boon #${result.boon.id} recorded — ${result.boon.debtor_character_name} owes you.`);
+}
+
+async function handleStatus(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const result = await ctx.adapter.getBoonsForCharacter(interaction.user.id, ownership.characterName);
+  if (!result) {
+    await interaction.editReply('No active character found.');
+    return;
+  }
+
+  const owedToMe = result.boons.filter((b) => b.direction === 'owed_to_me');
+  const iOwe = result.boons.filter((b) => b.direction === 'i_owe');
+
+  const lineFor = (b: (typeof result.boons)[number]) =>
+    `#${b.id} — ${b.counterparty_name} — ${tierBadge(b.tier)} — *${b.status}*${b.reason ? ` — ${b.reason}` : ''}`;
+
+  const embed = new EmbedBuilder()
+    .setTitle(`🩸 ${result.character_name}'s Boons`)
+    .setColor(_BLOOD)
+    .addFields(
+      { name: 'Owed to you', value: owedToMe.length ? owedToMe.map(lineFor).join('\n') : '—', inline: false },
+      { name: 'You owe', value: iOwe.length ? iOwe.map(lineFor).join('\n') : '—', inline: false },
+    );
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleRepay(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondencePrestationChannelId) {
+    await interaction.reply({
+      content: 'The prestation channel is not configured yet — ask a staff member to set `CORRESPONDENCE_PRESTATION_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const requestedCharacter = interaction.options.getString('character');
+  const ownership = await resolveOwnedCharacter(ctx.adapter, interaction.user.id, requestedCharacter);
+  if (!ownership.ok) {
+    await interaction.reply({ content: ownership.errorMessage, ephemeral: true });
+    return;
+  }
+
+  const boonIdRaw = interaction.options.getString('boon_id', true).trim();
+  const boonId = Number(boonIdRaw);
+  if (!Number.isInteger(boonId) || boonId <= 0) {
+    await interaction.reply({ content: 'Pick a boon from the autocomplete list.', ephemeral: true });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const result = await ctx.adapter.actOnBoonRepay(boonId, {
+    requesterDiscordId: interaction.user.id,
+    requesterDiscordName: interaction.user.username,
+  });
+  if (!result.ok || !result.boon) {
+    await interaction.editReply(`Could not update the boon: ${result.message}`);
+    return;
+  }
+
+  const channel = await fetchPrestationChannel(interaction);
+  const boon = result.boon;
+  const summaryLine =
+    boon.status === 'repaid'
+      ? `✅ Boon #${boon.id} repaid — ${boon.creditor_character_name} ↔ ${boon.debtor_character_name}.`
+      : `🔸 Repayment of Boon #${boon.id} proposed by ${boon.debtor_character_name} — awaiting confirmation from ${boon.creditor_character_name}.`;
+
+  if (channel) {
+    try {
+      await channel.send({ content: summaryLine });
+    } catch {
+      // Non-fatal — the ephemeral reply below still confirms the state change.
+    }
+  }
+
+  await interaction.editReply(summaryLine);
+}

--- a/apps/bot/src/commands/prestation.ts
+++ b/apps/bot/src/commands/prestation.ts
@@ -212,10 +212,23 @@ async function handleOwe(interaction: ChatInputCommandInteraction, ctx: CommandC
       { name: 'Tier', value: tierBadge(result.boon.tier), inline: true },
       { name: 'Reason', value: result.boon.reason || '—', inline: false },
     )
-    .setFooter({ text: `Boon #${result.boon.id} — use /prestation repay to settle.` });
+    .setFooter({ text: `Boon #${result.boon.id} — use /prestation repay to settle.` })
+    .setTimestamp();
+
+  let debtorMention = '';
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const debtorName = result.boon.debtor_character_name.toLowerCase();
+    const debtorCharacter = roster.characters.find((c) => c.name.toLowerCase() === debtorName);
+    if (debtorCharacter?.discordId) {
+      debtorMention = `<@${debtorCharacter.discordId}>`;
+    }
+  } catch {
+    debtorMention = '';
+  }
 
   try {
-    await channel.send({ embeds: [embed] });
+    await channel.send({ content: debtorMention || undefined, embeds: [embed] });
   } catch (err) {
     await interaction.editReply(`Boon recorded, but could not post to the channel: ${errorToMessage(err)}`);
     return;

--- a/apps/bot/src/commands/rumor.ts
+++ b/apps/bot/src/commands/rumor.ts
@@ -1,0 +1,191 @@
+/**
+ * /rumor — posts to #rumors using the exact staff-provided template, as
+ * plain message content (not an embed) to preserve the markdown exactly.
+ * The rumor text itself is auto-wrapped in Discord spoiler tags.
+ */
+import {
+  ActionRowBuilder,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  SlashCommandBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type TextChannel,
+} from 'discord.js';
+import type { CommandContext } from '../discord';
+import { config } from '../config';
+import { errorToMessage } from '../logger';
+
+const MODAL_ID = 'rumor:submit';
+
+const DISCOVERY_CHOICES = [
+  { name: 'Kindred', value: 'Kindred' },
+  { name: 'Underworld', value: 'Underworld' },
+  { name: 'High Society', value: 'High Society' },
+  { name: 'Streets', value: 'Streets' },
+];
+
+type PendingRumor = { discovery: string; sourceCharacterName: string | null; sourceDiscordId: string | null };
+const pendingRumors = new Map<string, PendingRumor>();
+
+export const name = 'rumor';
+
+export const data = new SlashCommandBuilder()
+  .setName('rumor')
+  .setDescription('Post a rumor to #rumors using the standard template.')
+  .addStringOption((o) =>
+    o.setName('discovery').setDescription('Point of Discovery').setRequired(true).addChoices(...DISCOVERY_CHOICES),
+  )
+  .addStringOption((o) =>
+    o
+      .setName('source-character')
+      .setDescription('Point of Contact, if it\'s a known character rather than an investigation-roll DC')
+      .setRequired(false)
+      .setAutocomplete(true),
+  );
+
+export async function autocomplete(interaction: AutocompleteInteraction, ctx: CommandContext): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'source-character') {
+    await interaction.respond([]);
+    return;
+  }
+  const query = focused.value.toLowerCase();
+  try {
+    const roster = await ctx.adapter.getActiveRosterWithIds();
+    const choices = roster.characters
+      .map((c) => c.name)
+      .filter((n) => query === '' || n.toLowerCase().includes(query))
+      .slice(0, 25)
+      .map((n) => ({ name: n, value: n }));
+    await interaction.respond(choices);
+  } catch {
+    await interaction.respond([]);
+  }
+}
+
+export async function execute(interaction: ChatInputCommandInteraction, ctx: CommandContext): Promise<void> {
+  if (!config.correspondenceRumorChannelId) {
+    await interaction.reply({
+      content: 'The rumors channel is not configured yet — ask a staff member to set `CORRESPONDENCE_RUMOR_CHANNEL_ID`.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const discovery = interaction.options.getString('discovery', true);
+  const sourceCharacterName = interaction.options.getString('source-character');
+
+  let sourceDiscordId: string | null = null;
+  if (sourceCharacterName) {
+    try {
+      const roster = await ctx.adapter.getActiveRosterWithIds();
+      const match = roster.characters.find((c) => c.name.toLowerCase() === sourceCharacterName.toLowerCase());
+      if (!match) {
+        await interaction.reply({ content: `Unknown character: ${sourceCharacterName}`, ephemeral: true });
+        return;
+      }
+      sourceDiscordId = match.discordId;
+    } catch {
+      sourceDiscordId = null;
+    }
+  }
+
+  pendingRumors.set(interaction.user.id, { discovery, sourceCharacterName, sourceDiscordId });
+
+  const modal = new ModalBuilder().setCustomId(MODAL_ID).setTitle('Post a Rumor');
+  const rumorInput = new TextInputBuilder()
+    .setCustomId('rumor_text')
+    .setLabel('Rumor')
+    .setStyle(TextInputStyle.Paragraph)
+    .setPlaceholder('The rumor itself — will be spoiler-tagged automatically.')
+    .setMaxLength(1000)
+    .setRequired(true);
+  const locationInput = new TextInputBuilder()
+    .setCustomId('location')
+    .setLabel('Location (optional)')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('Where it originates or leads')
+    .setMaxLength(200)
+    .setRequired(false);
+  const contactInput = new TextInputBuilder()
+    .setCustomId('point_of_contact')
+    .setLabel(sourceDiscordId ? 'Point of Contact (optional)' : 'Point of Contact')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('A name, or a Manipulation + Subterfuge DC')
+    .setMaxLength(300)
+    .setRequired(!sourceDiscordId);
+  const rollInput = new TextInputBuilder()
+    .setCustomId('roll')
+    .setLabel('Roll')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('Attribute + Skill DC #')
+    .setMaxLength(200)
+    .setRequired(true);
+
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(rumorInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(locationInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(contactInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(rollInput),
+  );
+  await interaction.showModal(modal);
+}
+
+export async function handleRumorModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+  if (interaction.customId !== MODAL_ID) return false;
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const pending = pendingRumors.get(interaction.user.id);
+  pendingRumors.delete(interaction.user.id);
+  if (!pending) {
+    await interaction.editReply('Session expired — run `/rumor` again.');
+    return true;
+  }
+
+  const rumorText = interaction.fields.getTextInputValue('rumor_text').trim();
+  const location = interaction.fields.getTextInputValue('location').trim();
+  const pointOfContactTyped = interaction.fields.getTextInputValue('point_of_contact').trim();
+  const roll = interaction.fields.getTextInputValue('roll').trim();
+
+  const pointOfContact =
+    pointOfContactTyped || (pending.sourceDiscordId ? `<@${pending.sourceDiscordId}>` : pending.sourceCharacterName ?? '');
+
+  const lines = [
+    `**Rumor**: ||${rumorText}||`,
+    `**Point of Discovery**: ${pending.discovery}`,
+  ];
+  if (location) {
+    lines.push(`**Location (Optional)**: ${location}`);
+  }
+  lines.push(`**Point of Contact**: ${pointOfContact}`);
+  lines.push(`**Roll**: ${roll}`);
+  lines.push('');
+  lines.push('If you want to maintain a rumor, let us know during downtime and we will not delete it!');
+
+  let channel: TextChannel;
+  try {
+    const fetched = await interaction.client.channels.fetch(config.correspondenceRumorChannelId);
+    if (!fetched || !fetched.isTextBased() || !('send' in fetched)) {
+      await interaction.editReply('Could not find the rumors channel. Ask staff to check the configured channel ID.');
+      return true;
+    }
+    channel = fetched as TextChannel;
+  } catch (err) {
+    await interaction.editReply(`Could not reach the rumors channel: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  try {
+    await channel.send({ content: lines.join('\n') });
+  } catch (err) {
+    await interaction.editReply(`Could not post the rumor: ${errorToMessage(err)}`);
+    return true;
+  }
+
+  await interaction.editReply('Rumor posted.');
+  return true;
+}

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -195,6 +195,12 @@ const envSchema = z.object({
   MENTION_BREAKER_TIMEOUT_MINUTES: z.string().optional(),
   MENTION_BREAKER_EXEMPT_ROLE_IDS: z.string().optional(),
   MENTION_BREAKER_MOD_LOG_CHANNEL_ID: z.string().optional(),
+  CORRESPONDENCE_DELIVERY_CHANNEL_ID: z.string().optional(),
+  CORRESPONDENCE_CONTACT_CHANNEL_ID: z.string().optional(),
+  CORRESPONDENCE_PRESTATION_CHANNEL_ID: z.string().optional(),
+  CORRESPONDENCE_SOCIAL_CHANNEL_ID: z.string().optional(),
+  CORRESPONDENCE_COBWEB_CHANNEL_ID: z.string().optional(),
+  CORRESPONDENCE_RUMOR_CHANNEL_ID: z.string().optional(),
   VERIFIED_MEMBER_ROLE_ID: z.string().optional(),
   PERMISSION_SNAPSHOT_DIR: z.string().optional(),
 });
@@ -495,6 +501,12 @@ export const config = {
     env.MENTION_BREAKER_MOD_LOG_CHANNEL_ID ?? env.HONEYPOT_MOD_LOG_CHANNEL_ID ?? '',
   verifiedMemberRoleId: env.VERIFIED_MEMBER_ROLE_ID,
   permissionSnapshotDir: env.PERMISSION_SNAPSHOT_DIR ?? '',
+  correspondenceDeliveryChannelId: env.CORRESPONDENCE_DELIVERY_CHANNEL_ID ?? '',
+  correspondenceContactChannelId: env.CORRESPONDENCE_CONTACT_CHANNEL_ID ?? '',
+  correspondencePrestationChannelId: env.CORRESPONDENCE_PRESTATION_CHANNEL_ID ?? '',
+  correspondenceSocialChannelId: env.CORRESPONDENCE_SOCIAL_CHANNEL_ID ?? '',
+  correspondenceCobwebChannelId: env.CORRESPONDENCE_COBWEB_CHANNEL_ID ?? '',
+  correspondenceRumorChannelId: env.CORRESPONDENCE_RUMOR_CHANNEL_ID ?? '',
 };
 
 if (config.testRequesterDiscordId) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from './interactiveClaimWizard';
 import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButton, isCombatButton } from './combatSetupWizard';
 import { handleBroadcastModal, handleDeleteButton, handleUpdateModal, isDeleteButton } from './commands/lasombra';
+import { handleDeliveryModal } from './commands/delivery';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -485,6 +486,11 @@ void applyStartupConfigOverrides().then(() => {
       }
       const combatHandled = await handleCombatSetupModal(interaction);
       if (combatHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const deliveryHandled = await handleDeliveryModal(interaction);
+      if (deliveryHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;
       }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -34,6 +34,7 @@ import { handleContactSendModal, handleContactReplyModal, handleContactReplyButt
 import { handlePostModal, handlePostReplyButton } from './commands/post';
 import { handleCobwebModal, handleCobwebReplyButton } from './commands/cobweb';
 import { handleRumorModal } from './commands/rumor';
+import { buildDisableTokens, isAnyTokenDisabled } from './services/commandGating';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -387,6 +388,17 @@ void applyStartupConfigOverrides().then(() => {
       if (!cmd?.autocomplete) {
         return;
       }
+      if (!config.testerDiscordIds.has(interaction.user.id)) {
+        const tokens = buildDisableTokens(
+          interaction.commandName,
+          interaction.options.getSubcommandGroup(false),
+          interaction.options.getSubcommand(false),
+        );
+        if (isAnyTokenDisabled(tokens, liveConfig.disabledCommands)) {
+          await interaction.respond([]);
+          return;
+        }
+      }
       await cmd.autocomplete(interaction, { client, adapter });
       return;
     }
@@ -557,6 +569,19 @@ void applyStartupConfigOverrides().then(() => {
     const cmd = client.commands.get(interaction.commandName);
     if (!cmd) {
       return;
+    }
+
+    if (!config.testerDiscordIds.has(interaction.user.id)) {
+      const tokens = buildDisableTokens(
+        interaction.commandName,
+        interaction.options.getSubcommandGroup(false),
+        interaction.options.getSubcommand(false),
+      );
+      if (isAnyTokenDisabled(tokens, liveConfig.disabledCommands)) {
+        logEvent('info', 'command_execute_blocked_disabled', { ...baseMeta, commandName: interaction.commandName, tokens });
+        await interaction.reply({ content: 'This command is currently disabled by staff.', ephemeral: true });
+        return;
+      }
     }
 
     logEvent('info', 'command_execute_start', { ...baseMeta, commandName: interaction.commandName });

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButton, isCombatButton } from './combatSetupWizard';
 import { handleBroadcastModal, handleDeleteButton, handleUpdateModal, isDeleteButton } from './commands/lasombra';
 import { handleDeliveryModal } from './commands/delivery';
+import { handleContactSendModal, handleContactReplyModal } from './commands/contact';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -491,6 +492,16 @@ void applyStartupConfigOverrides().then(() => {
       }
       const deliveryHandled = await handleDeliveryModal(interaction);
       if (deliveryHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const contactSendHandled = await handleContactSendModal(interaction, { client, adapter });
+      if (contactSendHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const contactReplyHandled = await handleContactReplyModal(interaction, { client, adapter });
+      if (contactReplyHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;
       }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -31,6 +31,8 @@ import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButt
 import { handleBroadcastModal, handleDeleteButton, handleUpdateModal, isDeleteButton } from './commands/lasombra';
 import { handleDeliveryModal } from './commands/delivery';
 import { handleContactSendModal, handleContactReplyModal } from './commands/contact';
+import { handlePostModal } from './commands/post';
+import { handleCobwebModal } from './commands/cobweb';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -502,6 +504,16 @@ void applyStartupConfigOverrides().then(() => {
       }
       const contactReplyHandled = await handleContactReplyModal(interaction, { client, adapter });
       if (contactReplyHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const postHandled = await handlePostModal(interaction);
+      if (postHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const cobwebHandled = await handleCobwebModal(interaction);
+      if (cobwebHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;
       }

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -29,10 +29,10 @@ import {
 } from './interactiveClaimWizard';
 import { handleCombatParticipantSelect, handleCombatSetupModal, handleCombatButton, isCombatButton } from './combatSetupWizard';
 import { handleBroadcastModal, handleDeleteButton, handleUpdateModal, isDeleteButton } from './commands/lasombra';
-import { handleDeliveryModal } from './commands/delivery';
-import { handleContactSendModal, handleContactReplyModal } from './commands/contact';
-import { handlePostModal } from './commands/post';
-import { handleCobwebModal } from './commands/cobweb';
+import { handleDeliveryModal, handleDeliveryReplyButton } from './commands/delivery';
+import { handleContactSendModal, handleContactReplyModal, handleContactReplyButton } from './commands/contact';
+import { handlePostModal, handlePostReplyButton } from './commands/post';
+import { handleCobwebModal, handleCobwebReplyButton } from './commands/cobweb';
 import { handleRumorModal } from './commands/rumor';
 import {
   handleApproveWizardStringSelect,
@@ -460,6 +460,26 @@ void applyStartupConfigOverrides().then(() => {
         logEvent('info', 'interaction_handled_reminder_button', { ...baseMeta, customId: interaction.customId });
         return;
       }
+      const contactReplyButtonHandled = await handleContactReplyButton(interaction, { client, adapter });
+      if (contactReplyButtonHandled) {
+        logEvent('info', 'interaction_handled_contact_reply_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const deliveryReplyButtonHandled = await handleDeliveryReplyButton(interaction, { client, adapter });
+      if (deliveryReplyButtonHandled) {
+        logEvent('info', 'interaction_handled_delivery_reply_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const cobwebReplyButtonHandled = await handleCobwebReplyButton(interaction, { client, adapter });
+      if (cobwebReplyButtonHandled) {
+        logEvent('info', 'interaction_handled_cobweb_reply_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const postReplyButtonHandled = await handlePostReplyButton(interaction, { client, adapter });
+      if (postReplyButtonHandled) {
+        logEvent('info', 'interaction_handled_post_reply_button', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
       const handled = await handleClaimWizardButton(interaction, adapter);
       if (handled) {
         logEvent('info', 'interaction_handled_button', { ...baseMeta, customId: interaction.customId });
@@ -493,7 +513,7 @@ void applyStartupConfigOverrides().then(() => {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;
       }
-      const deliveryHandled = await handleDeliveryModal(interaction);
+      const deliveryHandled = await handleDeliveryModal(interaction, { client, adapter });
       if (deliveryHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -33,6 +33,7 @@ import { handleDeliveryModal } from './commands/delivery';
 import { handleContactSendModal, handleContactReplyModal } from './commands/contact';
 import { handlePostModal } from './commands/post';
 import { handleCobwebModal } from './commands/cobweb';
+import { handleRumorModal } from './commands/rumor';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -514,6 +515,11 @@ void applyStartupConfigOverrides().then(() => {
       }
       const cobwebHandled = await handleCobwebModal(interaction);
       if (cobwebHandled) {
+        logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
+        return;
+      }
+      const rumorHandled = await handleRumorModal(interaction);
+      if (rumorHandled) {
         logEvent('info', 'interaction_handled_modal', { ...baseMeta, customId: interaction.customId });
         return;
       }

--- a/apps/bot/src/liveConfig.ts
+++ b/apps/bot/src/liveConfig.ts
@@ -33,4 +33,6 @@ export const liveConfig = {
   mentionBreakerExemptRoleIds: new Set<string>(),
   mentionBreakerModLogChannelId: '',
   verifiedMemberRoleId: '',
+  /** Per-command/subcommand kill switches, e.g. "xp.submit", "cobweb". Set-membership check, no restart needed. */
+  disabledCommands: new Set<string>(),
 };

--- a/apps/bot/src/scripts/setupTestChannels.ts
+++ b/apps/bot/src/scripts/setupTestChannels.ts
@@ -1,0 +1,92 @@
+/**
+ * setupTestChannels.ts — one-time helper for standing up a dev/test Discord
+ * environment for the Correspondence commands (/deliver, /contact,
+ * /prestation, /post, /cobweb, /rumor).
+ *
+ * Creates a "Correspondence (Test)" category plus the six channels those
+ * commands post to, in whatever guild you point it at (reusing any that
+ * already exist by name), then prints the CORRESPONDENCE_*_CHANNEL_ID lines
+ * ready to paste into apps/bot/.env.dev.
+ *
+ * Usage (from apps/bot/):
+ *   npm run ops:setup-test-channels                    # uses .env.dev + TEST_GUILD_ID
+ *   npm run ops:setup-test-channels -- --guild <id>     # override the target guild
+ *   npm run ops:setup-test-channels -- --env-file <path>
+ *
+ * Requires BOT_TOKEN with "Manage Channels" in the target guild.
+ */
+
+import path from 'node:path';
+import * as dotenv from 'dotenv';
+import { ChannelType, Client, GatewayIntentBits } from 'discord.js';
+
+const TARGET_CHANNELS: Array<{ channelName: string; envVar: string }> = [
+  { channelName: 'kindred-delivery', envVar: 'CORRESPONDENCE_DELIVERY_CHANNEL_ID' },
+  { channelName: 'kindred-contact', envVar: 'CORRESPONDENCE_CONTACT_CHANNEL_ID' },
+  { channelName: 'prestation', envVar: 'CORRESPONDENCE_PRESTATION_CHANNEL_ID' },
+  { channelName: 'social-media', envVar: 'CORRESPONDENCE_SOCIAL_CHANNEL_ID' },
+  { channelName: 'reach-out-and-touch-mind', envVar: 'CORRESPONDENCE_COBWEB_CHANNEL_ID' },
+  { channelName: 'rumors', envVar: 'CORRESPONDENCE_RUMOR_CHANNEL_ID' },
+];
+
+const CATEGORY_NAME = 'Correspondence (Test)';
+
+function parseArgs(argv: string[]) {
+  const args = { guildId: '', envFile: '.env.dev' };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--guild') args.guildId = argv[++i] ?? '';
+    else if (argv[i] === '--env-file') args.envFile = argv[++i] ?? '.env.dev';
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  dotenv.config({ path: path.resolve(__dirname, '..', '..', args.envFile) });
+
+  const token = process.env.BOT_TOKEN;
+  const guildId = args.guildId || process.env.TEST_GUILD_ID;
+
+  if (!token || !guildId) {
+    console.error(`BOT_TOKEN and TEST_GUILD_ID are required (loaded from ${args.envFile}, or pass --guild <id>).`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+  await client.login(token);
+  try {
+    const guild = await client.guilds.fetch(guildId);
+    const channels = await guild.channels.fetch();
+    console.log(`Guild: ${guild.name} (${guild.id})\n`);
+
+    let category = [...channels.values()].find(
+      (c) => c?.type === ChannelType.GuildCategory && c.name === CATEGORY_NAME,
+    );
+    if (!category) {
+      category = await guild.channels.create({ name: CATEGORY_NAME, type: ChannelType.GuildCategory });
+      console.log(`Created category "${CATEGORY_NAME}".`);
+    } else {
+      console.log(`Reusing existing category "${CATEGORY_NAME}".`);
+    }
+
+    console.log('\nPaste these into apps/bot/.env.dev:\n');
+    for (const target of TARGET_CHANNELS) {
+      let channel = [...channels.values()].find(
+        (c) => c?.type === ChannelType.GuildText && c.name === target.channelName && c.parentId === category!.id,
+      );
+      if (!channel) {
+        channel = await guild.channels.create({
+          name: target.channelName,
+          type: ChannelType.GuildText,
+          parent: category.id,
+        });
+      }
+      console.log(`${target.envVar}=${channel.id}`);
+    }
+  } finally {
+    await client.destroy();
+  }
+}
+
+void main();

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -186,7 +186,65 @@ export interface TrackerAdapter {
     } | null;
     members: Array<{ character_name: string; clan: string; player_discord_id: string; player_name: string }>;
   } | null>;
+  createBoon(
+    requester: RequesterContext,
+    payload: { creditorCharacterName: string; debtorCharacterName: string; tier: BoonTier; reason: string },
+  ): Promise<{ ok: boolean; message: string; boon?: BoonDetails }>;
+  getBoonsForCharacter(
+    discordId: string,
+    characterName?: string,
+    status?: string,
+  ): Promise<{ character_name: string; boons: BoonSummary[] } | null>;
+  actOnBoonRepay(
+    boonId: number,
+    requester: RequesterContext,
+  ): Promise<{ ok: boolean; message: string; boon?: BoonDetails }>;
+  createContactThread(
+    requester: RequesterContext,
+    payload: { senderCharacterName: string; recipientCharacterNames: string[]; body: string },
+  ): Promise<{ ok: boolean; message: string; threadId?: number; participants?: ContactParticipant[] }>;
+  getContactThreadsForCharacter(
+    discordId: string,
+    characterName?: string,
+  ): Promise<{ character_name: string; threads: ContactThreadSummary[] } | null>;
+  replyToContactThread(
+    threadId: number,
+    requester: RequesterContext,
+    payload: { senderCharacterName: string; body: string },
+  ): Promise<{ ok: boolean; message: string; otherParticipants?: ContactParticipant[] }>;
 }
+
+export type BoonTier = 'trivial' | 'minor' | 'major' | 'life';
+
+export type BoonDetails = {
+  id: number;
+  creditor_character_name: string;
+  debtor_character_name: string;
+  tier: string;
+  reason: string;
+  status: string;
+  created_at: string | null;
+  resolved_at: string | null;
+};
+
+export type BoonSummary = {
+  id: number;
+  direction: 'owed_to_me' | 'i_owe';
+  counterparty_name: string;
+  tier: string;
+  reason: string;
+  status: string;
+  created_at: string | null;
+};
+
+export type ContactParticipant = { character_name: string; discord_id: string };
+
+export type ContactThreadSummary = {
+  id: number;
+  participant_names: string[];
+  last_message_at: string | null;
+  message_count: number;
+};
 
 export type CharacterDetails = {
   character_name: string;
@@ -1496,6 +1554,150 @@ export class WebAppAdapter implements TrackerAdapter {
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`coteries/by-character GET failed: ${res.status}`);
     return res.json() as Promise<ReturnType<TrackerAdapter['getCoterieForCharacter']> extends Promise<infer T> ? T : never>;
+  }
+
+  private async errorMessageFrom(resp: Response, fallback: string): Promise<string> {
+    const body = await resp.json().catch(() => ({})) as Record<string, unknown>;
+    return (body.error as string | undefined) ?? fallback;
+  }
+
+  async createBoon(
+    requester: RequesterContext,
+    payload: { creditorCharacterName: string; debtorCharacterName: string; tier: BoonTier; reason: string },
+  ): Promise<{ ok: boolean; message: string; boon?: BoonDetails }> {
+    const requestTimestamp = Math.floor(Date.now() / 1000).toString();
+    const requestNonce = randomUUID();
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/boons`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Timestamp': requestTimestamp,
+        'X-Request-Nonce': requestNonce,
+        ...this.writeAuthHeaders(),
+      },
+      body: JSON.stringify({
+        requesterDiscordId: requester.requesterDiscordId,
+        requesterDiscordName: requester.requesterDiscordName,
+        creditorCharacterName: payload.creditorCharacterName,
+        debtorCharacterName: payload.debtorCharacterName,
+        tier: payload.tier,
+        reason: payload.reason,
+      }),
+    }).catch(() => null);
+
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (!resp.ok) return { ok: false, message: await this.errorMessageFrom(resp, `Request failed (${resp.status}).`) };
+    const data = await resp.json() as { ok: boolean; boon: BoonDetails };
+    return { ok: data.ok, message: 'Boon recorded.', boon: data.boon };
+  }
+
+  async getBoonsForCharacter(discordId: string, characterName?: string, status?: string) {
+    const params = new URLSearchParams();
+    if (characterName) params.set('character_name', characterName);
+    if (status) params.set('status', status);
+    const qs = params.toString() ? `?${params.toString()}` : '';
+    const res = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/boons/by-character/${encodeURIComponent(discordId)}${qs}`,
+      { method: 'GET', headers: this.readAuthHeaders() },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`boons/by-character GET failed: ${res.status}`);
+    return res.json() as Promise<{ character_name: string; boons: BoonSummary[] }>;
+  }
+
+  async actOnBoonRepay(
+    boonId: number,
+    requester: RequesterContext,
+  ): Promise<{ ok: boolean; message: string; boon?: BoonDetails }> {
+    const requestTimestamp = Math.floor(Date.now() / 1000).toString();
+    const requestNonce = randomUUID();
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/boons/${boonId}/repay-action`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Timestamp': requestTimestamp,
+        'X-Request-Nonce': requestNonce,
+        ...this.writeAuthHeaders(),
+      },
+      body: JSON.stringify({
+        requesterDiscordId: requester.requesterDiscordId,
+        requesterDiscordName: requester.requesterDiscordName,
+      }),
+    }).catch(() => null);
+
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (!resp.ok) return { ok: false, message: await this.errorMessageFrom(resp, `Request failed (${resp.status}).`) };
+    const data = await resp.json() as { ok: boolean; boon: BoonDetails };
+    return { ok: data.ok, message: 'Boon updated.', boon: data.boon };
+  }
+
+  async createContactThread(
+    requester: RequesterContext,
+    payload: { senderCharacterName: string; recipientCharacterNames: string[]; body: string },
+  ): Promise<{ ok: boolean; message: string; threadId?: number; participants?: ContactParticipant[] }> {
+    const requestTimestamp = Math.floor(Date.now() / 1000).toString();
+    const requestNonce = randomUUID();
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/contact-threads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Timestamp': requestTimestamp,
+        'X-Request-Nonce': requestNonce,
+        ...this.writeAuthHeaders(),
+      },
+      body: JSON.stringify({
+        requesterDiscordId: requester.requesterDiscordId,
+        requesterDiscordName: requester.requesterDiscordName,
+        senderCharacterName: payload.senderCharacterName,
+        recipientCharacterNames: payload.recipientCharacterNames,
+        body: payload.body,
+      }),
+    }).catch(() => null);
+
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (!resp.ok) return { ok: false, message: await this.errorMessageFrom(resp, `Request failed (${resp.status}).`) };
+    const data = await resp.json() as { ok: boolean; thread_id: number; participants: ContactParticipant[] };
+    return { ok: data.ok, message: 'Message sent.', threadId: data.thread_id, participants: data.participants };
+  }
+
+  async getContactThreadsForCharacter(discordId: string, characterName?: string) {
+    const qs = characterName ? `?character_name=${encodeURIComponent(characterName)}` : '';
+    const res = await this.fetchWithTimeout(
+      `${this.baseUrl}/api/contact-threads/by-character/${encodeURIComponent(discordId)}${qs}`,
+      { method: 'GET', headers: this.readAuthHeaders() },
+    );
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`contact-threads/by-character GET failed: ${res.status}`);
+    return res.json() as Promise<{ character_name: string; threads: ContactThreadSummary[] }>;
+  }
+
+  async replyToContactThread(
+    threadId: number,
+    requester: RequesterContext,
+    payload: { senderCharacterName: string; body: string },
+  ): Promise<{ ok: boolean; message: string; otherParticipants?: ContactParticipant[] }> {
+    const requestTimestamp = Math.floor(Date.now() / 1000).toString();
+    const requestNonce = randomUUID();
+    const resp = await this.fetchWithTimeout(`${this.baseUrl}/api/contact-threads/${threadId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Timestamp': requestTimestamp,
+        'X-Request-Nonce': requestNonce,
+        ...this.writeAuthHeaders(),
+      },
+      body: JSON.stringify({
+        requesterDiscordId: requester.requesterDiscordId,
+        requesterDiscordName: requester.requesterDiscordName,
+        senderCharacterName: payload.senderCharacterName,
+        body: payload.body,
+      }),
+    }).catch(() => null);
+
+    if (!resp) return { ok: false, message: 'Unable to reach web app API.' };
+    if (!resp.ok) return { ok: false, message: await this.errorMessageFrom(resp, `Request failed (${resp.status}).`) };
+    const data = await resp.json() as { ok: boolean; other_participants: ContactParticipant[] };
+    return { ok: data.ok, message: 'Reply sent.', otherParticipants: data.other_participants };
   }
 
   private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -46,6 +46,7 @@ export interface BotConfigResponse {
   mentionBreakerModLogChannelId: string | null;
   verifiedMemberRoleId: string | null;
   staffDiscordIds: string[] | null;
+  disabledCommands: string | null;
 }
 
 export interface TrackerAdapter {

--- a/apps/bot/src/services/characterOwnership.ts
+++ b/apps/bot/src/services/characterOwnership.ts
@@ -1,0 +1,37 @@
+import type { TrackerAdapter } from './adapter';
+
+export type OwnershipResult =
+  | { ok: true; characterName: string }
+  | { ok: false; errorMessage: string };
+
+/**
+ * Resolves which of a Discord user's own active characters is posting.
+ * Mirrors the character-option pattern already used by /lasombra blank —
+ * an optional `character` option disambiguates when a player has more than
+ * one linked character, rather than a follow-up select-menu interaction.
+ */
+export async function resolveOwnedCharacter(
+  adapter: TrackerAdapter,
+  discordUserId: string,
+  requestedCharacter?: string | null,
+): Promise<OwnershipResult> {
+  const roster = await adapter.getActiveRosterWithIds();
+  const owned = roster.characters.filter((c) => c.discordId === discordUserId);
+
+  const requested = requestedCharacter?.trim();
+  if (requested) {
+    const match = owned.find((c) => c.name.toLowerCase() === requested.toLowerCase());
+    if (!match) {
+      return { ok: false, errorMessage: `You don't have an active character named "${requested}".` };
+    }
+    return { ok: true, characterName: match.name };
+  }
+
+  if (owned.length === 1) {
+    return { ok: true, characterName: owned[0].name };
+  }
+  if (owned.length > 1) {
+    return { ok: false, errorMessage: 'You have multiple linked characters. Please provide the `character` option.' };
+  }
+  return { ok: false, errorMessage: 'No linked active character found. Use the web player page to link one first.' };
+}

--- a/apps/bot/src/services/commandGating.ts
+++ b/apps/bot/src/services/commandGating.ts
@@ -1,0 +1,29 @@
+/**
+ * Per-command/subcommand kill switches, driven by `liveConfig.disabledCommands`
+ * (staff-editable from the web dashboard's Settings page — see
+ * apps/web/app/blueprints/settings.py's toggle_bot_command route).
+ *
+ * A bare token ("xp") disables the whole command, cascading to every
+ * subcommand. A dotted token ("xp.submit", "lasombra.permissions.apply")
+ * disables just that leaf. Staff (config.testerDiscordIds) always bypass —
+ * this module only answers "is it disabled," callers decide whether to
+ * enforce that for a given user.
+ */
+
+export function buildDisableTokens(
+  commandName: string,
+  subcommandGroup: string | null,
+  subcommand: string | null,
+): string[] {
+  if (!subcommand) {
+    return [commandName];
+  }
+  const leaf = subcommandGroup
+    ? `${commandName}.${subcommandGroup}.${subcommand}`
+    : `${commandName}.${subcommand}`;
+  return [leaf, commandName];
+}
+
+export function isAnyTokenDisabled(tokens: string[], disabledSet: Set<string>): boolean {
+  return tokens.some((token) => disabledSet.has(token));
+}

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -51,6 +51,9 @@ export class ConfigSyncWorker {
         : new Set(config.mentionBreakerExemptRoleIds);
       liveConfig.mentionBreakerModLogChannelId = cfg.mentionBreakerModLogChannelId ?? config.mentionBreakerModLogChannelId;
       liveConfig.verifiedMemberRoleId = cfg.verifiedMemberRoleId ?? config.verifiedMemberRoleId ?? '';
+      liveConfig.disabledCommands = cfg.disabledCommands != null
+        ? new Set(cfg.disabledCommands.split(',').map(s => s.trim()).filter(Boolean))
+        : new Set();
       // Rebuild testerDiscordIds each sync so removals are respected:
       // start from the env-seeded snapshot, then union in current DB staff.
       config.testerDiscordIds = new Set(config.envTesterDiscordIds);

--- a/apps/bot/src/services/retirementAutomationWorker.ts
+++ b/apps/bot/src/services/retirementAutomationWorker.ts
@@ -147,6 +147,8 @@ export class RetirementAutomationWorker {
       if (this.cfg.wikiBatchEnabled && !config.wikiSyncEnabled) {
         await this.maybeRequestWikiBatch();
       }
+    } catch (err) {
+      logEvent('warn', 'retirement_automation_tick_failed', { error: errorToMessage(err) });
     } finally {
       this.running = false;
     }

--- a/apps/web/app/app_settings.py
+++ b/apps/web/app/app_settings.py
@@ -31,6 +31,8 @@ EDITABLE_KEYS = {
     # Bot restart / sync signals
     'BOT_RESTART_REQUESTED',
     'BOT_WIKI_SYNC_REQUESTED',
+    # Per-command/subcommand kill switches (polled by bot via /api/bot-config)
+    'BOT_DISABLED_COMMANDS',
     # CC ticket monitor (polled by bot via /api/bot-config; applies within 1 minute)
     'BOT_CC_TICKET_MONITOR_ENABLED',
     'BOT_CC_TICKET_CATEGORY_IDS',

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -802,6 +802,7 @@ def bot_config():
         'BOT_MENTION_BREAKER_EXEMPT_ROLE_IDS': 'mentionBreakerExemptRoleIds',
         'BOT_MENTION_BREAKER_MOD_LOG_CHANNEL_ID': 'mentionBreakerModLogChannelId',
         'BOT_VERIFIED_MEMBER_ROLE_ID': 'verifiedMemberRoleId',
+        'BOT_DISABLED_COMMANDS': 'disabledCommands',
     }
     all_keys = list(BOOL_KEYS) + list(INT_KEYS) + list(STR_KEYS)
     from app.db import AppSetting

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -17,6 +17,7 @@ from app.app_settings import (
     get_app_setting,
     set_app_setting,
 )
+from app.bot_commands_catalog import BOT_COMMAND_CATALOG, flattened_tokens
 from app.db import RetirementAutomationJob
 from app.retirement_automation import retirement_next_retry_at
 
@@ -359,6 +360,32 @@ def index():
         },
     ]
 
+    # ── Bot command kill switches (DB-backed CSV; polled by bot via /api/bot-config) ──
+    _disabled_raw = get_app_setting('BOT_DISABLED_COMMANDS', '')
+    _disabled_tokens = {t.strip() for t in _disabled_raw.split(',') if t.strip()}
+
+    bot_commands = []
+    for _cmd in BOT_COMMAND_CATALOG:
+        _cmd_disabled = _cmd['name'] in _disabled_tokens
+        subcommands = []
+        for _sub in _cmd['subcommands']:
+            _sub_token = f"{_cmd['name']}.{_sub['name']}"
+            subcommands.append({
+                'token': _sub_token,
+                'label': _sub['label'],
+                'description': _sub['description'],
+                'own_disabled': _sub_token in _disabled_tokens,
+                'disabled': _cmd_disabled or _sub_token in _disabled_tokens,
+                'inherited': _cmd_disabled and _sub_token not in _disabled_tokens,
+            })
+        bot_commands.append({
+            'token': _cmd['name'],
+            'label': _cmd['label'],
+            'description': _cmd['description'],
+            'disabled': _cmd_disabled,
+            'subcommands': subcommands,
+        })
+
     # ── Bot channel IDs (DB-backed; take effect after bot restart) ────────
     def _eff_str(key):
         record = overrides.get(key)
@@ -700,6 +727,7 @@ def index():
         web_tuning=web_tuning,
         integrations=integrations,
         bot_flags=bot_flags,
+        bot_commands=bot_commands,
         bot_channels=bot_channels,
         bot_tuning=bot_tuning,
         chronicle_settings=chronicle_settings,
@@ -878,6 +906,41 @@ def update():
             set_app_setting(key, raw_value, updated_by)
         flash(f'{key} updated.', 'success')
 
+    return redirect(url_for('settings.index'))
+
+
+@bp.route('/commands/toggle', methods=['POST'])
+@require_staff
+def toggle_bot_command():
+    if not is_settings_admin():
+        flash('You do not have permission to change settings.', 'danger')
+        return redirect(url_for('settings.index'))
+
+    token = request.form.get('token', '').strip()
+    action = request.form.get('action', '').strip()  # 'disable' or 'enable'
+
+    if token not in flattened_tokens():
+        flash(f'Unknown command: {token}', 'danger')
+        return redirect(url_for('settings.index'))
+    if action not in ('disable', 'enable'):
+        flash('Invalid action.', 'danger')
+        return redirect(url_for('settings.index'))
+
+    updated_by = (
+        session.get('discord_name')
+        or session.get('staff_user')
+        or session.get('discord_id', 'unknown')
+    )
+
+    current = {t.strip() for t in get_app_setting('BOT_DISABLED_COMMANDS', '').split(',') if t.strip()}
+    if action == 'disable':
+        current.add(token)
+        flash(f'`{token}` disabled.', 'success')
+    else:
+        current.discard(token)
+        flash(f'`{token}` re-enabled.', 'success')
+
+    set_app_setting('BOT_DISABLED_COMMANDS', ','.join(sorted(current)), updated_by)
     return redirect(url_for('settings.index'))
 
 

--- a/apps/web/app/bot_commands_catalog.py
+++ b/apps/web/app/bot_commands_catalog.py
@@ -1,0 +1,131 @@
+"""Hand-maintained mirror of the bot's Discord command tree, for the
+Settings page's per-command/subcommand kill switches.
+
+This is a manual mirror — same convention this codebase already uses for
+BOOL_KEYS/INT_KEYS/STR_KEYS duplicated across api.py/settings.py and the
+bot's configSyncWorker.ts/liveConfig.ts for every existing flag. Update this
+file whenever a command or subcommand is added, renamed, or removed in
+apps/bot/src/commands/*.ts — nothing here is auto-discovered from the bot.
+
+Tokens: a bare command name (e.g. "xp") disables the whole command,
+cascading to every subcommand. A dotted token (e.g. "xp.submit",
+"lasombra.permissions.apply") disables just that leaf. Subcommand *groups*
+(lasombra's "permissions") are flattened directly into their children's
+tokens — there is no separate group-level toggle.
+"""
+
+BOT_COMMAND_CATALOG = [
+    {
+        'name': 'ping',
+        'label': '/ping',
+        'description': 'Bot health check.',
+        'subcommands': [],
+    },
+    {
+        'name': 'xp',
+        'label': '/xp',
+        'description': 'XP workflow bridge commands.',
+        'subcommands': [
+            {'name': 'submit', 'label': 'submit', 'description': 'Player-portal claim link (wizard stubbed out).'},
+            {'name': 'summary', 'label': 'summary', 'description': 'XP totals for a character.'},
+            {'name': 'history', 'label': 'history', 'description': 'Recent approved claims and spends.'},
+            {'name': 'claim', 'label': 'claim', 'description': 'Player-portal claim link (wizard stubbed out).'},
+            {'name': 'spend', 'label': 'spend', 'description': 'Player-portal spend link (wizard stubbed out).'},
+            {'name': 'spend-cost', 'label': 'spend-cost', 'description': 'Preview V5 XP cost of a spend.'},
+            {'name': 'health', 'label': 'health', 'description': 'Staff: bot-to-web API health check.'},
+            {'name': 'help', 'label': 'help', 'description': 'Quick player help text.'},
+            {'name': 'test-reminder', 'label': 'test-reminder', 'description': 'Staff test: post a dummy cubby reminder.'},
+            {'name': 'test-passage', 'label': 'test-passage', 'description': 'Staff test: post a passage-of-time message.'},
+            {'name': 'sync-cubby-access', 'label': 'sync-cubby-access', 'description': 'Staff: grant bot permissions on cubby channels.'},
+        ],
+    },
+    {
+        'name': 'coterie',
+        'label': '/coterie',
+        'description': 'Coterie information commands.',
+        'subcommands': [
+            {'name': 'status', 'label': 'status', 'description': "Show your coterie's domain and members."},
+        ],
+    },
+    {
+        'name': 'combat',
+        'label': '/combat',
+        'description': 'Combat tracker commands.',
+        'subcommands': [
+            {'name': 'start', 'label': 'start', 'description': 'Open the combat setup form.'},
+        ],
+    },
+    {
+        'name': 'lasombra',
+        'label': '/lasombra',
+        'description': 'Staff utility commands.',
+        'subcommands': [
+            {'name': 'approve', 'label': 'approve', 'description': 'Approve a character ticket.'},
+            {'name': 'update', 'label': 'update', 'description': 'Post a sheet update to #player-character-sheets.'},
+            {'name': 'edit', 'label': 'edit', 'description': "Edit a character's clan/sect/age."},
+            {'name': 'delete', 'label': 'delete', 'description': 'Hard-delete a character with no history.'},
+            {'name': 'broadcast', 'label': 'broadcast', 'description': 'Send a staff message to cubbies/announcements/a channel.'},
+            {'name': 'sync-cubbies', 'label': 'sync-cubbies', 'description': 'Scan cubby channels, backfill IDs, retire missing cubbies.'},
+            {'name': 'scan-activity', 'label': 'scan-activity', 'description': 'Backfill Discord post counts for IC nights.'},
+            {'name': 'cancel-scan', 'label': 'cancel-scan', 'description': 'Cancel a running scan-activity backfill.'},
+            {'name': 'coterie-create', 'label': 'coterie-create', 'description': 'Activate a coterie and post the setup link.'},
+            {'name': 'blank', 'label': 'blank', 'description': 'Blank a tracked background for one night.'},
+            {'name': 'permissions.audit', 'label': 'permissions audit', 'description': 'Read-only mention/overwrite/visibility scan.'},
+            {'name': 'permissions.apply', 'label': 'permissions apply', 'description': 'Administrator-only: fix + snapshot.'},
+            {'name': 'permissions.rollback', 'label': 'permissions rollback', 'description': 'Administrator-only: restore a prior snapshot.'},
+        ],
+    },
+    {
+        'name': 'deliver',
+        'label': '/deliver',
+        'description': 'Hand-deliver an in-character letter to #kindred-delivery.',
+        'subcommands': [],
+    },
+    {
+        'name': 'contact',
+        'label': '/contact',
+        'description': 'Text messages between characters via #kindred-contact.',
+        'subcommands': [
+            {'name': 'send', 'label': 'send', 'description': 'Start a new conversation.'},
+            {'name': 'reply', 'label': 'reply', 'description': 'Reply to an existing conversation.'},
+        ],
+    },
+    {
+        'name': 'prestation',
+        'label': '/prestation',
+        'description': 'Boon ledger for #prestation.',
+        'subcommands': [
+            {'name': 'owe', 'label': 'owe', 'description': 'Record that another character owes you a boon.'},
+            {'name': 'status', 'label': 'status', 'description': 'See boons owed to you and boons you owe.'},
+            {'name': 'repay', 'label': 'repay', 'description': 'Propose or confirm repayment of a boon.'},
+        ],
+    },
+    {
+        'name': 'post',
+        'label': '/post',
+        'description': 'In-character social media post to #social-media.',
+        'subcommands': [],
+    },
+    {
+        'name': 'cobweb',
+        'label': '/cobweb',
+        'description': 'Malkavian Cobweb broadcast to #reach-out-and-touch-mind.',
+        'subcommands': [],
+    },
+    {
+        'name': 'rumor',
+        'label': '/rumor',
+        'description': 'Post a rumor to #rumors using the standard template.',
+        'subcommands': [],
+    },
+]
+
+
+def flattened_tokens() -> set[str]:
+    """All valid tokens (command names and dotted subcommand tokens)."""
+    tokens: set[str] = set()
+    for command in BOT_COMMAND_CATALOG:
+        tokens.add(command['name'])
+        for sub in command['subcommands']:
+            tokens.add(f"{command['name']}.{sub['name']}")
+    return tokens

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -799,6 +799,79 @@
     </div>
   </div>
 
+  {# Bot — Commands #}
+  <h5 class="mb-2 mt-2">
+    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
+            style="font-size:0.75rem; letter-spacing:0.05em;"
+            data-bs-toggle="collapse" data-bs-target="#section-bot-commands" aria-expanded="false">
+      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
+      Bot — Commands
+    </button>
+  </h5>
+  <div class="collapse mb-4" id="section-bot-commands">
+    <p class="text-muted small mb-2">
+      Turn any Discord command (or individual subcommand) off without a redeploy. Staff (BOT_TESTER_IDS) can still
+      run a disabled command themselves; everyone else gets a polite "disabled" reply. Disabling a whole command
+      disables all of its subcommands too. Changes apply to the bot within 1 minute — the command still appears
+      in Discord's picker either way, it just won't run for non-staff users while off.
+    </p>
+    <div class="card">
+      <div class="card-body p-0">
+        <table class="table table-dark table-sm mb-0 align-middle">
+          <thead>
+            <tr>
+              <th style="width:260px">Command</th>
+              <th style="width:140px">Status</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for cmd in bot_commands %}
+            <tr>
+              <td class="fw-semibold">{{ cmd.label }}</td>
+              <td>
+                {% if can_edit %}
+                <form method="POST" action="{{ url_for('settings.toggle_bot_command') }}" class="mb-0">
+                  <input type="hidden" name="token" value="{{ cmd.token }}">
+                  <input type="hidden" name="action" value="{{ 'enable' if cmd.disabled else 'disable' }}">
+                  <button type="submit" class="btn btn-sm {% if cmd.disabled %}btn-outline-secondary{% else %}btn-success{% endif %}" style="min-width:90px">
+                    {% if cmd.disabled %}<i class="bi bi-toggle-off"></i> OFF{% else %}<i class="bi bi-toggle-on"></i> ON{% endif %}
+                  </button>
+                </form>
+                {% else %}
+                  {% if cmd.disabled %}<span class="badge bg-secondary">Disabled</span>{% else %}<span class="badge bg-success">Enabled</span>{% endif %}
+                {% endif %}
+              </td>
+              <td class="text-muted small">{{ cmd.description }}</td>
+            </tr>
+            {% for sub in cmd.subcommands %}
+            <tr>
+              <td class="text-muted small ps-4">↳ {{ sub.label }}</td>
+              <td>
+                {% if can_edit %}
+                <form method="POST" action="{{ url_for('settings.toggle_bot_command') }}" class="d-flex align-items-center gap-1 mb-0">
+                  <input type="hidden" name="token" value="{{ sub.token }}">
+                  <input type="hidden" name="action" value="{{ 'enable' if sub.own_disabled else 'disable' }}">
+                  <button type="submit" class="btn btn-sm {% if sub.disabled %}btn-outline-secondary{% else %}btn-success{% endif %}"
+                          style="min-width:90px" {% if cmd.disabled and not sub.own_disabled %}disabled{% endif %}>
+                    {% if sub.disabled %}<i class="bi bi-toggle-off"></i> OFF{% else %}<i class="bi bi-toggle-on"></i> ON{% endif %}
+                  </button>
+                  {% if sub.inherited %}<span class="badge bg-secondary ms-1" title="Disabled via the master switch above">via master</span>{% endif %}
+                </form>
+                {% else %}
+                  {% if sub.disabled %}<span class="badge bg-secondary">Disabled</span>{% else %}<span class="badge bg-success">Enabled</span>{% endif %}
+                {% endif %}
+              </td>
+              <td class="text-muted small">{{ sub.description }}</td>
+            </tr>
+            {% endfor %}
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
 </div>
 
 {% if wiki_sync.requested or (wiki_sync.status == 'running' and not wiki_sync.is_stale) %}

--- a/apps/web/tests/test_settings_bot_commands.py
+++ b/apps/web/tests/test_settings_bot_commands.py
@@ -1,0 +1,129 @@
+"""Tests for the per-command/subcommand kill-switch toggles on the Settings page."""
+
+from datetime import timedelta
+from pathlib import Path
+
+from flask import Blueprint, Flask
+
+from app.blueprints.settings import bp as settings_bp
+from app.db import AppSetting, db
+
+_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
+_STATIC_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
+
+
+def _stub_bp(name: str, prefix: str, routes: dict[str, str]) -> Blueprint:
+    bp = Blueprint(name, __name__, url_prefix=prefix)
+    for rule, fn_name in routes.items():
+        bp.add_url_rule(rule, fn_name, lambda **_: ('', 200))
+    return bp
+
+
+def _app():
+    app = Flask(__name__, template_folder=_TEMPLATE_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.secret_key = 'test-secret'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SETTINGS_ADMIN_DISCORD_IDS'] = {'12345'}
+    app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(hours=12)
+    app.jinja_env.globals['csrf_token'] = lambda: 'test-csrf'
+    db.init_app(app)
+    app.register_blueprint(_stub_bp('dashboard', '/', {'/': 'index', '/login': 'login', '/logout': 'logout'}))
+    app.register_blueprint(_stub_bp('claims', '/claims', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('spends', '/spends', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('roster', '/roster', {'/': 'list_characters'}))
+    app.register_blueprint(_stub_bp('periods', '/periods', {'/': 'list_periods'}))
+    app.register_blueprint(_stub_bp('audit', '/audit', {'/': 'log', '/errors': 'errors'}))
+    app.register_blueprint(_stub_bp('player', '/player', {'/': 'my_characters'}))
+    app.register_blueprint(_stub_bp('wiki', '/wiki', {'/': 'index'}))
+    app.register_blueprint(_stub_bp('cc_admin', '/cc-admin', {'/loresheets': 'loresheet_list', '/drafts': 'draft_list', '/drafts/<int:draft_id>': 'draft_review'}))
+    app.register_blueprint(_stub_bp('coteries', '/coteries', {'/': 'index'}))
+    app.register_blueprint(settings_bp, url_prefix='/settings')
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _set_session(client, discord_id: str):
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['discord_id'] = discord_id
+        sess['discord_name'] = 'Tester'
+        sess['staff_user'] = 'Tester'
+
+
+def _disabled_value(app: Flask) -> str:
+    with app.app_context():
+        record = db.session.get(AppSetting, 'BOT_DISABLED_COMMANDS')
+        return record.value if record else ''
+
+
+def test_disable_subcommand_adds_token_for_admin():
+    app = _app()
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post('/settings/commands/toggle', data={'token': 'xp.submit', 'action': 'disable'})
+        assert res.status_code == 302
+
+    assert _disabled_value(app) == 'xp.submit'
+
+
+def test_enable_removes_token():
+    app = _app()
+    with app.app_context():
+        db.session.merge(AppSetting(key='BOT_DISABLED_COMMANDS', value='xp.submit,cobweb', updated_by='test'))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post('/settings/commands/toggle', data={'token': 'xp.submit', 'action': 'enable'})
+        assert res.status_code == 302
+
+    assert _disabled_value(app) == 'cobweb'
+
+
+def test_disable_whole_command_token():
+    app = _app()
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post('/settings/commands/toggle', data={'token': 'lasombra', 'action': 'disable'})
+        assert res.status_code == 302
+
+    assert _disabled_value(app) == 'lasombra'
+
+
+def test_unknown_token_is_rejected():
+    app = _app()
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post('/settings/commands/toggle', data={'token': 'not-a-real-command', 'action': 'disable'})
+        assert res.status_code == 302
+
+    assert _disabled_value(app) == ''
+
+
+def test_denied_for_non_admin():
+    app = _app()
+    with app.test_client() as client:
+        _set_session(client, '99999')
+        res = client.post('/settings/commands/toggle', data={'token': 'xp.submit', 'action': 'disable'})
+        assert res.status_code == 302
+
+    assert _disabled_value(app) == ''
+
+
+def test_settings_index_renders_bot_commands_section():
+    app = _app()
+    with app.app_context():
+        db.session.merge(AppSetting(key='BOT_DISABLED_COMMANDS', value='xp.submit', updated_by='test'))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.get('/settings/')
+        assert res.status_code == 200
+        body = res.get_data(as_text=True)
+        assert 'Bot — Commands' in body
+        assert '/xp' in body
+        assert 'submit' in body

--- a/compose.bot-dev.yml
+++ b/compose.bot-dev.yml
@@ -1,6 +1,6 @@
 services:
   bot-dev:
-    container_name: lasombra-dev
+    container_name: zapathasura
     build:
       context: ./apps/bot
       dockerfile: Dockerfile

--- a/docs/RUN_BOT_DEV.md
+++ b/docs/RUN_BOT_DEV.md
@@ -1,0 +1,77 @@
+# Run a Dev/Test Discord Bot
+
+Use this when you want to exercise bot features (especially the [Correspondence
+commands](./API_ENDPOINTS.md) — `/deliver`, `/contact`, `/prestation`, `/post`,
+`/cobweb`, `/rumor`) against a separate test Discord server and the dev web
+dashboard, without touching production data or the live server.
+
+This is a second, independent bot process — a different Discord application,
+pointed at a different guild and a different web backend. It runs alongside
+(never instead of) the production Lasombra bot; nothing here changes how
+production is deployed or run.
+
+## Why a separate bot, not just a test channel in the main server
+
+Several Correspondence commands are inherently multi-party — a `/contact`
+group text, or `/prestation`'s two-step debtor-proposes/creditor-confirms
+repayment — and can't be fully verified by one person testing solo. A
+dedicated test guild also means slash commands can be registered
+guild-scoped (see `TEST_GUILD_ID` below), which applies changes instantly
+instead of waiting up to an hour for global command propagation.
+
+## 1) Configure env
+
+```bash
+cd apps/bot
+cp .env.dev.example .env.dev
+```
+
+Populate `apps/bot/.env.dev`:
+
+- `BOT_TOKEN` / `CLIENT_ID` — the dev bot's own Discord application, **not**
+  production Lasombra's.
+- `TEST_GUILD_ID` — the test server's guild ID.
+- `WEB_APP_BASE_URL`, `WEB_APP_API_READ_TOKEN`, `WEB_APP_API_WRITE_TOKEN` —
+  point these at the **dev** web dashboard, not production, so nothing here
+  can write real player data.
+- Any other vars a feature you're testing needs (staff role IDs, other
+  feature flags) — copy from `.env.example` as needed. `.env.dev` is a
+  minimal overlay, not a full copy of `.env.example`.
+
+## 2) Create the test channels
+
+```bash
+npm run ops:setup-test-channels
+```
+
+Creates a "Correspondence (Test)" category and the six channels the
+Correspondence commands post to (reusing any that already exist by name), and
+prints the six `CORRESPONDENCE_*_CHANNEL_ID` lines — paste them into
+`.env.dev`.
+
+## 3) Link test characters to real Discord accounts
+
+Several flows (group texts, boon repayment, reply-notifies-others) need more
+than one real, distinct Discord account with a linked active character on the
+**dev** web dashboard. Recruit a player or two to sit in the test server for
+this — one account can't exercise "does the creditor's confirmation actually
+require a different person than the debtor" on its own.
+
+## 4) Run the dev bot
+
+```bash
+npm run dev:test-guild
+```
+
+This loads `.env.dev` (via `DOTENV_CONFIG_PATH`) instead of `.env`, and
+registers commands guild-scoped to `TEST_GUILD_ID` — changes to command
+definitions show up in the test server within seconds, not up to an hour.
+
+## Notes
+
+- `.env.dev` is gitignored — never commit it (same rule as `.env`).
+- This is a plain local process (`tsx src/index.ts`), not a Docker profile —
+  simpler to iterate on, and nothing here needs the container logging/restart
+  guarantees the production Docker setup exists for. See
+  [`RUN_BOT_DOCKER.md`](./RUN_BOT_DOCKER.md) if you want the dev bot
+  containerized too; point its env file at `.env.dev` instead of `.env`.

--- a/docs/RUN_BOT_DEV.md
+++ b/docs/RUN_BOT_DEV.md
@@ -31,9 +31,14 @@ Populate `apps/bot/.env.dev`:
 - `BOT_TOKEN` / `CLIENT_ID` — the dev bot's own Discord application, **not**
   production Lasombra's.
 - `TEST_GUILD_ID` — the test server's guild ID.
-- `WEB_APP_BASE_URL`, `WEB_APP_API_READ_TOKEN`, `WEB_APP_API_WRITE_TOKEN` —
-  point these at the **dev** web dashboard, not production, so nothing here
-  can write real player data.
+- `WEB_APP_BASE_URL` — point this at the **dev** web dashboard, not
+  production, so nothing here can write real player data.
+- `WEB_APP_API_TOKEN` — a shared secret you invent (e.g.
+  `openssl rand -hex 32`), set to the same value here and as
+  `WEB_APP_API_TOKEN` in the dev web app's own `.env`. It's not issued by
+  anything — it's just a password the bot and web app agree on. Grants both
+  read and write; the separate `WEB_APP_API_READ_TOKEN`/
+  `WEB_APP_API_WRITE_TOKEN` are optional scoped alternatives, not needed here.
 - Any other vars a feature you're testing needs (staff role IDs, other
   feature flags) — copy from `.env.example` as needed. `.env.dev` is a
   minimal overlay, not a full copy of `.env.example`.


### PR DESCRIPTION
## Summary

Web-side foundation from #327 is merged; this PR is the complete bot-side follow-up plus infrastructure that came out of testing it. All six Correspondence commands, dev-bot test scaffolding, and — most recently — per-command/subcommand kill switches on the dashboard landed here across several commits.

- **`TrackerAdapter`/`WebAppAdapter`** (`services/adapter.ts`): all six new methods — `createBoon`, `getBoonsForCharacter`, `actOnBoonRepay`, `createContactThread`, `getContactThreadsForCharacter`, `replyToContactThread` — calling the six endpoints from #327, mirroring the existing `blankBackground`/`getCoterieForCharacter` conventions (write-auth headers + `X-Request-Timestamp`/`X-Request-Nonce` on mutating calls, `{ok, message}` non-throwing return shape for writes, `null` on 404 for reads).
- **`services/characterOwnership.ts`** (new): `resolveOwnedCharacter(adapter, discordUserId, requestedCharacter?)` — extracts the 0/1/&gt;1-owned-character resolution logic duplicated inline elsewhere (e.g. `/lasombra blank`) into one helper every command below reuses.
- **`/deliver`** — hand-delivers a letter to `#kindred-delivery`. One-shot, no reply/threading. Gold/parchment embed, now with an @-mention to the recipient at creation time.
- **`/contact send|reply`** — thread-tracked, multi-recipient text messages to `#kindred-contact`. `send` starts a conversation (deduped recipients), `reply` continues an existing thread via an autocomplete thread-picker and mentions every other participant except the replier. Restyled as a text-bubble embed with an in-medium **Reply** button that jumps straight to the reply modal (resolved by thread membership, not by requiring exactly one linked character).
- **`/prestation owe|status|repay`** — the boon ledger. `owe` creates a boon, posts publicly to `#prestation`, and now @-mentions the debtor; `status` lists a character's boons both directions (ephemeral); `repay` advances the two-step debtor-proposes/creditor-confirms lifecycle — one subcommand handles both steps since the API response tells the bot which step just happened.
- **`/post`** — generic in-character social media post to `#social-media`, optional custom handle defaulting to the character name. Restyled + Reply button.
- **`/cobweb`** — Malkavian Cobweb telepathic broadcast to `#reach-out-and-touch-mind`. Trust-based per the earlier scope decision — no discipline check, since the bot has no discipline data to check against. Restyled as a whisper + Reply button.
- **`/rumor`** — reproduces the staff-provided template exactly, as plain message content (not an embed) to avoid reformatting the markdown. Rumor text auto-wrapped in spoiler tags; Location line omitted entirely when blank; Point of Contact resolves to a real `@mention` when a source-character with a linked Discord account is given, otherwise falls back to typed free text (e.g. an investigation-roll DC).
- Six `CORRESPONDENCE_*_CHANNEL_ID` config vars in `config.ts`/`.env.example`, all optional — any command whose channel isn't set replies with an ephemeral "not configured" error instead of posting nowhere/wrong, matching the honeypot/mention-breaker disabled-by-default posture.

### Dev-bot test scaffolding

`.env.dev.example`, `ops:setup-test-channels` (creates the 6 test channels in a target guild and prints their IDs), `dev:test-guild` npm script, and `docs/RUN_BOT_DEV.md` — lets a second, independent bot process run against a dedicated test Discord server + the dev web dashboard, so multi-party flows (group texts, boon two-step repay) can be exercised with real distinct Discord accounts before anything ships live. Also fixes the dev Cloud Run deploy workflow, which was silently reverting `WEB_APP_API_TOKEN` back to prod's secret on every dev deploy.

### Bugfix

`RetirementAutomationWorker.tick()` was missing a top-level `catch` (unlike every other periodic worker in this codebase) — an API failure (e.g. an auth mismatch, as hit during dev-bot testing) crashed the entire bot process instead of logging and retrying.

### Per-command/subcommand kill switches (new)

Surfaced while writing staff docs: some commands (`/xp submit` in particular) were assumed disabled but were actually still fully live. Added a general dashboard-driven on/off switch for every command and, where applicable, every individual subcommand:

- New `BOT_DISABLED_COMMANDS` DB setting (CSV of dot-joined tokens, e.g. `xp.submit`, `lasombra.permissions.apply`), following the exact existing DB-backed live-flag pattern (`AppSetting` + `/api/bot-config` + `configSyncWorker`) already used for every other toggle.
- New Settings page section ("Bot — Commands") with a master toggle per command and nested per-subcommand toggles, backed by a new `POST /settings/commands/toggle` route and a hand-maintained catalog (`app/bot_commands_catalog.py`).
- Bot-side gating is centralized in `index.ts`'s `interactionCreate` handler (one check, before `execute`/`autocomplete`) rather than touching all 11 command files. Staff (`BOT_TESTER_IDS`) always bypass; everyone else gets an ephemeral "This command is currently disabled by staff." reply.
- **Known limitation**: Discord's Application Command Permissions v2 API — the only way to truly hide a command from the picker for some users but not others — cannot be called with a bot token (requires a user-authorized OAuth Bearer token). Disabled commands therefore remain visible in the Discord picker; they're blocked at execution time instead. Flagged in the plan file, not blocking.

## Checklist

- [x] Tests added/updated where appropriate (7 new bot test files for the correspondence commands — 79 tests — plus reply-button coverage and a new `commandGating.test.ts` for the kill switches; bot suite is now 229 tests, up from 151).
- [x] `./venv/bin/pytest -q` passes locally (204 tests, including new `test_settings_bot_commands.py` for the toggle route)
- [x] Docs updated (`.env.example`/`.env.dev.example` document the channel-ID vars; `docs/RUN_BOT_DEV.md` new; `CLAUDE.md` links it)
- [x] No secrets/tokens included in code, logs, or screenshots

## Validation

- `npm run lint && npm run format:check && npm run typecheck && npm run test && npm run build` in `apps/bot` — all pass, 229/229 tests.
- `./venv/bin/pytest -q` in `apps/web` — all pass, 204/204 tests.
- `/rumor`'s template output is asserted byte-for-byte against the staff-provided format, including the blank-Location-omits-the-line and mention-vs-typed-text Point of Contact behaviors.

## Risks / Rollback

- Known risks: none — every Correspondence command is disabled by default until its `CORRESPONDENCE_*_CHANNEL_ID` is set. Kill switches default to nothing disabled (no behavior change until staff explicitly flips one off). No existing command's core logic is modified, only gated.
- Rollback plan: revert this PR; the underlying web endpoints from #327 are inert without a bot command calling them, and the kill-switch DB setting has no effect if unset.

## Follow-up (explicitly out of scope here)

- Locking down raw `Send Messages` permissions in these six channels once the commands are proven in real use — a separate, later pass.
- True per-user hiding of disabled commands from the Discord picker would require a one-time OAuth consent flow per guild admin — not built here, see "Known limitation" above.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129V5Kt7zKu5Vjsxm958Q35)_