### PR TITLE
Require Mortal/Ghoul/Kindred or staff role to use the bot at all

### DIFF
--- a/apps/bot/src/__tests__/roleGate.test.ts
+++ b/apps/bot/src/__tests__/roleGate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { memberHasAnyRole, requiredRoleIds } from '../services/roleGate';
+
+describe('requiredRoleIds', () => {
+  it('includes only the configured (non-empty) role IDs', () => {
+    const ids = requiredRoleIds({
+      passageOfTimeMortalRoleId: 'mortal',
+      passageOfTimeGhoulRoleId: '',
+      passageOfTimeKindredRoleId: undefined,
+      staffRoleSystemHelperId: 'helper',
+      staffRoleStorytellerId: 'st',
+      staffRoleModeratorId: 'mod',
+      staffRoleAdministratorId: 'admin',
+    });
+    expect(ids).toEqual(['mortal', 'helper', 'st', 'mod', 'admin']);
+  });
+
+  it('returns an empty list when nothing is configured', () => {
+    expect(requiredRoleIds({})).toEqual([]);
+  });
+});
+
+describe('memberHasAnyRole', () => {
+  const roleIds = ['mortal', 'ghoul', 'kindred', 'admin'];
+
+  it('is false for a null/undefined member (e.g. DM context)', () => {
+    expect(memberHasAnyRole(null, roleIds)).toBe(false);
+    expect(memberHasAnyRole(undefined, roleIds)).toBe(false);
+  });
+
+  it('is false when there are no required role IDs at all', () => {
+    const member = { roles: ['mortal'] };
+    expect(memberHasAnyRole(member, [])).toBe(false);
+  });
+
+  it('checks a raw interaction member (roles as a plain string array)', () => {
+    expect(memberHasAnyRole({ roles: ['mortal'] }, roleIds)).toBe(true);
+    expect(memberHasAnyRole({ roles: ['some-other-role'] }, roleIds)).toBe(false);
+  });
+
+  it('checks a cached GuildMember (roles.cache.has)', () => {
+    const cachedMember = { roles: { cache: { has: (id: string) => id === 'admin' } } };
+    expect(memberHasAnyRole(cachedMember, roleIds)).toBe(true);
+
+    const unmatchedMember = { roles: { cache: { has: () => false } } };
+    expect(memberHasAnyRole(unmatchedMember, roleIds)).toBe(false);
+  });
+});

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -35,6 +35,7 @@ import { handlePostModal, handlePostReplyButton } from './commands/post';
 import { handleCobwebModal, handleCobwebReplyButton } from './commands/cobweb';
 import { handleRumorModal } from './commands/rumor';
 import { buildDisableTokens, isAnyTokenDisabled } from './services/commandGating';
