### PR TITLE
Add optional nickname/alias field to /contact

### DIFF
--- a/apps/bot/src/commands/contact.ts
+++ b/apps/bot/src/commands/contact.ts
@@ -195,7 +195,17 @@ async function handleSend(interaction: ChatInputCommandInteraction, ctx: Command
     .setPlaceholder('Type your text...')
     .setMaxLength(1500)
     .setRequired(true);
-  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
+  const aliasInput = new TextInputBuilder()
+    .setCustomId('alias')
+    .setLabel('Nickname/Alias (optional)')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('How this character signs this text, if not their real name')
+    .setMaxLength(50)
+    .setRequired(false);
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(aliasInput),
+  );
   await interaction.showModal(modal);
 }
 
@@ -235,7 +245,17 @@ function buildReplyModal(): ModalBuilder {
     .setPlaceholder('Type your reply...')
     .setMaxLength(1500)
     .setRequired(true);
-  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput));
+  const aliasInput = new TextInputBuilder()
+    .setCustomId('alias')
+    .setLabel('Nickname/Alias (optional)')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('How this character signs this text, if not their real name')
+    .setMaxLength(50)
+    .setRequired(false);
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(aliasInput),
+  );
   return modal;
 }
 
@@ -383,6 +403,7 @@ export async function handleContactSendModal(
   }
 
   const message = interaction.fields.getTextInputValue('message').trim();
+  const alias = interaction.fields.getTextInputValue('alias').trim();
 
   const result = await ctx.adapter.createContactThread(
     { requesterDiscordId: interaction.user.id, requesterDiscordName: interaction.user.username },
@@ -404,7 +425,7 @@ export async function handleContactSendModal(
   );
   const { embed, content, components } = buildContactEmbed(
     '📲 New Text Message',
-    pending.senderCharacterName,
+    alias || pending.senderCharacterName,
     otherParticipants.map((p) => p.character_name),
     message,
     otherParticipants,
@@ -442,6 +463,7 @@ export async function handleContactReplyModal(
   }
 
   const message = interaction.fields.getTextInputValue('message').trim();
+  const alias = interaction.fields.getTextInputValue('alias').trim();
 
   const result = await ctx.adapter.replyToContactThread(
     pending.threadId,
@@ -461,7 +483,7 @@ export async function handleContactReplyModal(
 
   const { embed, content, components } = buildContactEmbed(
     '📲 Reply',
-    pending.senderCharacterName,
+    alias || pending.senderCharacterName,
     result.otherParticipants.map((p) => p.character_name),
     message,
     result.otherParticipants,


### PR DESCRIPTION
## Summary
- Adds an optional "Nickname/Alias" text field to both the `/contact send` and `/contact reply` modals.
- When set, the posted embed's **From:** line shows the alias instead of the character's real name — matches existing IC conventions around story-based nicknames used in ongoing conversations.
- Purely a display override: the real character name still drives ownership resolution, thread participation, and mentions on the backend — no schema/DB changes needed.

Closes #343

## Test plan
- [x] `npm run typecheck && npm run lint && npm run test && npm run format:check && npm run build` (bot) — all green
- [ ] On dev guild: `/contact send` a message with an alias filled in, confirm the embed shows the alias in **From:**, confirm leaving it blank still shows the real character name
- [ ] `/contact reply` (both via the reply button and the `/contact reply` command) with and without an alias, same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)