### PR TITLE
Warn staff on spend review when trait name doesn't match the sheet

### DIFF
--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -6,7 +6,7 @@ from flask import (
 from app import db_service, sheets_sync
 from app.auth import require_staff, get_staff_user
 from app.xp_rules import validate_spend_request
-from app.character_sheet import patch_character_draft
+from app.character_sheet import patch_character_draft, find_trait_sheet_match
 
 bp = Blueprint('spends', __name__)
 
@@ -48,6 +48,11 @@ def review(row_id):
     depends_on_spend = db_service.get_spend_by_row(spend.depends_on) if spend.depends_on else None
     dependents = db_service.get_spend_dependents(spend.row_index)
 
+    # Warn staff if the trait name doesn't exactly match an existing sheet
+    # entry — e.g. "Status" submitted when the sheet has "Status (Tremere)" —
+    # since approving as-is creates a stray duplicate instead of raising it.
+    sheet_match = find_trait_sheet_match(spend.character_name, spend.spend_category, spend.trait_name)
+
     return render_template(
         'spends/review.html',
         spend=spend,
@@ -55,6 +60,7 @@ def review(row_id):
         available_xp=available_xp,
         depends_on_spend=depends_on_spend,
         dependents=dependents,
+        sheet_match=sheet_match,
     )
 
 

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -42,21 +42,80 @@ def patch_character_draft(spend) -> bool:
         return False
 
 
-def _do_patch(spend) -> bool:
-    from app.db import db, CharacterDraft, DbCharacter, WikiPage
+def _find_approved_draft(character_name: str):
+    """Return the roster character's approved CharacterDraft row, or None."""
+    from app.db import CharacterDraft, DbCharacter
     from sqlalchemy import func
 
-    # Resolve roster character → draft
     char_row = DbCharacter.query.filter(
-        func.lower(DbCharacter.character_name) == spend.character_name.lower()
+        func.lower(DbCharacter.character_name) == character_name.lower()
     ).first()
     if not char_row:
-        return False
+        return None
 
-    draft = CharacterDraft.query.filter_by(
+    return CharacterDraft.query.filter_by(
         roster_character_id=char_row.id,
         status='approved',
     ).first()
+
+
+def _load_approved_sheet_data(character_name: str) -> dict | None:
+    """Load the character_data JSON off the roster character's approved draft.
+
+    Returns None if there's no roster character, no approved draft, or the
+    stored JSON doesn't parse — any of which just means there's nothing to
+    check/patch against.
+    """
+    draft = _find_approved_draft(character_name)
+    if not draft or not draft.character_data:
+        return None
+
+    try:
+        return json.loads(draft.character_data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def find_trait_sheet_match(character_name: str, category: str, trait_name: str) -> dict | None:
+    """Check a pending spend's trait name against the character's current sheet.
+
+    Only meaningful for 'Advantage (Merit/Background)': these are the traits
+    that can carry a parenthetical source (e.g. "Status (Tremere)"), so a
+    spend submitted as plain "Status" can silently miss an existing entry and
+    create a stray duplicate instead of raising it — the bug that hit Marcus.
+
+    Returns None if there's nothing to check (wrong category, no sheet, blank
+    trait name). Otherwise returns {'exact': bool, 'close_matches': [...]} —
+    close_matches lists existing entries whose name starts with trait_name
+    but isn't an exact match, e.g. trait_name="Status" surfaces an existing
+    "Status (Tremere)" entry as a likely-intended match.
+    """
+    if category != 'Advantage (Merit/Background)':
+        return None
+    trait_name = (trait_name or '').strip()
+    if not trait_name:
+        return None
+
+    data = _load_approved_sheet_data(character_name)
+    if data is None:
+        return None
+
+    key = trait_name.lower()
+    entries = list(data.get('backgrounds') or []) + list(data.get('merits') or [])
+    exact = any((e.get('name') or '').lower() == key for e in entries)
+    close_matches = [
+        {'name': e.get('name', ''), 'level': e.get('level', 0)}
+        for e in entries
+        if (e.get('name') or '').lower() != key and (e.get('name') or '').lower().startswith(key)
+    ]
+    return {'exact': exact, 'close_matches': close_matches}
+
+
+def _do_patch(spend) -> bool:
+    from app.db import db, WikiPage
+    from sqlalchemy import func
+
+    draft = _find_approved_draft(spend.character_name)
     if not draft or not draft.character_data:
         return False
 
@@ -156,12 +215,23 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         return True
 
     if category == 'Advantage (Merit/Background)':
-        merits = data.setdefault('merits', [])
-        for m in merits:
-            if m.get('name', '').lower() == trait_name.lower():
-                m['level'] = new_dots
-                return True
-        merits.append({
+        key = trait_name.lower()
+        # Schema v7+ splits Backgrounds (Status, Resources, Contacts, Haven,
+        # etc.) into their own array, separate from Merits — but both use the
+        # same entry shape (`type` is always 'merit', it's just stored under
+        # a different top-level key). Check both arrays for an existing entry
+        # before appending a new one, so raising an existing background
+        # doesn't create a stray duplicate in the wrong array.
+        for array_name in ('backgrounds', 'merits'):
+            items = data.get(array_name)
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if item.get('name', '').lower() == key:
+                    item['level'] = new_dots
+                    return True
+        target_array = 'backgrounds' if isinstance(data.get('backgrounds'), list) else 'merits'
+        data.setdefault(target_array, []).append({
             'name': trait_name,
             'level': new_dots,
             'summary': '',
@@ -259,8 +329,8 @@ def _generate_stats_markdown(data: dict) -> str:
         lines.append(', '.join(f'{r["name"]} (L{r.get("level", "?")})' for r in sorted(other_rituals, key=lambda r: r.get('level', 0))))
         lines.append('')
 
-    # Merits & Flaws
-    merits = data.get('merits', [])
+    # Merits & Flaws (schema v7+ keeps Backgrounds in a separate array)
+    merits = data.get('merits', []) + data.get('backgrounds', [])
     flaws = data.get('flaws', [])
     if merits:
         lines.append('**Merits & Backgrounds:** ' + ', '.join(f'{m["name"]} {_dots_str(m.get("level", 0))}' for m in merits))

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -230,8 +230,12 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
                 if item.get('name', '').lower() == key:
                     item['level'] = new_dots
                     return True
-        target_array = 'backgrounds' if isinstance(data.get('backgrounds'), list) else 'merits'
-        data.setdefault(target_array, []).append({
+        # No existing entry in either array — this is a genuinely new
+        # purchase. We can't reliably tell "new Background" from "new Merit"
+        # from the trait name alone without duplicating the character-app's
+        # full background-name catalog here (a maintenance/drift risk), so
+        # default to merits, matching this function's original behavior.
+        data.setdefault('merits', []).append({
             'name': trait_name,
             'level': new_dots,
             'summary': '',

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -1318,7 +1318,8 @@ document.addEventListener('DOMContentLoaded', function() {
             return null;
         }
         if (cat === 'Advantage (Merit/Background)') {
-            const merits = SHEET_DATA.merits || [];
+            // Schema v7+ keeps Backgrounds in a separate array from Merits.
+            const merits = (SHEET_DATA.backgrounds || []).concat(SHEET_DATA.merits || []);
             const m = merits.find(m => m.name && m.name.toLowerCase() === traitName.trim().toLowerCase());
             return m ? (m.level || 0) : null;
         }

--- a/apps/web/app/templates/spends/review.html
+++ b/apps/web/app/templates/spends/review.html
@@ -160,6 +160,27 @@
                 </div>
             </div>
 
+            <!-- Trait name mismatch warning -->
+            {% if sheet_match and not sheet_match.exact and sheet_match.close_matches %}
+            <div class="card mb-3 border-warning">
+                <div class="card-header bg-warning bg-opacity-25">
+                    <h6 class="mb-0"><i class="bi bi-exclamation-triangle"></i> No exact sheet match for "{{ spend.trait_name }}"</h6>
+                </div>
+                <div class="card-body">
+                    <p class="small text-muted mb-2">
+                        This character's sheet has no entry named exactly "{{ spend.trait_name }}". Approving as-is
+                        will create a <strong>new, separate</strong> entry rather than raising an existing one.
+                        Did they mean one of these?
+                    </p>
+                    <ul class="mb-0 small">
+                        {% for m in sheet_match.close_matches %}
+                        <li><strong>{{ m.name }}</strong> (currently {{ m.level }})</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- Approve -->
             <div class="card mb-3 border-success">
                 <div class="card-header bg-success bg-opacity-25">

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -65,13 +65,20 @@ def test_updates_existing_merit_entry_when_not_in_backgrounds():
     assert data['backgrounds'] == []
 
 
-def test_new_background_appends_to_backgrounds_array_when_it_exists():
+def test_new_entry_always_defaults_to_merits_even_when_backgrounds_array_exists():
+    """A genuinely new purchase (no existing entry in either array) can't be
+    reliably classified as Background vs. Merit from the name alone without
+    duplicating the character-app's full background catalog here — so it
+    always defaults to merits, matching this function's original behavior.
+    Regression guard for a bug caught in review: defaulting new entries to
+    'backgrounds' whenever that array happened to exist would misclassify
+    ordinary new merit purchases (e.g. Iron Will) as backgrounds instead."""
     data = {'backgrounds': [], 'merits': []}
-    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Contacts', '', 1)
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Iron Will', '', 1)
 
     assert patched is True
-    assert data['backgrounds'] == [{'name': 'Contacts', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}]
-    assert data['merits'] == []
+    assert data['merits'] == [{'name': 'Iron Will', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}]
+    assert data['backgrounds'] == []
 
 
 def test_new_entry_falls_back_to_merits_for_pre_v7_sheets_with_no_backgrounds_array():

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -1,0 +1,127 @@
+import json
+
+import pytest
+from flask import Flask
+
+import app as app_module
+from app.character_sheet import _apply_patch, find_trait_sheet_match
+from app.db import CharacterDraft, DbCharacter, db
+from app.db_service import DBService
+
+
+@pytest.fixture()
+def app_ctx():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        app_module.db_service = DBService()
+        yield app
+
+
+def _seed_approved_character(character_name: str, character_data: dict):
+    char = DbCharacter(character_name=character_name, active=True)
+    db.session.add(char)
+    db.session.flush()
+    draft = CharacterDraft(
+        player_discord_id='111111111111111111',
+        character_name=character_name,
+        status='approved',
+        roster_character_id=char.id,
+        character_data=json.dumps(character_data),
+    )
+    db.session.add(draft)
+    db.session.commit()
+
+
+def test_updates_existing_background_entry_not_merits():
+    """Regression test: approving a raise on an existing Background (e.g. Status)
+    must update the entry in data['backgrounds'], not create a stray duplicate
+    in data['merits'] — schema v7+ keeps them as separate arrays."""
+    data = {
+        'backgrounds': [{'name': 'Status', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+        'merits': [{'name': 'Iron Will', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    }
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Status', '', 2)
+
+    assert patched is True
+    assert data['backgrounds'] == [{'name': 'Status', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'}]
+    assert len(data['merits']) == 1
+    assert data['merits'][0]['name'] == 'Iron Will'
+
+
+def test_updates_existing_merit_entry_when_not_in_backgrounds():
+    data = {
+        'backgrounds': [],
+        'merits': [{'name': 'Iron Will', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    }
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Iron Will', '', 3)
+
+    assert patched is True
+    assert data['merits'][0]['level'] == 3
+    assert data['backgrounds'] == []
+
+
+def test_new_background_appends_to_backgrounds_array_when_it_exists():
+    data = {'backgrounds': [], 'merits': []}
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Contacts', '', 1)
+
+    assert patched is True
+    assert data['backgrounds'] == [{'name': 'Contacts', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}]
+    assert data['merits'] == []
+
+
+def test_new_entry_falls_back_to_merits_for_pre_v7_sheets_with_no_backgrounds_array():
+    data = {'merits': []}
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Iron Will', '', 1)
+
+    assert patched is True
+    assert data['merits'] == [{'name': 'Iron Will', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}]
+    assert 'backgrounds' not in data
+
+
+def test_find_trait_sheet_match_surfaces_close_match(app_ctx):
+    """Regression test for the Marcus bug: submitting "Status" against a sheet
+    that only has "Status (Tremere)" should be flagged as a likely mismatch."""
+    _seed_approved_character('Marcus', {
+        'merits': [{'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+
+    result = find_trait_sheet_match('Marcus', 'Advantage (Merit/Background)', 'Status')
+
+    assert result == {'exact': False, 'close_matches': [{'name': 'Status (Tremere)', 'level': 1}]}
+
+
+def test_find_trait_sheet_match_no_warning_on_exact_match(app_ctx):
+    _seed_approved_character('Marcus', {
+        'backgrounds': [{'name': 'Status', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+
+    result = find_trait_sheet_match('Marcus', 'Advantage (Merit/Background)', 'Status')
+
+    assert result == {'exact': True, 'close_matches': []}
+
+
+def test_find_trait_sheet_match_no_warning_for_genuinely_new_trait(app_ctx):
+    _seed_approved_character('Marcus', {
+        'merits': [{'name': 'Iron Will', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+
+    result = find_trait_sheet_match('Marcus', 'Advantage (Merit/Background)', 'Contacts')
+
+    assert result == {'exact': False, 'close_matches': []}
+
+
+def test_find_trait_sheet_match_ignored_for_other_categories(app_ctx):
+    _seed_approved_character('Marcus', {
+        'merits': [{'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+
+    assert find_trait_sheet_match('Marcus', 'Attribute', 'Status') is None
+
+
+def test_find_trait_sheet_match_none_when_no_approved_sheet(app_ctx):
+    assert find_trait_sheet_match('Nobody', 'Advantage (Merit/Background)', 'Status') is None


### PR DESCRIPTION
## Summary

Found while investigating a live report: Marcus's approved "Status to 2" spend applied correctly, but landed as a brand-new `Status` merit entry instead of raising his existing `Status (Tremere)` — the spend-approval code does an exact (case-insensitive) string match on trait name, and sourced traits (Status, Contacts, Influence, etc.) commonly carry a parenthetical the submitted trait name doesn't include. Nothing was silently dropped or failed to commit; the mismatch just created a sibling entry instead of updating the intended one. (Marcus's live data has already been manually corrected, with an audit_log entry recording why.)

## Changes

- **`app/character_sheet.py`**: fixes a related bug uncovered along the way — spend approval only ever patched `data['merits']`, never checking `data['backgrounds']` (the newer character-sheet schema splits Backgrounds like Status into their own array from Merits). Now checks both arrays for an existing entry before appending a new one.
- New `find_trait_sheet_match()` checks a pending spend's trait name against the character's current sheet and surfaces "close matches" — existing entries whose name starts with the submitted trait name (e.g. `"Status"` → `"Status (Tremere)"`). Scoped to the `'Advantage (Merit/Background)'` category, since that's specifically where source-qualified names cause this ambiguity.
- **`blueprints/spends.py` / `templates/spends/review.html`**: the spend review page now shows a warning card when the trait name doesn't exactly match anything on the sheet but a close match exists, so staff can catch it (fix the trait name and resubmit, or approve knowingly) *before* approving — rather than after, when it's already landed wrong.
- Same merits+backgrounds fix applied to the spend-request form's current-dots auto-fill in `player/character.html` (was also only reading `merits`).

## Test plan
- [x] New tests in `tests/test_character_sheet_patch.py` (9 total: 4 for the merits/backgrounds patch fix, 5 for `find_trait_sheet_match`) — all pass
- [x] `./venv/bin/pytest -q` — 213/213 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)