### PR TITLE
Add ack/dismiss for Sheets Sync Errors

### DIFF
--- a/apps/web/app/blueprints/audit.py
+++ b/apps/web/app/blueprints/audit.py
@@ -157,6 +157,38 @@ def bulk_dismiss_errors():
     return jsonify({'ok': True, 'count': updated})
 
 
+@bp.route('/errors/sync/<int:entry_id>/dismiss', methods=['POST'])
+@require_staff
+def dismiss_sync_error(entry_id: int):
+    from app.db import DbSheetsSyncError, db
+    entry = DbSheetsSyncError.query.get_or_404(entry_id)
+    entry.dismissed = True
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/errors/sync/bulk-dismiss', methods=['POST'])
+@require_staff
+def bulk_dismiss_sync_errors():
+    """Dismiss many Sheets sync error entries at once (checkbox selection on /audit/errors)."""
+    from app.db import DbSheetsSyncError, db
+    body = request.get_json(silent=True) or {}
+    raw_ids = body.get('ids')
+    if not isinstance(raw_ids, list) or not raw_ids:
+        return jsonify({'error': 'ids must be a non-empty array'}), 400
+    try:
+        entry_ids = [int(i) for i in raw_ids]
+    except (TypeError, ValueError):
+        return jsonify({'error': 'ids must be integers'}), 400
+    updated = (
+        DbSheetsSyncError.query
+        .filter(DbSheetsSyncError.id.in_(entry_ids))
+        .update({'dismissed': True}, synchronize_session=False)
+    )
+    db.session.commit()
+    return jsonify({'ok': True, 'count': updated})
+
+
 @bp.route('/errors')
 @require_staff
 def errors():
@@ -197,9 +229,12 @@ def errors():
     for e in entries:
         event_counts[e['event']] = event_counts.get(e['event'], 0) + 1
 
-    # Merge in-memory (real-time, current session) and DB (historical) sync errors
+    # Merge in-memory (real-time, current session — never dismissable, since
+    # it's cleared on process restart anyway) and DB (historical, dismissable)
+    # sync errors. show_dismissed also governs the DB-backed ones here so
+    # there's a single toggle for the whole page.
     rt_errors = _get_recent_sync_errors()
-    db_sync_errors = db_service.get_recent_sync_errors(limit=100)
+    db_sync_errors = db_service.get_recent_sync_errors(limit=100, show_dismissed=show_dismissed)
     db_keys = {(e['timestamp'], e['operation'], e['error']) for e in db_sync_errors}
     rt_only = [e for e in rt_errors
                if (e['timestamp'], e['operation'], e['error']) not in db_keys]

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -191,6 +191,7 @@ class DbSheetsSyncError(db.Model):
     operation = db.Column(String(100), default='')
     error = db.Column(Text, default='')
     details = db.Column(Text, default='')
+    dismissed = db.Column(Boolean, default=False, nullable=False, index=True)
 
 
 class WikiPage(db.Model):

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -1411,9 +1411,19 @@ class DBService:
         db.session.add(row)
         db.session.commit()
 
-    def get_recent_sync_errors(self, limit: int = 100) -> list[dict]:
-        rows = DbSheetsSyncError.query.order_by(DbSheetsSyncError.id.desc()).limit(limit).all()
+    def get_recent_sync_errors(self, limit: int = 100, show_dismissed: bool = False) -> list[dict]:
+        query = DbSheetsSyncError.query
+        if not show_dismissed:
+            query = query.filter(DbSheetsSyncError.dismissed == False)  # noqa: E712
+        rows = query.order_by(DbSheetsSyncError.id.desc()).limit(limit).all()
         return [
-            {'timestamp': r.timestamp, 'operation': r.operation, 'error': r.error, 'details': r.details}
+            {
+                'id': r.id,
+                'timestamp': r.timestamp,
+                'operation': r.operation,
+                'error': r.error,
+                'details': r.details,
+                'dismissed': r.dismissed,
+            }
             for r in rows
         ]

