### PR TITLE
Add new-PCs-approved metric to Server Health dashboard

### DIFF
--- a/apps/web/app/activity_health.py
+++ b/apps/web/app/activity_health.py
@@ -136,3 +136,25 @@ def build_health_report(
         'not_posting': not_posting,
         'unlinked_character_count': len(unlinked_characters),
     }
+
+
+def build_new_characters_report(characters: list[dict], prev_characters: list[dict]) -> dict:
+    """characters/prev_characters: [{'character_name', 'clan', 'sect',
+    'age_category', 'date_added'}, ...] — already filtered by the caller to
+    the current/prior windows respectively. date_added is only used for
+    sort order here; the caller owns date parsing and windowing.
+    """
+    count = len(characters)
+    prev_count = len(prev_characters)
+    if prev_count > 0:
+        delta_pct = round((count - prev_count) / prev_count * 100)
+    elif count > 0:
+        delta_pct = None  # no prior baseline to compare against
+    else:
+        delta_pct = 0
+
+    return {
+        'count': count,
+        'delta_pct': delta_pct,
+        'characters': sorted(characters, key=lambda c: c['date_added']),
+    }

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -337,17 +337,25 @@ def health():
 
     report = build_health_report(rows, prev_rows, active_characters, display_names, start, end)
 
-    # ── New PCs approved (date_added is 'YYYYMMDD HH:MM:SS' — parse rather
-    # than string-compare against the '%Y-%m-%d' window bounds; a raw string
-    # comparison between those two formats silently breaks, as it already
-    # has elsewhere in this codebase). ─────────────────────────────────────
+    # ── New PCs approved. date_added has two formats in the wild, parsed
+    # rather than string-compared against the '%Y-%m-%d' window bounds (a
+    # raw string comparison between mismatched formats silently breaks, as
+    # it already has elsewhere in this codebase):
+    #   - 'YYYYMMDD HH:MM:SS' — every live approval path (db_service.py's
+    #     _now_str() fallback in add_character).
+    #   - 'YYYY-MM-DD' — rows created by the one-time CSV migration
+    #     (migrate_csv_to_sheets.py), which predates the live approval flow.
+    # ─────────────────────────────────────────────────────────────────────
     def _parse_date_added(raw: str):
         if not raw:
             return None
