### PR TITLE
Fix discord-activity/record so backfill re-runs can't corrupt counts again

### DIFF
--- a/apps/bot/src/__tests__/activityBackfillScanner.test.ts
+++ b/apps/bot/src/__tests__/activityBackfillScanner.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { flushEntries, type ActivityEntry } from '../services/activityBackfillScanner';
+import type { TrackerAdapter } from '../services/adapter';
+
+function fakeAdapter() {
+  return { recordDiscordActivity: vi.fn().mockResolvedValue(undefined) } as unknown as TrackerAdapter & {
+    recordDiscordActivity: ReturnType<typeof vi.fn>;
+  };
+}
+
+function entry(overrides: Partial<ActivityEntry> = {}): ActivityEntry {
+  return { discord_id: 'u1', date: '2026-06-01', category: 'ic', count: 5, ...overrides };
+}
+
+describe('flushEntries', () => {
+  it('sends a first-time flush with mode=replace', async () => {
+    const adapter = fakeAdapter();
+    const seen = new Set<string>();
+    await flushEntries(adapter, [entry()], {}, seen);
+
+    expect(adapter.recordDiscordActivity).toHaveBeenCalledTimes(1);
+    expect(adapter.recordDiscordActivity).toHaveBeenCalledWith([entry()], {}, 'replace');
+  });
+
+  it('marks the key as seen after a replace flush', async () => {
+    const adapter = fakeAdapter();
+    const seen = new Set<string>();
+    await flushEntries(adapter, [entry()], {}, seen);
+
+    expect(seen.has('u1|2026-06-01|ic')).toBe(true);
+  });
+
+  it('sends a second flush of the same key within one run as mode=increment', async () => {
+    const adapter = fakeAdapter();
+    const seen = new Set<string>();
+    await flushEntries(adapter, [entry({ count: 5 })], {}, seen);
+    await flushEntries(adapter, [entry({ count: 3 })], {}, seen);
+
+    expect(adapter.recordDiscordActivity).toHaveBeenNthCalledWith(1, [entry({ count: 5 })], {}, 'replace');
+    expect(adapter.recordDiscordActivity).toHaveBeenNthCalledWith(2, [entry({ count: 3 })], {}, 'increment');
+  });
+
+  it('splits a mixed batch: new keys go via replace, already-seen keys via increment', async () => {
+    const adapter = fakeAdapter();
+    const seen = new Set<string>(['u1|2026-06-01|ic']);
+    const newEntry = entry({ discord_id: 'u2', count: 7 });
+    const seenEntry = entry({ discord_id: 'u1', count: 2 });
+
+    await flushEntries(adapter, [newEntry, seenEntry], {}, seen);
+
+    expect(adapter.recordDiscordActivity).toHaveBeenCalledTimes(2);
+    expect(adapter.recordDiscordActivity).toHaveBeenCalledWith([newEntry], {}, 'replace');
+    expect(adapter.recordDiscordActivity).toHaveBeenCalledWith([seenEntry], {}, 'increment');
+  });
+
+  it('does not call the adapter at all for an empty entries list', async () => {
+    const adapter = fakeAdapter();
+    await flushEntries(adapter, [], {}, new Set());
+    expect(adapter.recordDiscordActivity).not.toHaveBeenCalled();
+  });
+
+  it('treats different categories on the same day as distinct keys', async () => {
+    const adapter = fakeAdapter();
+    const seen = new Set<string>();
+    await flushEntries(adapter, [entry({ category: 'ic' })], {}, seen);
+    await flushEntries(adapter, [entry({ category: 'ooc' })], {}, seen);
+
+    expect(adapter.recordDiscordActivity).toHaveBeenNthCalledWith(1, [entry({ category: 'ic' })], {}, 'replace');
+    expect(adapter.recordDiscordActivity).toHaveBeenNthCalledWith(2, [entry({ category: 'ooc' })], {}, 'replace');
+  });
+});

--- a/apps/bot/src/services/activityBackfillScanner.ts
+++ b/apps/bot/src/services/activityBackfillScanner.ts
@@ -64,7 +64,7 @@ async function fetchBatch(
   throw new Error('unreachable');
 }
 