--- a/apps/web/app/templates/audit/errors.html
+++ b/apps/web/app/templates/audit/errors.html
@@ -26,7 +26,14 @@
 <div class="card mb-4 border-warning">
     <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
         <span><i class="bi bi-cloud-slash"></i> <strong>Sheets Sync Errors</strong></span>
-        <span class="badge bg-dark">{{ sync_errors|length }}</span>
+        <div class="d-flex align-items-center gap-2">
+            <span class="badge bg-dark">{{ sync_errors|length }}</span>
+            {% if sync_errors | selectattr('id') | list %}
+            <button id="sync-dismiss-all-btn" class="btn btn-sm btn-outline-dark">
+                <i class="bi bi-check2-all"></i> Dismiss all
+            </button>
+            {% endif %}
+        </div>
     </div>
     <div class="table-responsive">
         <table class="table table-sm table-dark mb-0">
@@ -35,14 +42,25 @@
                     <th>Time (Eastern)</th>
                     <th>Operation</th>
                     <th>Error</th>
+                    <th style="width: 40px;"></th>
                 </tr>
             </thead>
             <tbody>
                 {% for e in sync_errors %}
-                <tr>
+                <tr id="sync-error-row-{{ e.id }}">
                     <td class="text-muted small text-nowrap">{{ e.timestamp | to_eastern }}</td>
                     <td><code>{{ e.operation }}</code></td>
                     <td class="text-warning small">{{ e.error }}</td>
+                    <td class="text-center">
+                        {% if e.id %}
+                        <button class="btn btn-sm btn-outline-secondary sync-dismiss-btn" title="Dismiss"
+                                data-id="{{ e.id }}" data-url="{{ url_for('audit.dismiss_sync_error', entry_id=e.id) }}">
+                            <i class="bi bi-check-lg"></i>
+                        </button>
+                        {% else %}
+                        <span class="text-muted small" title="Real-time entry — clears automatically on next process restart">—</span>
+                        {% endif %}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -187,6 +205,51 @@
       })
       .catch(() => { btn.disabled = false; });
   });