+import { memberHasAnyRole, requiredRoleIds } from './services/roleGate';
 import {
   handleApproveWizardStringSelect,
   handleApproveWizardButton,
@@ -381,6 +382,8 @@ void applyStartupConfigOverrides().then(() => {
     startMentionSpamBreaker(client);
   });
 
+  const accessRoleIds = requiredRoleIds(config);
+
   client.on('interactionCreate', async (interaction) => {
   const baseMeta = {
     interactionId: interaction.id,
@@ -390,6 +393,19 @@ void applyStartupConfigOverrides().then(() => {
   };
 
   try {
+    if (!config.testerDiscordIds.has(interaction.user.id) && !memberHasAnyRole(interaction.member, accessRoleIds)) {
+      logEvent('info', 'interaction_blocked_unverified_role', baseMeta);
+      if (interaction.isAutocomplete()) {
+        await interaction.respond([]);
+      } else if (interaction.isRepliable()) {
+        await interaction.reply({
+          content: 'You need an approved character (Mortal, Ghoul, or Kindred) or a staff role to use this bot.',
+          ephemeral: true,
+        });
+      }
+      return;
+    }
+
     if (interaction.isAutocomplete()) {
       const cmd = client.commands.get(interaction.commandName);
       if (!cmd?.autocomplete) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -383,6 +383,9 @@ void applyStartupConfigOverrides().then(() => {
   });
 
   const accessRoleIds = requiredRoleIds(config);
+  if (accessRoleIds.length === 0) {
+    logEvent('warn', 'access_gate_misconfigured_no_role_ids', {});
+  }
 
   client.on('interactionCreate', async (interaction) => {
   const baseMeta = {
@@ -393,6 +396,9 @@ void applyStartupConfigOverrides().then(() => {
   };
 
   try {
+    // interaction.member is null for DM-context interactions — denied by
+    // memberHasAnyRole, which is intentional: correspondence/RP commands
+    // are guild-only, so DM usage has no legitimate case here.
     if (!config.testerDiscordIds.has(interaction.user.id) && !memberHasAnyRole(interaction.member, accessRoleIds)) {
       logEvent('info', 'interaction_blocked_unverified_role', baseMeta);
       if (interaction.isAutocomplete()) {

--- a/apps/bot/src/services/roleGate.ts
+++ b/apps/bot/src/services/roleGate.ts
@@ -1,0 +1,41 @@
+/**
+ * Bot-wide access gate: an interaction may only be handled if the invoking
+ * member holds a player-status role (Mortal, Ghoul, Kindred) or a staff role
+ * (System Helper, Storyteller, Moderator, Administrator). Blocks unverified
+ * accounts (e.g. spammers who just joined) from using any bot command,
+ * button, modal, or autocomplete. Staff (config.testerDiscordIds) always
+ * bypass, matching the existing kill-switch convention in commandGating.ts.
+ */
+
+type RoleCollectionMember = { roles: { cache: { has(id: string): boolean } } };
+type RawInteractionMember = { roles: string[] };
+export type RoleCheckableMember = RoleCollectionMember | RawInteractionMember | null | undefined;
+
+export function requiredRoleIds(config: {
+  passageOfTimeMortalRoleId?: string | null;
+  passageOfTimeGhoulRoleId?: string | null;
+  passageOfTimeKindredRoleId?: string | null;
+  staffRoleSystemHelperId?: string | null;
+  staffRoleStorytellerId?: string | null;
+  staffRoleModeratorId?: string | null;
+  staffRoleAdministratorId?: string | null;
+}): string[] {
+  return [
+    config.passageOfTimeMortalRoleId,
+    config.passageOfTimeGhoulRoleId,
+    config.passageOfTimeKindredRoleId,
+    config.staffRoleSystemHelperId,
+    config.staffRoleStorytellerId,
+    config.staffRoleModeratorId,
+    config.staffRoleAdministratorId,
+  ].filter((id): id is string => Boolean(id));
+}
+
+export function memberHasAnyRole(member: RoleCheckableMember, roleIds: string[]): boolean {
+  if (!member || roleIds.length === 0) return false;
+  const roles = member.roles;
+  if (Array.isArray(roles)) {
+    return roleIds.some((id) => roles.includes(id));
+  }
+  return roleIds.some((id) => roles.cache.has(id));
+}


### PR DESCRIPTION
## Summary
Blocks spammers and unverified new-server-joins from using the bot at all — not just the Correspondence commands. Every interaction (slash commands, buttons, modals, autocomplete) now requires the invoking member to hold a player-status role (Mortal, Ghoul, Kindred — granted on character approval) or a staff role (System Helper, Storyteller, Moderator, Administrator). Everyone else gets a clear ephemeral rejection (or an empty autocomplete list, matching the existing kill-switch convention). Staff (`BOT_TESTER_IDS`) always bypass, consistent with every other gate in this codebase.

No new Discord-side setup needed — reuses role IDs that are already configured in prod:
- `PASSAGE_OF_TIME_{MORTAL,GHOUL,KINDRED}_ROLE_ID` (already used for passage-of-time pings)
- The four `STAFF_ROLE_*` IDs (already used for staff role sync)

## Changes
- `apps/bot/src/services/roleGate.ts` (new) — `requiredRoleIds()` collects the seven configured role IDs; `memberHasAnyRole()` checks a member against them, handling both a cached `GuildMember` (`roles.cache.has`) and a raw interaction-payload member (`roles: string[]`).
- `apps/bot/src/index.ts` — gate wired in at the very top of the single `interactionCreate` handler, before any dispatch branch (autocomplete/select/button/modal/chat-input), so buttons and modals — previously completely ungated — are now covered too. Also logs a startup warning if all role IDs are unset (misconfiguration would otherwise silently block everyone).
- `apps/bot/src/__tests__/roleGate.test.ts` (new) — unit tests for both member shapes plus null/empty edge cases.

## Security review
Ran an independent security-reviewer pass on this branch before opening the PR. Findings: clean, no blocking issues.
- Confirmed `interaction.member` is populated straight from Discord's authenticated `INTERACTION_CREATE` gateway payload (checked discord.js source) — not user-forgeable, and exactly as fresh as an explicit `guild.members.fetch()` call (the one prior-art usage in `permissionsWizard.ts` that does fetch is a defense-in-depth choice for a finer-grained, higher-privilege gate, not a requirement this coarser floor-check was missing).
- Confirmed there's exactly one `interactionCreate` listener and no alternate dispatch path (collectors, `awaitMessageComponent`, etc.) that could bypass the gate.
- Confirmed fail-closed behavior: null/missing member (DM context) and empty role config both correctly deny rather than accidentally allow.
- Two non-blocking suggestions from the review (startup warning on misconfiguration, a comment noting DM-denial is intentional) are included in this PR.

## Test plan
- [x] `npm run typecheck && npm run lint && npm run format:check && npm run test` in `apps/bot` — 235/235 pass
- [ ] On dev, confirm an account with no Mortal/Ghoul/Kindred/staff role gets blocked on a slash command, a button, and a modal; confirm a staff account and an approved-character account both pass through normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)