### PR TITLE
Add Server Health dashboard (30/60/90-day posting activity)

### DIFF
--- a/apps/web/app/activity_health.py
+++ b/apps/web/app/activity_health.py
@@ -86,12 +86,19 @@ def build_health_report(
     # characters, and posting once should count for all of them.
     active_by_player: dict[str, list[str]] = {}
     unlinked_characters: list[str] = []
+    # Roster's own known name for a player — the only source available for
+    # someone who's never posted, since display_names is only ever populated
+    # from activity the bot has actually observed.
+    roster_display_name: dict[str, str] = {}
     for char in active_characters:
         pid = (char.get('player_discord') or '').strip()
         if not pid:
             unlinked_characters.append(char['character_name'])
             continue
         active_by_player.setdefault(pid, []).append(char['character_name'])
+        name = (char.get('player_discord_name') or '').strip()
+        if name and pid not in roster_display_name:
+            roster_display_name[pid] = name
 
     posted_player_ids = set(active_by_player) & posted_discord_ids
     not_posted_player_ids = set(active_by_player) - posted_discord_ids
@@ -105,7 +112,7 @@ def build_health_report(
         (
             {
                 'discord_id': pid,
-                'display_name': display_names.get(pid, ''),
+                'display_name': display_names.get(pid) or roster_display_name.get(pid, ''),
                 'characters': sorted(active_by_player[pid]),
             }
             for pid in not_posted_player_ids

--- a/apps/web/app/activity_health.py
+++ b/apps/web/app/activity_health.py
@@ -1,0 +1,131 @@
+"""Server-health activity report: aggregates DiscordPostCount rows into the
+daily trend series, top-poster leaderboard, and participation stats behind
+the /reports/health dashboard.
+
+Pure functions on plain dicts/lists — no Flask/DB imports — so the
+aggregation logic is unit-testable without a database fixture.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+CATEGORIES = ('ic', 'ooc', 'rolls', 'cubby')
+
+
+def daterange(start: str, end: str) -> list[str]:
+    """Inclusive list of YYYY-MM-DD strings from start to end."""
+    start_d = datetime.strptime(start, '%Y-%m-%d').date()
+    end_d = datetime.strptime(end, '%Y-%m-%d').date()
+    days = (end_d - start_d).days
+    return [(start_d + timedelta(days=i)).isoformat() for i in range(days + 1)]
+
+
+def shift_window(start: str, end: str) -> tuple[str, str]:
+    """Return the immediately-preceding window of the same length."""
+    start_d = datetime.strptime(start, '%Y-%m-%d').date()
+    end_d = datetime.strptime(end, '%Y-%m-%d').date()
+    length = (end_d - start_d).days + 1
+    prev_end = start_d - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=length - 1)
+    return prev_start.isoformat(), prev_end.isoformat()
+
+
+def build_health_report(
+    rows: list[dict],
+    prev_rows: list[dict],
+    active_characters: list[dict],
+    display_names: dict[str, str],
+    start: str,
+    end: str,
+) -> dict:
+    """rows/prev_rows: [{'discord_id','date','category','count'}, ...]
+    active_characters: [{'character_name','player_discord'}, ...] — active roster.
+    """
+    days = daterange(start, end)
+
+    # ── Daily series (zero-filled for continuous chart axes) ──────────────
+    daily_by_cat: dict[str, dict[str, int]] = {d: {c: 0 for c in CATEGORIES} for d in days}
+    daily_posters: dict[str, set[str]] = {d: set() for d in days}
+    per_user_total: dict[str, int] = {}
+    posted_discord_ids: set[str] = set()
+
+    for row in rows:
+        date, cat, discord_id, count = row['date'], row['category'], row['discord_id'], row['count']
+        if date not in daily_by_cat or cat not in CATEGORIES or count <= 0:
+            continue
+        daily_by_cat[date][cat] += count
+        daily_posters[date].add(discord_id)
+        per_user_total[discord_id] = per_user_total.get(discord_id, 0) + count
+        posted_discord_ids.add(discord_id)
+
+    daily_totals = [sum(daily_by_cat[d].values()) for d in days]
+    daily_unique_posters = [len(daily_posters[d]) for d in days]
+
+    period_by_category = {c: sum(daily_by_cat[d][c] for d in days) for c in CATEGORIES}
+    period_total = sum(period_by_category.values())
+
+    prev_total = sum(r['count'] for r in prev_rows if r['category'] in CATEGORIES and r['count'] > 0)
+    if prev_total > 0:
+        delta_pct = round((period_total - prev_total) / prev_total * 100)
+    elif period_total > 0:
+        delta_pct = None  # no prior baseline to compare against
+    else:
+        delta_pct = 0
+
+    leaderboard = sorted(
+        (
+            {'discord_id': did, 'display_name': display_names.get(did, ''), 'total': total}
+            for did, total in per_user_total.items()
+        ),
+        key=lambda r: -r['total'],
+    )
+
+    # ── Participation: active players who did/didn't post in the window ───
+    # Dedup by player, not by character — one player can own several active
+    # characters, and posting once should count for all of them.
+    active_by_player: dict[str, list[str]] = {}
+    unlinked_characters: list[str] = []
+    for char in active_characters:
+        pid = (char.get('player_discord') or '').strip()
+        if not pid:
+            unlinked_characters.append(char['character_name'])
+            continue
+        active_by_player.setdefault(pid, []).append(char['character_name'])
+
+    posted_player_ids = set(active_by_player) & posted_discord_ids
+    not_posted_player_ids = set(active_by_player) - posted_discord_ids
+
+    participation_pct = (
+        round(len(posted_player_ids) / len(active_by_player) * 100)
+        if active_by_player else 0
+    )
+
+    not_posting = sorted(
+        (
+            {
+                'discord_id': pid,
+                'display_name': display_names.get(pid, ''),
+                'characters': sorted(active_by_player[pid]),
+            }
+            for pid in not_posted_player_ids
+        ),
+        key=lambda r: r['characters'][0].lower() if r['characters'] else '',
+    )
+
+    return {
+        'days': days,
+        'daily_totals': daily_totals,
+        'daily_unique_posters': daily_unique_posters,
+        'daily_by_category': {c: [daily_by_cat[d][c] for d in days] for c in CATEGORIES},
+        'period_total': period_total,
+        'period_by_category': period_by_category,
+        'delta_pct': delta_pct,
+        'unique_posters': len(posted_discord_ids),
+        'leaderboard': leaderboard[:15],
+        'active_player_count': len(active_by_player),
+        'posted_player_count': len(posted_player_ids),
+        'participation_pct': participation_pct,
+        'not_posting': not_posting,
+        'unlinked_character_count': len(unlinked_characters),
+    }

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import csv
 import io
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, flash, redirect, render_template, request, session, url_for
 
+from app.activity_health import build_health_report, shift_window
 from app.auth import require_staff
 from app.db import (
     DbCharacter,
@@ -269,4 +270,73 @@ def activity_csv():
         buf.getvalue(),
         mimetype='text/csv',
         headers={'Content-Disposition': 'attachment; filename="discord_activity.csv"'},
+    )
+
+
+HEALTH_RANGE_OPTIONS = (30, 60, 90)
+
+
+@bp.route('/reports/health')
+@require_staff
+def health():
+    """Server-health dashboard: posting trend, participation, and a
+    "who hasn't posted" list over a rolling 30/60/90-day window."""
+    try:
+        range_days = int(request.args.get('range', 30))
+    except (TypeError, ValueError):
+        range_days = 30
+    if range_days not in HEALTH_RANGE_OPTIONS:
+        range_days = 30
+
+    earliest_row = (
+        DiscordPostCount.query.order_by(DiscordPostCount.date.asc()).first()
+    )
+    earliest_date = earliest_row.date if earliest_row else None
+
+    end = datetime.now(timezone.utc).date().isoformat()
+    requested_start = (
+        datetime.strptime(end, '%Y-%m-%d').date() - timedelta(days=range_days - 1)
+    ).isoformat()
+    start = max(requested_start, earliest_date) if earliest_date else requested_start
+    data_capped = bool(earliest_date) and requested_start < earliest_date
+
+    prev_start, prev_end = shift_window(start, end)
+    if earliest_date:
+        prev_start = max(prev_start, earliest_date)
+
+    def _rows_for(since: str, until: str) -> list[dict]:
+        if since > until:
+            return []
+        q = DiscordPostCount.query.filter(
+            DiscordPostCount.date >= since,
+            DiscordPostCount.date <= until,
+        )
+        return [
+            {'discord_id': r.discord_id, 'date': r.date, 'category': r.category, 'count': r.count}
+            for r in q.all()
+        ]
+
+    rows = _rows_for(start, end)
+    prev_rows = _rows_for(prev_start, prev_end)
+
+    discord_ids = {r['discord_id'] for r in rows} | {r['discord_id'] for r in prev_rows}
+    name_rows = DiscordDisplayName.query.filter(DiscordDisplayName.discord_id.in_(discord_ids)).all()
+    display_names = {r.discord_id: r.display_name for r in name_rows}
+
+    active_characters = [
+        {'character_name': c.character_name, 'player_discord': c.player_discord}
+        for c in DbCharacter.query.filter_by(active=True).all()
+    ]
+
+    report = build_health_report(rows, prev_rows, active_characters, display_names, start, end)
+
+    return render_template(
+        'reports/health.html',
+        report=report,
+        range_days=range_days,
+        range_options=HEALTH_RANGE_OPTIONS,
+        start=start,
+        end=end,
+        data_capped=data_capped,
+        earliest_data_date=earliest_date,
     )

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -301,8 +301,6 @@ def health():
     data_capped = bool(earliest_date) and requested_start < earliest_date
 
     prev_start, prev_end = shift_window(start, end)
-    if earliest_date:
-        prev_start = max(prev_start, earliest_date)
 
     def _rows_for(since: str, until: str) -> list[dict]:
         if since > until:
@@ -317,14 +315,23 @@ def health():
         ]
 
     rows = _rows_for(start, end)
-    prev_rows = _rows_for(prev_start, prev_end)
+    # Only compare against a *full* prior period — if the natural previous
+    # window would dip before the earliest tracked date, there's no fair
+    # same-length baseline to compare against, so skip it entirely rather
+    # than silently comparing against a truncated (shorter) window, which
+    # can read as a misleading spike or drop.
+    prev_rows = [] if (earliest_date and prev_start < earliest_date) else _rows_for(prev_start, prev_end)
 
     discord_ids = {r['discord_id'] for r in rows} | {r['discord_id'] for r in prev_rows}
     name_rows = DiscordDisplayName.query.filter(DiscordDisplayName.discord_id.in_(discord_ids)).all()
     display_names = {r.discord_id: r.display_name for r in name_rows}
 
     active_characters = [
-        {'character_name': c.character_name, 'player_discord': c.player_discord}
+        {
+            'character_name': c.character_name,
+            'player_discord': c.player_discord,
+            'player_discord_name': c.player_discord_name,
+        }
         for c in DbCharacter.query.filter_by(active=True).all()
     ]
 

--- a/apps/web/app/templates/reports.html
+++ b/apps/web/app/templates/reports.html
@@ -5,9 +5,14 @@
 {% block content %}
 <div class="container-fluid mt-4">
 
-  <div class="mb-4">
-    <h2 class="mb-0">Reports</h2>
-    <small class="text-muted">Roster statistics and recent engagement.</small>
+  <div class="mb-4 d-flex align-items-center justify-content-between flex-wrap gap-2">
+    <div>
+      <h2 class="mb-0">Reports</h2>
+      <small class="text-muted">Roster statistics and recent engagement.</small>
+    </div>
+    <a href="{{ url_for('reports.health') }}" class="btn btn-sm btn-outline-secondary">
+      <i class="bi bi-heart-pulse"></i> Server Health
+    </a>
   </div>
 
   {# ── Engagement ── #}

--- a/apps/web/app/templates/reports/health.html
+++ b/apps/web/app/templates/reports/health.html
@@ -1,0 +1,292 @@
+{% extends "base.html" %}
+
+{% block title %}Server Health — Reports{% endblock %}
+
+{% block content %}
+<div class="container-fluid mt-4">
+
+  <div class="mb-4 d-flex align-items-center justify-content-between flex-wrap gap-2">
+    <div>
+      <h2 class="mb-0">Server Health</h2>
+      <small class="text-muted">Posting activity — {{ start }} to {{ end }}.</small>
+    </div>
+    <div class="d-flex align-items-center gap-2">
+      <div class="btn-group" role="group" aria-label="Date range">
+        {% for opt in range_options %}
+        <a href="{{ url_for('reports.health', range=opt) }}"
+           class="btn btn-sm {% if opt == range_days %}btn-primary{% else %}btn-outline-secondary{% endif %}">
+          {{ opt }}d
+        </a>
+        {% endfor %}
+      </div>
+      <a href="{{ url_for('reports.index') }}" class="btn btn-sm btn-outline-secondary">
+        <i class="bi bi-arrow-left"></i> Reports
+      </a>
+    </div>
+  </div>
+
+  {% if data_capped %}
+  <div class="alert alert-warning py-2 small mb-4">
+    <i class="bi bi-info-circle me-1"></i>
+    Activity tracking only has clean data back to <strong>{{ earliest_data_date }}</strong> —
+    this {{ range_days }}-day view is showing what's actually available ({{ report.days | length }} days),
+    not the full {{ range_days }}.
+  </div>
+  {% endif %}
+
+  {# ── Stat tiles ── #}
+  <div class="row g-3 mb-4">
+    <div class="col-6 col-md-3">
+      <div class="stat-card h-100">
+        <span class="stat-label">Total Posts</span>
+        <span class="stat-value">{{ report.period_total }}</span>
+        <span class="stat-sub">
+          {% if report.delta_pct is none %}
+            no prior baseline
+          {% elif report.delta_pct > 0 %}
+            <span style="color:#0ca30c;"><i class="bi bi-arrow-up-short"></i>{{ report.delta_pct }}%</span> vs prior period
+          {% elif report.delta_pct < 0 %}
+            <span style="color:var(--accent-soft);"><i class="bi bi-arrow-down-short"></i>{{ -report.delta_pct }}%</span> vs prior period
+          {% else %}
+            flat vs prior period
+          {% endif %}
+        </span>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="stat-card h-100">
+        <span class="stat-label">Active Posters</span>
+        <span class="stat-value">{{ report.unique_posters }}</span>
+        <span class="stat-sub">distinct people who posted</span>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="stat-card h-100 stat-card--accent">
+        <span class="stat-label">Roster Participation</span>
+        <span class="stat-value">{{ report.participation_pct }}%</span>
+        <span class="stat-sub">{{ report.posted_player_count }} / {{ report.active_player_count }} active players posted</span>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="stat-card h-100">
+        <span class="stat-label">Not Posting</span>
+        <span class="stat-value">{{ report.not_posting | length }}</span>
+        <span class="stat-sub">
+          active players, zero posts
+          {% if report.unlinked_character_count %}· {{ report.unlinked_character_count }} unlinked{% endif %}
+        </span>
+      </div>
+    </div>
+  </div>
+
+  {# ── Daily activity by category ── #}
+  <div class="card mb-4">
+    <div class="card-header py-2 d-flex align-items-center justify-content-between flex-wrap gap-2">
+      <span class="fw-semibold"><i class="bi bi-bar-chart-line me-1"></i> Daily Activity by Category</span>
+      <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#daily-table">
+        Table view
+      </button>
+    </div>
+    <div class="card-body">
+      <canvas id="categoryChart" height="90" role="img" aria-label="Stacked bar chart of daily posts by category"></canvas>
+    </div>
+    <div class="collapse" id="daily-table">
+      <div class="table-responsive">
+        <table class="table table-dark table-sm align-middle mb-0">
+          <thead>
+            <tr><th>Date</th><th>IC</th><th>OOC</th><th>Rolls</th><th>Cubby</th><th>Total</th></tr>
+          </thead>
+          <tbody>
+            {% for d in report.days %}
+            {% set i = loop.index0 %}
+            <tr>
+              <td class="font-monospace">{{ d }}</td>
+              <td>{{ report.daily_by_category.ic[i] }}</td>
+              <td>{{ report.daily_by_category.ooc[i] }}</td>
+              <td>{{ report.daily_by_category.rolls[i] }}</td>
+              <td>{{ report.daily_by_category.cubby[i] }}</td>
+              <td class="fw-semibold">{{ report.daily_totals[i] }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-3 mb-4">
+    {# ── Unique posters trend ── #}
+    <div class="col-lg-6">
+      <div class="card h-100">
+        <div class="card-header py-2 fw-semibold">
+          <i class="bi bi-graph-up me-1"></i> Daily Unique Posters
+        </div>
+        <div class="card-body">
+          <canvas id="postersChart" height="140" role="img" aria-label="Line chart of distinct posters per day"></canvas>
+        </div>
+      </div>
+    </div>
+
+    {# ── Top posters ── #}
+    <div class="col-lg-6">
+      <div class="card h-100">
+        <div class="card-header py-2 fw-semibold">
+          <i class="bi bi-trophy me-1"></i> Top Posters ({{ start }}–{{ end }})
+        </div>
+        <div class="card-body">
+          {% if report.leaderboard %}
+          <canvas id="leaderboardChart" height="140" role="img" aria-label="Bar chart of the top 15 posters by total post count"></canvas>
+          {% else %}
+          <p class="text-muted mb-0">No posts recorded in this window.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {# ── Not posting ── #}
+  <div class="card mb-4">
+    <div class="card-header py-2 fw-semibold">
+      <i class="bi bi-person-dash me-1"></i> Not Posting
+      <span class="badge bg-secondary ms-1">{{ report.not_posting | length }}</span>
+      <span class="text-muted small fw-normal ms-2">active players with zero posts in this window</span>
+    </div>
+    <div class="card-body p-0">
+      {% if not report.not_posting %}
+        <p class="text-muted p-3 mb-0">Everyone active posted at least once in this window.</p>
+      {% else %}
+        <div class="table-responsive">
+          <table class="table table-dark table-hover table-sm align-middle mb-0">
+            <thead>
+              <tr><th>Player</th><th>Discord ID</th><th>Characters</th></tr>
+            </thead>
+            <tbody>
+              {% for p in report.not_posting %}
+              <tr>
+                <td class="fw-semibold">{{ p.display_name or '—' }}</td>
+                <td class="text-muted small font-monospace">{{ p.discord_id }}</td>
+                <td>{{ p.characters | join(', ') }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="text-end mb-4">
+    <a href="{{ url_for('reports.activity_csv', since=start, until=end) }}" class="btn btn-sm btn-outline-secondary">
+      <i class="bi bi-download"></i> Export raw CSV for this range
+    </a>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script>
+(function () {
+  const days = {{ report.days | tojson }};
+  const dailyByCategory = {{ report.daily_by_category | tojson }};
+  const dailyPosters = {{ report.daily_unique_posters | tojson }};
+  const leaderboard = {{ report.leaderboard | tojson }};
+
+  // Validated categorical palette (dark mode, 4 slots) — see dataviz skill.
+  const CATEGORY_COLORS = {
+    ic:    { bg: '#3987e5', label: 'IC' },
+    ooc:   { bg: '#199e70', label: 'OOC' },
+    rolls: { bg: '#c98500', label: 'Rolls' },
+    cubby: { bg: '#008300', label: 'Cubby' },
+  };
+  const INK_MUTED = '#8b94a3';
+  const GRIDLINE = 'rgba(255,255,255,0.07)';
+
+  Chart.defaults.color = INK_MUTED;
+  Chart.defaults.font.family = "'Space Grotesk', system-ui, -apple-system, sans-serif";
+  Chart.defaults.borderColor = GRIDLINE;
+
+  new Chart(document.getElementById('categoryChart'), {
+    type: 'bar',
+    data: {
+      labels: days,
+      datasets: Object.entries(CATEGORY_COLORS).map(([key, meta]) => ({
+        label: meta.label,
+        data: dailyByCategory[key],
+        backgroundColor: meta.bg,
+        borderRadius: 2,
+        borderSkipped: false,
+      })),
+    },
+    options: {
+      responsive: true,
+      scales: {
+        x: { stacked: true, grid: { display: false } },
+        y: { stacked: true, beginAtZero: true, grid: { color: GRIDLINE } },
+      },
+      plugins: {
+        legend: { position: 'bottom', labels: { boxWidth: 10, boxHeight: 10 } },
+        tooltip: { mode: 'index', intersect: false },
+      },
+    },
+  });
+
+  new Chart(document.getElementById('postersChart'), {
+    type: 'line',
+    data: {
+      labels: days,
+      datasets: [{
+        label: 'Unique posters',
+        data: dailyPosters,
+        borderColor: '#3987e5',
+        backgroundColor: 'rgba(57,135,229,0.12)',
+        borderWidth: 2,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+        tension: 0.15,
+        fill: true,
+      }],
+    },
+    options: {
+      responsive: true,
+      scales: {
+        x: { grid: { display: false } },
+        y: { beginAtZero: true, grid: { color: GRIDLINE }, ticks: { precision: 0 } },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: { mode: 'index', intersect: false },
+      },
+    },
+  });
+
+  if (leaderboard.length) {
+    new Chart(document.getElementById('leaderboardChart'), {
+      type: 'bar',
+      data: {
+        labels: leaderboard.map((r) => r.display_name || r.discord_id),
+        datasets: [{
+          label: 'Posts',
+          data: leaderboard.map((r) => r.total),
+          backgroundColor: '#3987e5',
+          borderRadius: 3,
+        }],
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        scales: {
+          x: { beginAtZero: true, grid: { color: GRIDLINE }, ticks: { precision: 0 } },
+          y: { grid: { display: false } },
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { intersect: false },
+        },
+      },
+    });
+  }
+})();
+</script>
+{% endblock %}

--- a/apps/web/tests/test_activity_health.py
+++ b/apps/web/tests/test_activity_health.py
@@ -143,3 +143,35 @@ def test_not_posting_lists_all_characters_for_a_silent_multi_character_player():
     ]
     report = build_health_report([], [], active_characters, {}, '2026-06-01', '2026-06-01')
     assert report['not_posting'][0]['characters'] == ['Alpha', 'Beta']
+
+
+def test_not_posting_falls_back_to_roster_display_name_when_never_posted():
+    """Regression test: a player with zero posts in either window never gets
+    a display_names entry (that dict is only populated from activity rows),
+    so the not-posting table needs the roster's own player_discord_name as a
+    fallback instead of rendering a raw Discord ID."""
+    active_characters = [
+        {'character_name': 'Zara', 'player_discord': 'p2', 'player_discord_name': 'ZaraPlayer'},
+    ]
+    report = build_health_report([], [], active_characters, {}, '2026-06-01', '2026-06-01')
+    assert report['not_posting'][0]['display_name'] == 'ZaraPlayer'
+
+
+def test_not_posting_prefers_activity_tracked_name_over_roster_name():
+    """A player who posted last period but not this one is in not_posting
+    with a real (possibly more current) activity-tracked name — prefer that
+    over the roster snapshot when both are available."""
+    active_characters = [
+        {'character_name': 'Zara', 'player_discord': 'p2', 'player_discord_name': 'OldRosterName'},
+    ]
+    prev_rows = _rows(('p2', '2026-05-01', 'ic', 1))
+    report = build_health_report(
+        [], prev_rows, active_characters, {'p2': 'CurrentDisplayName'}, '2026-06-01', '2026-06-01',
+    )
+    assert report['not_posting'][0]['display_name'] == 'CurrentDisplayName'
+
+
+def test_not_posting_blank_display_name_when_neither_source_available():
+    active_characters = [{'character_name': 'Zara', 'player_discord': 'p2'}]
+    report = build_health_report([], [], active_characters, {}, '2026-06-01', '2026-06-01')
+    assert report['not_posting'][0]['display_name'] == ''

--- a/apps/web/tests/test_activity_health.py
+++ b/apps/web/tests/test_activity_health.py
@@ -1,0 +1,145 @@
+from app.activity_health import build_health_report, daterange, shift_window
+
+
+def test_daterange_inclusive():
+    assert daterange('2026-06-01', '2026-06-03') == ['2026-06-01', '2026-06-02', '2026-06-03']
+
+
+def test_daterange_single_day():
+    assert daterange('2026-06-01', '2026-06-01') == ['2026-06-01']
+
+
+def test_shift_window_same_length_immediately_before():
+    assert shift_window('2026-06-08', '2026-06-14') == ('2026-06-01', '2026-06-07')
+
+
+def test_shift_window_single_day():
+    assert shift_window('2026-06-08', '2026-06-08') == ('2026-06-07', '2026-06-07')
+
+
+def _rows(*entries):
+    return [
+        {'discord_id': did, 'date': date, 'category': cat, 'count': count}
+        for did, date, cat, count in entries
+    ]
+
+
+def test_daily_totals_zero_filled_across_full_range():
+    rows = _rows(('u1', '2026-06-01', 'ic', 5))
+    report = build_health_report(rows, [], [], {}, '2026-06-01', '2026-06-03')
+    assert report['days'] == ['2026-06-01', '2026-06-02', '2026-06-03']
+    assert report['daily_totals'] == [5, 0, 0]
+
+
+def test_daily_by_category_breakdown():
+    rows = _rows(
+        ('u1', '2026-06-01', 'ic', 3),
+        ('u1', '2026-06-01', 'ooc', 2),
+        ('u2', '2026-06-01', 'cubby', 1),
+    )
+    report = build_health_report(rows, [], [], {}, '2026-06-01', '2026-06-01')
+    assert report['daily_by_category']['ic'] == [3]
+    assert report['daily_by_category']['ooc'] == [2]
+    assert report['daily_by_category']['cubby'] == [1]
+    assert report['daily_by_category']['rolls'] == [0]
+    assert report['period_by_category'] == {'ic': 3, 'ooc': 2, 'rolls': 0, 'cubby': 1}
+    assert report['period_total'] == 6
+
+
+def test_unknown_category_and_nonpositive_count_ignored():
+    rows = _rows(
+        ('u1', '2026-06-01', 'ic', 3),
+        ('u1', '2026-06-01', 'bogus', 100),
+        ('u1', '2026-06-01', 'ooc', 0),
+    )
+    report = build_health_report(rows, [], [], {}, '2026-06-01', '2026-06-01')
+    assert report['period_total'] == 3
+
+
+def test_daily_unique_posters_dedupes_within_a_day():
+    rows = _rows(
+        ('u1', '2026-06-01', 'ic', 3),
+        ('u1', '2026-06-01', 'ooc', 1),
+        ('u2', '2026-06-01', 'ic', 1),
+    )
+    report = build_health_report(rows, [], [], {}, '2026-06-01', '2026-06-01')
+    assert report['daily_unique_posters'] == [2]
+    assert report['unique_posters'] == 2
+
+
+def test_leaderboard_sorted_descending_and_capped_at_15():
+    rows = _rows(*[(f'u{i}', '2026-06-01', 'ic', i) for i in range(1, 20)])
+    report = build_health_report(rows, [], [], {}, '2026-06-01', '2026-06-01')
+    assert len(report['leaderboard']) == 15
+    assert report['leaderboard'][0]['total'] == 19
+    assert report['leaderboard'][0]['discord_id'] == 'u19'
+    totals = [r['total'] for r in report['leaderboard']]
+    assert totals == sorted(totals, reverse=True)
+
+
+def test_leaderboard_uses_display_name_when_available():
+    rows = _rows(('u1', '2026-06-01', 'ic', 1))
+    report = build_health_report(rows, [], [], {'u1': 'Alice'}, '2026-06-01', '2026-06-01')
+    assert report['leaderboard'][0]['display_name'] == 'Alice'
+
+
+def test_delta_pct_computed_against_previous_window():
+    rows = _rows(('u1', '2026-06-08', 'ic', 20))
+    prev_rows = _rows(('u1', '2026-06-01', 'ic', 10))
+    report = build_health_report(rows, prev_rows, [], {}, '2026-06-08', '2026-06-08')
+    assert report['delta_pct'] == 100
+
+
+def test_delta_pct_none_when_no_prior_baseline_but_current_activity():
+    rows = _rows(('u1', '2026-06-08', 'ic', 20))
+    report = build_health_report(rows, [], [], {}, '2026-06-08', '2026-06-08')
+    assert report['delta_pct'] is None
+
+
+def test_delta_pct_zero_when_both_windows_empty():
+    report = build_health_report([], [], [], {}, '2026-06-08', '2026-06-08')
+    assert report['delta_pct'] == 0
+
+
+def test_participation_dedupes_by_player_across_multiple_characters():
+    active_characters = [
+        {'character_name': 'Marcus', 'player_discord': 'p1'},
+        {'character_name': "Marcus's Retainer", 'player_discord': 'p1'},
+        {'character_name': 'Zara', 'player_discord': 'p2'},
+    ]
+    rows = _rows(('p1', '2026-06-01', 'ic', 1))
+    report = build_health_report(rows, [], active_characters, {}, '2026-06-01', '2026-06-01')
+
+    assert report['active_player_count'] == 2
+    assert report['posted_player_count'] == 1
+    assert report['participation_pct'] == 50
+    assert len(report['not_posting']) == 1
+    assert report['not_posting'][0]['discord_id'] == 'p2'
+    assert report['not_posting'][0]['characters'] == ['Zara']
+
+
+def test_participation_zero_active_players_does_not_divide_by_zero():
+    report = build_health_report([], [], [], {}, '2026-06-01', '2026-06-01')
+    assert report['participation_pct'] == 0
+    assert report['active_player_count'] == 0
+    assert report['not_posting'] == []
+
+
+def test_unlinked_characters_excluded_from_participation_but_counted():
+    active_characters = [
+        {'character_name': 'NoDiscordLinked', 'player_discord': ''},
+        {'character_name': 'Zara', 'player_discord': 'p2'},
+    ]
+    report = build_health_report([], [], active_characters, {}, '2026-06-01', '2026-06-01')
+    assert report['active_player_count'] == 1
+    assert report['unlinked_character_count'] == 1
+    assert report['not_posting'][0]['characters'] == ['Zara']
+
+
+def test_not_posting_lists_all_characters_for_a_silent_multi_character_player():
+    active_characters = [
+        {'character_name': 'Beta', 'player_discord': 'p1'},
+        {'character_name': 'Alpha', 'player_discord': 'p1'},
+    ]
+    report = build_health_report([], [], active_characters, {}, '2026-06-01', '2026-06-01')
+    assert report['not_posting'][0]['characters'] == ['Alpha', 'Beta']

--- a/apps/web/tests/test_reports_health_route.py
+++ b/apps/web/tests/test_reports_health_route.py
@@ -1,0 +1,124 @@
+"""Regression tests for /reports/health: truncated-baseline delta suppression
+and the not-posting table's display-name fallback."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from flask import Blueprint, Flask
+from flask_wtf import CSRFProtect
+
+from app.blueprints.reports import bp as reports_bp
+from app.db import DbCharacter, DiscordPostCount, db
+
+_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
+_STATIC_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
+
+
+def _stub_bp(name: str, prefix: str, routes: dict[str, str]) -> Blueprint:
+    bp = Blueprint(name, __name__, url_prefix=prefix)
+    for rule, fn_name in routes.items():
+        bp.add_url_rule(rule, fn_name, lambda **_: ('', 200))
+    return bp
+
+
+def _app():
+    app = Flask(__name__, template_folder=_TEMPLATE_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.secret_key = 'test-secret'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    CSRFProtect(app)
+    db.init_app(app)
+    app.register_blueprint(_stub_bp('dashboard', '/', {
+        '/': 'index', '/login': 'login', '/logout': 'logout', '/view-as/clear': 'clear_view_as',
+    }))
+    app.register_blueprint(_stub_bp('claims', '/claims', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('spends', '/spends', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('roster', '/roster', {'/': 'index', '/characters': 'list_characters'}))
+    app.register_blueprint(_stub_bp('periods', '/periods', {'/': 'index', '/list': 'list_periods'}))
+    app.register_blueprint(_stub_bp('audit', '/audit', {'/': 'log', '/errors': 'errors'}))
+    app.register_blueprint(_stub_bp('player', '/player', {'/': 'my_characters'}))
+    app.register_blueprint(_stub_bp('wiki', '/wiki', {'/': 'index'}))
+    app.register_blueprint(_stub_bp('cc_admin', '/cc-admin', {
+        '/loresheets': 'loresheet_list', '/drafts': 'draft_list', '/drafts/<int:draft_id>': 'draft_review',
+        '/sheet-imports': 'sheet_import_list',
+    }))
+    app.register_blueprint(_stub_bp('coteries', '/coteries', {'/': 'index'}))
+    app.register_blueprint(_stub_bp('settings', '/settings', {'/': 'index'}))
+    app.register_blueprint(_stub_bp('local_status', '/local/status', {'/': 'status_page'}))
+    app.register_blueprint(reports_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _set_session(client):
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['discord_id'] = '12345'
+        sess['discord_name'] = 'Tester'
+        sess['staff_user'] = 'Tester'
+
+
+def _days_ago(n: int) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=n)).isoformat()
+
+
+def test_delta_suppressed_when_prior_window_would_be_truncated():
+    """A full 30-day current window compared against a prior 30-day window
+    that's truncated (tracking only started partway through it) must not
+    produce a misleading delta — the comparison should be skipped entirely
+    rather than computed against a shorter baseline.
+
+    range=30: current window is days 29..0 ago. Natural prior window is
+    days 59..30 ago. Earliest tracked date at day 40 ago sits inside that
+    prior window (after its start) but doesn't affect the current window at
+    all (day 40 ago < day 29 ago), so only the comparison is truncated.
+    """
+    app = _app()
+    with app.app_context():
+        db.session.add(DiscordPostCount(discord_id='u1', date=_days_ago(40), category='ic', count=1))
+        db.session.add(DiscordPostCount(discord_id='u1', date=_days_ago(5), category='ic', count=10))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client)
+        resp = client.get('/reports/health?range=30')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'no prior baseline' in html
+
+
+def test_full_prior_window_available_shows_a_real_delta():
+    """Earliest tracked date (day 80 ago) sits before the natural prior
+    window's start (day 59 ago), so a full same-length baseline exists and
+    a real percentage delta should render."""
+    app = _app()
+    with app.app_context():
+        db.session.add(DiscordPostCount(discord_id='u1', date=_days_ago(80), category='ic', count=1))
+        db.session.add(DiscordPostCount(discord_id='u1', date=_days_ago(45), category='ic', count=5))
+        db.session.add(DiscordPostCount(discord_id='u1', date=_days_ago(5), category='ic', count=20))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client)
+        resp = client.get('/reports/health?range=30')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'vs prior period' in html
+
+
+def test_not_posting_shows_roster_name_for_a_never_posted_active_player():
+    app = _app()
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='Zara', player_discord='p2', player_discord_name='ZaraPlayer', active=True,
+        ))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client)
+        resp = client.get('/reports/health?range=30')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'ZaraPlayer' in html