+
+  document.addEventListener('click', function(e) {
+    const btn = e.target.closest('.sync-dismiss-btn');
+    if (!btn) return;
+    const id = btn.dataset.id;
+    const url = btn.dataset.url;
+    btn.disabled = true;
+    fetch(url, { method: 'POST', headers: { 'X-CSRFToken': csrfToken() } })
+      .then(r => r.json())
+      .then(data => {
+        if (data.ok) {
+          const row = document.getElementById('sync-error-row-' + id);
+          if (row) row.remove();
+        } else {
+          btn.disabled = false;
+        }
+      })
+      .catch(() => { btn.disabled = false; });
+  });
+
+  (function () {
+    const dismissAllBtn = document.getElementById('sync-dismiss-all-btn');
+    if (!dismissAllBtn) return;
+    dismissAllBtn.addEventListener('click', function () {
+      const ids = Array.from(document.querySelectorAll('.sync-dismiss-btn')).map((b) => parseInt(b.dataset.id, 10));
+      if (ids.length === 0) return;
+      dismissAllBtn.disabled = true;
+      fetch('{{ url_for("audit.bulk_dismiss_sync_errors") }}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken() },
+        body: JSON.stringify({ ids: ids }),
+      })
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.ok) {
+            ids.forEach((id) => {
+              const row = document.getElementById('sync-error-row-' + id);
+              if (row) row.remove();
+            });
+          }
+          dismissAllBtn.disabled = false;
+        })
+        .catch(() => { dismissAllBtn.disabled = false; });
+    });
+  })();
 
   (function () {
     const selectAll = document.getElementById('select-all-errors');

--- a/apps/web/migrations/versions/7e2b9c4f1a83_add_dismissed_to_sheets_sync_errors.py
+++ b/apps/web/migrations/versions/7e2b9c4f1a83_add_dismissed_to_sheets_sync_errors.py
@@ -1,0 +1,46 @@
+"""add dismissed column to sheets_sync_errors
+
+Revision ID: 7e2b9c4f1a83
+Revises: 235f1a01929d
+Create Date: 2026-07-08
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7e2b9c4f1a83'
+down_revision = '235f1a01929d'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    conn = op.get_bind()
+    rows = conn.execute(sa.text(f'PRAGMA table_info("{table_name}")')).fetchall()
+    return any(row[1] == column_name for row in rows)
+
+
+def _index_exists(index_name: str) -> bool:
+    conn = op.get_bind()
+    row = conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='index' AND name=:n"),
+        {'n': index_name},
+    ).fetchone()
+    return row is not None
+
+
+def upgrade():
+    if not _column_exists('sheets_sync_errors', 'dismissed'):
+        op.add_column(
+            'sheets_sync_errors',
+            sa.Column('dismissed', sa.Boolean, nullable=False, server_default='0'),
+        )
+    if not _index_exists('ix_sheets_sync_errors_dismissed'):
+        op.create_index('ix_sheets_sync_errors_dismissed', 'sheets_sync_errors', ['dismissed'])
+
+
+def downgrade():
+    op.drop_index('ix_sheets_sync_errors_dismissed', table_name='sheets_sync_errors')
+    op.drop_column('sheets_sync_errors', 'dismissed')

--- a/apps/web/tests/test_dismiss_sync_errors.py
+++ b/apps/web/tests/test_dismiss_sync_errors.py
@@ -1,0 +1,115 @@
+"""Tests for POST /audit/errors/sync/<id>/dismiss and /audit/errors/sync/bulk-dismiss."""
+
+from flask import Blueprint, Flask
+
+from app.blueprints.audit import bp as audit_bp
+from app.db import DbSheetsSyncError, db
+
+# require_staff redirects unauthenticated requests to 'dashboard.login'. See
+# tests/test_sheet_import_approval.py for why a minimal stand-in is used
+# instead of the real dashboard blueprint (module-level limiter.limit()).
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test'
+    db.init_app(app)
+    app.register_blueprint(audit_bp, url_prefix='/audit')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _staff_client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+    return client
+
+
+def _seed(app, n):
+    with app.app_context():
+        ids = []
+        for i in range(n):
+            entry = DbSheetsSyncError(timestamp='x', operation=f'op{i}', error='boom', details='')
+            db.session.add(entry)
+            db.session.flush()
+            ids.append(entry.id)
+        db.session.commit()
+        return ids
+
+
+def test_dismiss_single_requires_staff():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post('/audit/errors/sync/1/dismiss')
+    assert res.status_code == 302
+
+
+def test_dismiss_single_marks_dismissed():
+    app = _app()
+    ids = _seed(app, 1)
+    client = _staff_client(app)
+    res = client.post(f'/audit/errors/sync/{ids[0]}/dismiss')
+    assert res.status_code == 200
+    assert res.get_json() == {'ok': True}
+    with app.app_context():
+        assert db.session.get(DbSheetsSyncError, ids[0]).dismissed is True
+
+
+def test_dismiss_single_404s_for_unknown_id():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/sync/99999/dismiss')
+    assert res.status_code == 404
+
+
+def test_bulk_dismiss_requires_staff():
+    app = _app()
+    with app.test_client() as client:
+        res = client.post('/audit/errors/sync/bulk-dismiss', json={'ids': [1]})
+    assert res.status_code == 302
+
+
+def test_bulk_dismisses_only_the_given_ids():
+    app = _app()
+    ids = _seed(app, 3)
+    client = _staff_client(app)
+    res = client.post('/audit/errors/sync/bulk-dismiss', json={'ids': [ids[0], ids[1]]})
+    assert res.status_code == 200
+    assert res.get_json() == {'ok': True, 'count': 2}
+    with app.app_context():
+        assert db.session.get(DbSheetsSyncError, ids[0]).dismissed is True
+        assert db.session.get(DbSheetsSyncError, ids[1]).dismissed is True
+        assert db.session.get(DbSheetsSyncError, ids[2]).dismissed is False
+
+
+def test_bulk_rejects_empty_ids():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/sync/bulk-dismiss', json={'ids': []})
+    assert res.status_code == 400
+
+
+def test_bulk_rejects_missing_ids():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/sync/bulk-dismiss', json={})
+    assert res.status_code == 400
+
+
+def test_bulk_rejects_non_integer_ids():
+    app = _app()
+    client = _staff_client(app)
+    res = client.post('/audit/errors/sync/bulk-dismiss', json={'ids': ['not-a-number']})
+    assert res.status_code == 400

--- a/apps/web/tests/test_sheets_sync_errors.py
+++ b/apps/web/tests/test_sheets_sync_errors.py
@@ -56,3 +56,32 @@ def test_log_sync_error_with_details():
         svc.log_sheets_sync_error('reconcile', 'ok', details='{"claims_appended": 1}')
         errors = svc.get_recent_sync_errors()
     assert errors[0]['details'] == '{"claims_appended": 1}'
+
+
+def test_new_errors_default_to_not_dismissed():
+    app = _app()
+    svc = DBService(sheets_client=None)
+    with app.app_context():
+        svc.log_sheets_sync_error('op', 'err')
+        errors = svc.get_recent_sync_errors()
+    assert errors[0]['dismissed'] is False
+    assert errors[0]['id'] is not None
+
+
+def test_dismissed_errors_excluded_by_default():
+    from app.db import DbSheetsSyncError
+
+    app = _app()
+    svc = DBService(sheets_client=None)
+    with app.app_context():
+        svc.log_sheets_sync_error('op_a', 'err_a')
+        svc.log_sheets_sync_error('op_b', 'err_b')
+        row = DbSheetsSyncError.query.filter_by(operation='op_a').first()
+        row.dismissed = True
+        db.session.commit()
+
+        errors = svc.get_recent_sync_errors()
+        assert [e['operation'] for e in errors] == ['op_b']
+
+        errors_with_dismissed = svc.get_recent_sync_errors(show_dismissed=True)
+        assert {e['operation'] for e in errors_with_dismissed} == {'op_a', 'op_b'}


### PR DESCRIPTION
## Summary

The "Sheets Sync Errors" section on `/audit/errors` had no way to acknowledge/clear stale entries — some were sitting there from 6/30 and earlier with no path to dismiss them, unlike the "Error Alerts" (bot log) table right below it, which already has per-row and bulk dismiss.

## Changes

- `DbSheetsSyncError` gets a `dismissed` column (hand-written migration — this app's `create_app()` always runs `db.create_all()` before Alembic's autogenerate can diff, so new columns/tables are always hand-written against the `existing_tables`/`_column_exists` guard pattern already established here; this one is modeled directly on `a3c7d1e9f2b4_fix_add_dismissed_to_app_log_entries.py`).
- `db_service.get_recent_sync_errors` now returns `id`/`dismissed` and takes a `show_dismissed` flag, filtering dismissed rows out by default (mirrors `AppLogEntry`'s existing behavior).
- New `POST /audit/errors/sync/<id>/dismiss` and `POST /audit/errors/sync/bulk-dismiss` routes.
- Template: per-row dismiss button on each Sheets Sync Error row, plus a "Dismiss all" button in the card header (the backlog described is several rows at once, not a one-off). The page's existing "Show dismissed" toggle now governs this section too — one toggle for the whole page.
- Real-time (in-memory, current-process-only) sync errors have no DB id and just render without a dismiss button — they clear on their own at the next process/Cloud Run instance restart, so there's nothing meaningful to persist an ack against.

## Test plan
- [x] Verified the migration against a DB genuinely at the prior schema head (not one where `create_all()` already built the column)
- [x] `test_dismiss_sync_errors.py` (8 tests) — single/bulk dismiss, auth, validation, 404
- [x] `test_sheets_sync_errors.py` (+2) — `show_dismissed` filtering in `get_recent_sync_errors`
- [x] Manual smoke test: seeded one dismissed + one active sync error, confirmed the dismissed one is hidden by default and appears with `?show_dismissed=1`
- [x] `./venv/bin/pytest -q` — 279/279 pass; `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)