-type ActivityEntry = { discord_id: string; date: string; category: ActivityCategory; count: number };
+export type ActivityEntry = { discord_id: string; date: string; category: ActivityCategory; count: number };
 
 function utcDateOf(d: Date): string {
   return d.toISOString().slice(0, 10);
@@ -142,6 +142,40 @@ function countMapToEntries(countMap: Map<string, Map<string, number>>): Activity
     }
   }
   return entries;
+}
+
+/**
+ * Flush accumulated entries, using replace/increment mode per-entry based on
+ * whether this run has already touched that (discord_id, date, category)
+ * key. The shared countMap is periodically flushed and cleared *within* a
+ * single run as more channels are scanned, so the same key can legitimately
+ * split across two flush calls in one run (e.g. two different IC channels
+ * both posted-in by the same person on the same day). The first flush of a
+ * key must fully replace whatever a *prior run* left there — that's the fix
+ * for the corruption incident, where re-running a backfill compounded on
+ * top of stale numbers. Every later flush of that same key *within this
+ * run* must increment on top of this run's own earlier contribution,
+ * not replace it away.
+ */
+export async function flushEntries(
+  adapter: TrackerAdapter,
+  entries: ActivityEntry[],
+  names: Record<string, string>,
+  seenKeysThisRun: Set<string>,
+): Promise<void> {
+  const fresh: ActivityEntry[] = [];
+  const seenAgain: ActivityEntry[] = [];
+  for (const e of entries) {
+    const key = `${e.discord_id}|${e.date}|${e.category}`;
+    if (seenKeysThisRun.has(key)) {
+      seenAgain.push(e);
+    } else {
+      seenKeysThisRun.add(key);
+      fresh.push(e);
+    }
+  }
+  if (fresh.length > 0) await adapter.recordDiscordActivity(fresh, names, 'replace');
+  if (seenAgain.length > 0) await adapter.recordDiscordActivity(seenAgain, names, 'increment');
 }
 
 export async function runActivityBackfill(
@@ -232,6 +266,8 @@ async function _runActivityBackfillInner(
   const countMap = new Map<string, Map<string, number>>();
   const nameMap = new Map<string, string>();
   const allDiscordIds = new Set<string>();
+  // (discord_id|date|category) keys already flushed during this run — see flushEntries().
+  const seenKeysThisRun = new Set<string>();
   let totalMessages = 0;
   let channelsScanned = 0;
 
@@ -263,7 +299,7 @@ async function _runActivityBackfillInner(
       const entries = countMapToEntries(countMap);
       if (entries.length >= FLUSH_THRESHOLD) {
         for (const e of entries) allDiscordIds.add(e.discord_id);
-        await adapter.recordDiscordActivity(entries, Object.fromEntries(nameMap));
+        await flushEntries(adapter, entries, Object.fromEntries(nameMap), seenKeysThisRun);
         countMap.clear();
         nameMap.clear();
         log(`  Flushed ${entries.length} entries`);
@@ -318,7 +354,7 @@ async function _runActivityBackfillInner(
   const finalEntries = countMapToEntries(countMap);
   if (finalEntries.length > 0) {
     for (const e of finalEntries) allDiscordIds.add(e.discord_id);
-    await adapter.recordDiscordActivity(finalEntries, Object.fromEntries(nameMap));
+    await flushEntries(adapter, finalEntries, Object.fromEntries(nameMap), seenKeysThisRun);
     if (cancelled) log(`Flushed ${finalEntries.length} partial entries before stopping.`);
   }
 

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -152,6 +152,7 @@ export interface TrackerAdapter {
   recordDiscordActivity(
     entries: Array<{ discord_id: string; date: string; category: 'ic' | 'ooc' | 'rolls' | 'cubby'; count: number }>,
     names?: Record<string, string>,
+    mode?: 'increment' | 'replace',
   ): Promise<void>;
   getRecentPeriods(count?: number): Promise<Array<{ label: string; nightNumber: number; startDate: string; endDate: string }>>;
   syncStaff(
@@ -1338,11 +1339,12 @@ export class WebAppAdapter implements TrackerAdapter {
   async recordDiscordActivity(
     entries: Array<{ discord_id: string; date: string; category: 'ic' | 'ooc' | 'rolls' | 'cubby'; count: number }>,
     names?: Record<string, string>,
+    mode?: 'increment' | 'replace',
   ): Promise<void> {
     const res = await this.fetchWithTimeout(`${this.baseUrl}/api/discord-activity/record`, {
       method: 'POST',
       headers: { ...this.writeAuthHeaders(), 'Content-Type': 'application/json' },
-      body: JSON.stringify({ entries, ...(names ? { names } : {}) }),
+      body: JSON.stringify({ entries, ...(names ? { names } : {}), ...(mode ? { mode } : {}) }),
     });
     if (!res.ok) throw new Error(`discord-activity/record POST failed: ${res.status}`);
   }

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1989,11 +1989,24 @@ def cc_approved_drafts():
 @require_bot_scope('write')
 @_limit('120 per minute')
 def discord_activity_record():
-    """Accept batched Discord post count increments from the bot.
+    """Accept batched Discord post counts from the bot.
 
     Body: { "entries": [{ "discord_id": "...", "date": "YYYY-MM-DD",
-                          "category": "ic|ooc|rolls|cubby", "count": N }] }
-    Each entry is upserted: existing counts are incremented, not replaced.
+                          "category": "ic|ooc|rolls|cubby", "count": N }],
+            "mode": "increment" | "replace" }
+
+    mode="increment" (default): existing counts are incremented — for the
+    live tracker, which only ever reports a small delta of new messages
+    seen since its last flush.
+
+    mode="replace": existing counts are overwritten with the given value —
+    for the historical backfill scanner, which recomputes the true total
+    for whatever (discord_id, date, category) triples it scans each run.
+    Re-running a backfill over the same window must be idempotent; treating
+    a fresh full recount as an *increment* on top of a prior run's numbers
+    is what silently inflated historical counts by orders of magnitude
+    (one day hit 2.3M "posts") before this was caught and the corrupted
+    rows purged. See docs/RELEASE notes / audit_log for the incident.
     """
     from app.db import db
     from sqlalchemy import text
@@ -2004,10 +2017,20 @@ def discord_activity_record():
     if len(entries) > 2000:
         return jsonify({'error': 'too many entries'}), 400
 
+    mode = str(body.get('mode', 'increment')).strip().lower()
+    if mode not in ('increment', 'replace'):
+        mode = 'increment'
+
     _valid_categories = {'ic', 'ooc', 'rolls', 'cubby'}
+    # Generous per-entry ceiling — no legitimate human posts anywhere near
+    # this many times in one channel category in one day. Catches the next
+    # scanning/flush bug before it can silently inflate the table again,
+    # rather than only ever finding out by eyeballing totals after the fact.
+    _max_reasonable_count = 1000
 
     # Validate and collect entries
     valid: list[dict] = []
+    rejected_implausible = 0
     for entry in entries:
         discord_id = str(entry.get('discord_id', '')).strip()
         date = str(entry.get('date', '')).strip()
@@ -2017,6 +2040,13 @@ def discord_activity_record():
         except (TypeError, ValueError):
             continue
         if not discord_id or not date or category not in _valid_categories or count <= 0:
+            continue
+        if count > _max_reasonable_count:
+            rejected_implausible += 1
+            current_app.logger.warning(
+                'discord_activity_record: rejected implausible count %s for discord_id=%s date=%s category=%s (mode=%s)',
+                count, discord_id, date, category, mode,
+            )
             continue
         valid.append({'did': discord_id, 'dt': date, 'cat': category, 'cnt': count})
 
@@ -2030,12 +2060,17 @@ def discord_activity_record():
             params[f'dt_{i}'] = row['dt']
             params[f'cat_{i}'] = row['cat']
             params[f'cnt_{i}'] = row['cnt']
+        conflict_update = (
+            'count = excluded.count'
+            if mode == 'replace'
+            else 'count = discord_post_counts.count + excluded.count'
+        )
         db.session.execute(
             text(
                 f"INSERT INTO discord_post_counts (discord_id, date, category, count)"
                 f" VALUES {placeholders}"
                 f" ON CONFLICT(discord_id, date, category)"
-                f" DO UPDATE SET count = discord_post_counts.count + excluded.count"
+                f" DO UPDATE SET {conflict_update}"
             ),
             params,
         )
@@ -2067,7 +2102,7 @@ def discord_activity_record():
             )
 
     db.session.commit()
-    return jsonify({'ok': True, 'flushed': len(valid)})
+    return jsonify({'ok': True, 'flushed': len(valid), 'rejected': rejected_implausible})
 
 
 @bp.route('/periods/recent', methods=['GET'])

--- a/apps/web/tests/test_discord_activity_record.py
+++ b/apps/web/tests/test_discord_activity_record.py
@@ -1,0 +1,130 @@
+import time
+
+import pytest
+from flask import Flask
+
+import app as app_module
+from app.blueprints.api import bp as api_bp
+import app.blueprints.api as api_module
+from app.db import DiscordPostCount, db
+from app.db_service import DBService
+
+
+@pytest.fixture()
+def app_ctx():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WEB_APP_API_TOKEN'] = 'legacy-token'
+    app.config['WEB_APP_API_READ_TOKEN'] = 'read-token'
+    app.config['WEB_APP_API_WRITE_TOKEN'] = 'write-token'
+    app.config['BOT_API_REPLAY_PROTECTION_ENABLED'] = True
+    app.config['BOT_API_REPLAY_WINDOW_SECONDS'] = 300
+    app.config['BOT_API_NONCE_TTL_SECONDS'] = 600
+    app.config['BOT_API_NONCE_CACHE_SIZE'] = 1000
+    app.config['ALLOWED_DISCORD_IDS'] = {'999999999999999999'}
+    db.init_app(app)
+    app.register_blueprint(api_bp, url_prefix='/api')
+    with app.app_context():
+        db.create_all()
+        app_module.db_service = DBService()
+        api_module.db_service = app_module.db_service
+        yield app
+
+
+def _write_headers(nonce='n1'):
+    return {
+        'Authorization': 'Bearer write-token',
+        'X-Request-Timestamp': str(int(time.time())),
+        'X-Request-Nonce': nonce,
+    }
+
+
+def _post(client, entries, mode=None, nonce='n1'):
+    body = {'entries': entries}
+    if mode is not None:
+        body['mode'] = mode
+    return client.post('/api/discord-activity/record', headers=_write_headers(nonce=nonce), json=body)
+
+
+def _entry(count, discord_id='u1', date='2026-06-01', category='ic'):
+    return {'discord_id': discord_id, 'date': date, 'category': category, 'count': count}
+
+
+def _row_count(app):
+    with app.app_context():
+        row = DiscordPostCount.query.filter_by(discord_id='u1', date='2026-06-01', category='ic').first()
+        return row.count if row else None
+
+
+def test_default_mode_is_additive(app_ctx):
+    client = app_ctx.test_client()
+    resp1 = _post(client, [_entry(5)], nonce='a1')
+    assert resp1.status_code == 200
+    resp2 = _post(client, [_entry(3)], nonce='a2')
+    assert resp2.status_code == 200
+    assert _row_count(app_ctx) == 8
+
+
+def test_explicit_increment_mode_is_additive(app_ctx):
+    client = app_ctx.test_client()
+    _post(client, [_entry(5)], mode='increment', nonce='b1')
+    _post(client, [_entry(3)], mode='increment', nonce='b2')
+    assert _row_count(app_ctx) == 8
+
+
+def test_replace_mode_overwrites_instead_of_adding(app_ctx):
+    """Regression test for the corruption incident: re-running a backfill
+    scan over the same window must not compound counts on top of the prior
+    run's numbers — each run recomputes the true total from scratch."""
+    client = app_ctx.test_client()
+    _post(client, [_entry(50)], mode='replace', nonce='c1')
+    assert _row_count(app_ctx) == 50
+
+    # Same scan re-run, same window, same recomputed total — must land back
+    # at 50, not 100.
+    _post(client, [_entry(50)], mode='replace', nonce='c2')
+    assert _row_count(app_ctx) == 50
+
+
+def test_replace_mode_reflects_a_lower_recount(app_ctx):
+    client = app_ctx.test_client()
+    _post(client, [_entry(50)], mode='replace', nonce='d1')
+    _post(client, [_entry(12)], mode='replace', nonce='d2')
+    assert _row_count(app_ctx) == 12
+
+
+def test_invalid_mode_falls_back_to_increment(app_ctx):
+    client = app_ctx.test_client()
+    _post(client, [_entry(5)], mode='bogus', nonce='e1')
+    _post(client, [_entry(3)], mode='bogus', nonce='e2')
+    assert _row_count(app_ctx) == 8
+
+
+def test_implausible_count_rejected_not_stored(app_ctx):
+    client = app_ctx.test_client()
+    resp = _post(client, [_entry(50000)], nonce='f1')
+    assert resp.status_code == 200
+    assert resp.get_json()['rejected'] == 1
+    assert resp.get_json()['flushed'] == 0
+    assert _row_count(app_ctx) is None
+
+
+def test_implausible_count_does_not_block_other_valid_entries_in_same_batch(app_ctx):
+    client = app_ctx.test_client()
+    resp = _post(client, [_entry(50000), _entry(4, discord_id='u2')], nonce='g1')
+    body = resp.get_json()
+    assert body['flushed'] == 1
+    assert body['rejected'] == 1
+
+    with app_ctx.app_context():
+        row = DiscordPostCount.query.filter_by(discord_id='u2', date='2026-06-01', category='ic').first()
+        assert row.count == 4
+
+
+def test_count_at_ceiling_is_accepted(app_ctx):
+    client = app_ctx.test_client()
+    resp = _post(client, [_entry(1000)], nonce='h1')
+    assert resp.get_json()['rejected'] == 0
+    assert _row_count(app_ctx) == 1000


### PR DESCRIPTION
## Summary

Root-cause fix for the corruption incident found while building the Server Health dashboard (#334): 713 `discord_post_counts` rows inflated up to 2.3M "posts" in a single day, purged from prod after discovery.

**Root cause**: `/discord-activity/record` always upserted additively (`count = count + excluded.count`). That's correct for the live tracker (which only ever reports a small delta of new messages since its own last flush) — but `/lasombra scan-activity` recomputes the *true total* for a historical window from Discord's message history every time it runs. Re-running the backfill just piled a fresh full recount on top of whatever the previous run had already written, with no idempotency guard. Repeated staff test runs during the feature's initial rollout compounded this into the numbers we found.

## Changes

- **`api.py`**: `/discord-activity/record` now accepts `"mode": "increment" | "replace"` (default `increment`, unchanged for existing/live callers). Backfill runs use `replace`, so re-scanning the same window lands back at the correct total instead of compounding.
- **Sanity ceiling**: added a server-side cap (1000/entry) that rejects and logs implausible single counts instead of silently storing them — defense-in-depth against the *next* bug in this class, not just this one. Response now includes `rejected` alongside `flushed`.
- **`activityBackfillScanner.ts`**: subtler fix here — the scanner flushes its shared count map periodically *within a single run* as it works through channels, so the same `(discord_id, date, category)` key can legitimately split across two flush calls in one run (e.g. two different IC channels both posted-in by the same person on the same day). Naively sending `mode: replace` on every flush would have silently dropped the earlier flush's contribution. `flushEntries()` now tracks which keys this run has already flushed and only replaces on a key's *first* flush this run; later flushes of the same key within the same run increment on top of this run's own contribution, not a stale prior run's.
- **`adapter.ts`**: `recordDiscordActivity()` takes an optional `mode` param, defaulting to unset (server defaults to `increment`) — the live tracker's call site needs zero changes.

## Test plan
- [x] `tests/test_discord_activity_record.py` (new, 8 tests) — increment default, explicit replace overwriting vs. compounding, invalid-mode fallback, sanity-ceiling rejection alongside valid entries in the same batch
- [x] `src/__tests__/activityBackfillScanner.test.ts` (new, 6 tests) — `flushEntries`' replace-first/increment-after-within-run splitting logic, including the mixed-batch case
- [x] `npm run typecheck && npm run lint && npm run format:check && npm run test && npm run build` in `apps/bot` — 241/241 pass
- [x] `./venv/bin/pytest -q` in `apps/web` — 221/221 pass
- [ ] Next time `/lasombra scan-activity` is run for real, confirm re-running it over an already-scanned window doesn't inflate totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)