-        try:
-            return datetime.strptime(raw.strip(), '%Y%m%d %H:%M:%S').date()
-        except ValueError:
-            return None
+        raw = raw.strip()
+        for fmt in ('%Y%m%d %H:%M:%S', '%Y-%m-%d'):
+            try:
+                return datetime.strptime(raw, fmt).date()
+            except ValueError:
+                continue
+        return None
 
     all_chars_dated = [
         (c, parsed) for c in DbCharacter.query.all()

--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, flash, redirect, render_template, request, session, url_for
 
-from app.activity_health import build_health_report, shift_window
+from app.activity_health import build_health_report, build_new_characters_report, shift_window
 from app.auth import require_staff
 from app.db import (
     DbCharacter,
@@ -337,9 +337,52 @@ def health():
 
     report = build_health_report(rows, prev_rows, active_characters, display_names, start, end)
 
+    # ── New PCs approved (date_added is 'YYYYMMDD HH:MM:SS' — parse rather
+    # than string-compare against the '%Y-%m-%d' window bounds; a raw string
+    # comparison between those two formats silently breaks, as it already
+    # has elsewhere in this codebase). ─────────────────────────────────────
+    def _parse_date_added(raw: str):
+        if not raw:
+            return None
+        try:
+            return datetime.strptime(raw.strip(), '%Y%m%d %H:%M:%S').date()
+        except ValueError:
+            return None
+
+    all_chars_dated = [
+        (c, parsed) for c in DbCharacter.query.all()
+        if (parsed := _parse_date_added(c.date_added)) is not None
+    ]
+    earliest_char_date = min((d for _, d in all_chars_dated), default=None)
+    earliest_char_date_str = earliest_char_date.isoformat() if earliest_char_date else None
+
+    start_d = datetime.strptime(start, '%Y-%m-%d').date()
+    end_d = datetime.strptime(end, '%Y-%m-%d').date()
+    prev_start_d = datetime.strptime(prev_start, '%Y-%m-%d').date()
+    prev_end_d = datetime.strptime(prev_end, '%Y-%m-%d').date()
+
+    def _char_dict(c, d):
+        return {
+            'character_name': c.character_name,
+            'clan': c.clan or '',
+            'sect': c.sect or '',
+            'age_category': c.age_category or '',
+            'date_added': d.isoformat(),
+        }
+
+    new_chars_current = [_char_dict(c, d) for c, d in all_chars_dated if start_d <= d <= end_d]
+    new_chars_prev = (
+        []
+        if (earliest_char_date and prev_start_d < earliest_char_date)
+        else [_char_dict(c, d) for c, d in all_chars_dated if prev_start_d <= d <= prev_end_d]
+    )
+    new_characters_report = build_new_characters_report(new_chars_current, new_chars_prev)
+
     return render_template(
         'reports/health.html',
         report=report,
+        new_characters=new_characters_report,
+        earliest_char_date=earliest_char_date_str,
         range_days=range_days,
         range_options=HEALTH_RANGE_OPTIONS,
         start=start,

--- a/apps/web/app/templates/reports/health.html
+++ b/apps/web/app/templates/reports/health.html
@@ -79,6 +79,55 @@
     </div>
   </div>
 
+  {# ── Growth ── #}
+  <div class="row g-3 mb-4">
+    <div class="col-6 col-md-3">
+      <div class="stat-card h-100">
+        <span class="stat-label">New PCs Approved</span>
+        <span class="stat-value">{{ new_characters.count }}</span>
+        <span class="stat-sub">
+          {% if new_characters.delta_pct is none %}
+            no prior baseline
+          {% elif new_characters.delta_pct > 0 %}
+            <span style="color:#0ca30c;"><i class="bi bi-arrow-up-short"></i>{{ new_characters.delta_pct }}%</span> vs prior period
+          {% elif new_characters.delta_pct < 0 %}
+            <span style="color:var(--accent-soft);"><i class="bi bi-arrow-down-short"></i>{{ -new_characters.delta_pct }}%</span> vs prior period
+          {% else %}
+            flat vs prior period
+          {% endif %}
+        </span>
+      </div>
+    </div>
+  </div>
+
+  {% if new_characters.characters %}
+  <div class="card mb-4">
+    <div class="card-header py-2 fw-semibold">
+      <i class="bi bi-person-plus me-1"></i> New Characters ({{ start }}–{{ end }})
+    </div>
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-dark table-hover table-sm align-middle mb-0">
+          <thead>
+            <tr><th>Character</th><th>Clan</th><th>Sect</th><th>Age</th><th>Approved</th></tr>
+          </thead>
+          <tbody>
+            {% for c in new_characters.characters %}
+            <tr>
+              <td class="fw-semibold">{{ c.character_name }}</td>
+              <td>{{ c.clan or '—' }}</td>
+              <td>{{ c.sect or '—' }}</td>
+              <td class="text-capitalize">{{ c.age_category or '—' }}</td>
+              <td class="font-monospace text-muted small">{{ c.date_added }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   {# ── Daily activity by category ── #}
   <div class="card mb-4">
     <div class="card-header py-2 d-flex align-items-center justify-content-between flex-wrap gap-2">

--- a/apps/web/tests/test_activity_health.py
+++ b/apps/web/tests/test_activity_health.py
@@ -1,4 +1,4 @@
-from app.activity_health import build_health_report, daterange, shift_window
+from app.activity_health import build_health_report, build_new_characters_report, daterange, shift_window
 
 
 def test_daterange_inclusive():
@@ -175,3 +175,38 @@ def test_not_posting_blank_display_name_when_neither_source_available():
     active_characters = [{'character_name': 'Zara', 'player_discord': 'p2'}]
     report = build_health_report([], [], active_characters, {}, '2026-06-01', '2026-06-01')
     assert report['not_posting'][0]['display_name'] == ''
+
+
+def _char(name, date_added='20260601 12:00:00', **overrides):
+    return {
+        'character_name': name, 'clan': '', 'sect': '', 'age_category': '',
+        'date_added': date_added, **overrides,
+    }
+
+
+def test_new_characters_count_and_sorted_by_date_added():
+    characters = [
+        _char('Zara', date_added='20260603 10:00:00'),
+        _char('Marcus', date_added='20260601 09:00:00'),
+    ]
+    report = build_new_characters_report(characters, [])
+
+    assert report['count'] == 2
+    assert [c['character_name'] for c in report['characters']] == ['Marcus', 'Zara']
+
+
+def test_new_characters_delta_pct_against_prior_window():
+    report = build_new_characters_report([_char('A'), _char('B')], [_char('C')])
+    assert report['delta_pct'] == 100
+
+
+def test_new_characters_delta_none_when_no_prior_baseline():
+    report = build_new_characters_report([_char('A')], [])
+    assert report['delta_pct'] is None
+
+
+def test_new_characters_delta_zero_when_both_windows_empty():
+    report = build_new_characters_report([], [])
+    assert report['delta_pct'] == 0
+    assert report['count'] == 0
+    assert report['characters'] == []

--- a/apps/web/tests/test_reports_health_route.py
+++ b/apps/web/tests/test_reports_health_route.py
@@ -65,8 +65,15 @@ def _days_ago(n: int) -> str:
 
 
 def _date_added_days_ago(n: int) -> str:
-    """DbCharacter.date_added's actual on-disk format: 'YYYYMMDD HH:MM:SS'."""
+    """DbCharacter.date_added's on-disk format for live approvals: 'YYYYMMDD HH:MM:SS'."""
     return (datetime.now(timezone.utc) - timedelta(days=n)).strftime('%Y%m%d %H:%M:%S')
+
+
+def _migrated_date_added_days_ago(n: int) -> str:
+    """The other on-disk format: 'YYYY-MM-DD', written by the one-time CSV
+    migration (migrate_csv_to_sheets.py) for characters that predate the
+    live approval flow."""
+    return (datetime.now(timezone.utc) - timedelta(days=n)).strftime('%Y-%m-%d')
 
 
 def test_delta_suppressed_when_prior_window_would_be_truncated():
@@ -150,3 +157,24 @@ def test_new_characters_within_window_appear_and_outside_window_excluded():
         assert 'Marcus' in html
         assert 'Tremere' in html
         assert 'OldTimer' not in html
+
+
+def test_new_characters_recognizes_migrated_date_added_format():
+    """Regression test: characters created via the one-time CSV migration
+    have date_added stored as 'YYYY-MM-DD' instead of the live approval
+    flow's 'YYYYMMDD HH:MM:SS' — both formats must be recognized, or
+    migrated rows silently vanish from the new-PCs-approved report."""
+    app = _app()
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='MigratedCharacter', clan='Ventrue', active=True,
+            date_added=_migrated_date_added_days_ago(5),
+        ))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client)
+        resp = client.get('/reports/health?range=30')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'MigratedCharacter' in html

--- a/apps/web/tests/test_reports_health_route.py
+++ b/apps/web/tests/test_reports_health_route.py
@@ -64,6 +64,11 @@ def _days_ago(n: int) -> str:
     return (datetime.now(timezone.utc).date() - timedelta(days=n)).isoformat()
 
 
+def _date_added_days_ago(n: int) -> str:
+    """DbCharacter.date_added's actual on-disk format: 'YYYYMMDD HH:MM:SS'."""
+    return (datetime.now(timezone.utc) - timedelta(days=n)).strftime('%Y%m%d %H:%M:%S')
+
+
 def test_delta_suppressed_when_prior_window_would_be_truncated():
     """A full 30-day current window compared against a prior 30-day window
     that's truncated (tracking only started partway through it) must not
@@ -122,3 +127,26 @@ def test_not_posting_shows_roster_name_for_a_never_posted_active_player():
         assert resp.status_code == 200
         html = resp.data.decode()
         assert 'ZaraPlayer' in html
+
+
+def test_new_characters_within_window_appear_and_outside_window_excluded():
+    app = _app()
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='Marcus', clan='Tremere', active=True,
+            date_added=_date_added_days_ago(5),  # inside a 30-day window
+        ))
+        db.session.add(DbCharacter(
+            character_name='OldTimer', clan='Ventrue', active=True,
+            date_added=_date_added_days_ago(90),  # well outside a 30-day window
+        ))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client)
+        resp = client.get('/reports/health?range=30')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'Marcus' in html
+        assert 'Tremere' in html
+        assert 'OldTimer' not in html


### PR DESCRIPTION
## Summary

Adds a "New PCs Approved" stat tile (with period-over-period delta) and a table of newly approved characters (name/clan/sect/age/approved date) to `/reports/health` — the "new cubbies" metric requested, since that's synonymous with new-PC approvals in practice.

This data already existed — `DbCharacter.date_added` is set on every approval path (web `cc_admin.draft_approve` and bot `/lasombra approve` → `POST /api/roster/character`), so no new tracking was needed for this one.

**Format gotcha worth flagging**: `date_added` is stored as `'YYYYMMDD HH:MM:SS'` (no separators), and there's a pre-existing bug elsewhere in this codebase (`character_creator.py`'s `cc_eligibility`) that compares this format against `'%Y-%m-%d'`-formatted bounds as raw strings — which silently does the wrong thing (lexical comparison of `-` vs digit characters). This PR parses with `datetime.strptime` instead of repeating that mistake; didn't touch the pre-existing bug itself since it's out of scope here.

Same truncated-baseline guard as the existing posting-activity delta: if the natural prior comparison window would start before the earliest character's `date_added`, the delta is suppressed ("no prior baseline") rather than compared against a shorter window.

## Scope note

This is 1 of 3 metrics requested for server growth reporting. New Discord member joins and Kindred/Ghoul/Mortal role-gain tracking (the "lurker → active player" funnel) are **not** included here — neither is tracked anywhere today (no `guildMemberAdd`/`guildMemberUpdate` listener exists for this purpose), so they need a new bot-side tracking pipeline (new event listeners, new table, new ingestion endpoint) rather than a quick dashboard addition. Scoping that as separate follow-up work.

## Test plan
- [x] New tests in `test_activity_health.py` (4) and `test_reports_health_route.py` (1) — pure aggregation logic + a route-level in/out-of-window regression test
- [x] `./venv/bin/pytest -q` — 249/249 pass
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)