### PR DESCRIPTION
## Summary

New `/reports/health` page — server-health reporting on top of the activity data Lasombra's already been tracking (`discord_post_counts`, populated live by `discordActivityTracker.ts` + historically by `/lasombra scan-activity`).

**Stat tiles**: total posts, active posters, roster participation % (dedup'd by player — a player with 2 active characters only needs to post once), period-over-period % change.

**Charts** (first charting library in this app — Chart.js via CDN, same no-build-step convention as Bootstrap):
- Daily posts stacked by category (IC/OOC/Rolls/Cubby), with a collapsible table-view toggle
- Daily unique posters trend line
- Top-15 posters bar chart

**"Not Posting" table**: active players with zero posts in the selected window, listing every active character they own — the actual "who's posting and who isn't" ask.

30/60/90-day range selector, linked from the existing Reports page.

## Data-quality issue found & fixed along the way

Before building on this data, I checked its actual coverage and found `discord_post_counts` had ~713 rows (2026-05-19 through 2026-06-01) inflated by orders of magnitude — one day showed **2.3M "posts"** in a single day/user/category, which is obviously not real. Root cause: the ingestion endpoint (`/discord-activity/record`) upserts additively (`count = count + excluded.count`) and `/lasombra scan-activity` has no guard against re-scanning the same date window twice — almost certainly repeated staff test runs during the feature's initial rollout (migration landed 2026-05-31, with same-day follow-up fixes).

This wasn't just a problem for this new dashboard — it would have silently corrupted the *existing* Reports page and CSV export too, if that window were ever queried.

**Fixed**: purged those 713 rows directly in prod (confirmed with the user first), logged the correction to `audit_log` for traceability. Live tracking from 2026-06-02 onward was already sane and untouched. The new dashboard also caps any requested window at the earliest available clean date and shows a banner when it does, so a future tracking gap can't silently produce misleading totals again.

## Design notes
- Followed the dataviz skill's procedure: chose forms by job (trend → line/stacked-bar, ranking → single-hue bar, magnitude → stat tiles), then color, then validated.
- Categorical palette re-validated (`validate_palette.js`) against this app's *actual* dark chart surface (`#13161b`, the `--surface` token in `style.css`) rather than assuming the skill's generic default surface — passes all four checks (CVD separation lands in the 8–12 floor band, which is legal given the chart ships a legend + hover tooltips as the secondary encoding).
- All aggregation logic (`apps/web/app/activity_health.py`) is pure functions on plain dicts/lists — no Flask/DB imports — so it's unit-tested (17 tests) without needing a DB fixture.

## Test plan
- [x] New tests in `tests/test_activity_health.py` — 17/17 pass
- [x] `./venv/bin/pytest -q` — 230/230 pass, no regressions
- [x] `ruff check` — clean
- [x] Manual end-to-end smoke test via Flask test client (30/60/90-day ranges, seeded data) — renders correctly, stat tiles reconcile (participation %, not-posting count, totals all internally consistent)
- [ ] Eyeball the actual charts in a browser on dev — I verified rendering via HTTP response inspection, not a visual screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)