### PR TITLE
Redesign Settings page as a left sub-nav control panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,4 +138,5 @@ The `docker-and-docs-hygiene` job validates all compose files and smoke-starts t
 - `docs/RELEASE_2026-04-07_BROADCAST_AND_SCHEDULER_FIX.md` — staff broadcast overhaul, passage-of-time scheduler fix, MONOREPO_ROOT Docker fix
 - `docs/RELEASE_2026-04-21_BACKGROUNDS_GHOUL_DISCIPLINE_WIKI_OPS.md` — background blanking, Ghoul Discipline spend, error dismissal, wiki bulk delete + sync block tombstones, migration safety fixes
 - `docs/RELEASE_2026-05-20_CHARACTER_APPROVAL_WORKFLOW.md` — character approval workflow: /lasombra approve, edit, update, delete; full roster API
-- `docs/RELEASE_2026-06-18_COTERIE_SYSTEM.md` — **latest release notes** (full coterie lifecycle: player proposal/formation, background donation, XP spend donation, domain ratings, /coterie status bot command, CC schema v7 backgrounds field)
+- `docs/RELEASE_2026-06-18_COTERIE_SYSTEM.md` — full coterie lifecycle: player proposal/formation, background donation, XP spend donation, domain ratings, /coterie status bot command, CC schema v7 backgrounds field
+- `docs/RELEASE_2026-07-10_SETTINGS_CONTROL_PANEL.md` — **latest release notes** (Settings page control-panel redesign: left sub-nav, cross-section search, grouped channel IDs with "used by" badges, Integrations values + why-change copy)

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -52,6 +52,86 @@ def _is_truthy(value: str | None) -> bool:
     return str(value or '').strip().lower() in ('true', '1', 'yes')
 
 
+def _sheet_url(spreadsheet_id: str | None) -> str | None:
+    return f'https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit' if spreadsheet_id else None
+
+
+def _mask_token(token: str | None, keep: int = 4) -> str | None:
+    token = str(token or '')
+    if not token:
+        return None
+    return ('•' * max(0, len(token) - keep)) + token[-keep:]
+
+
+# ── Settings sub-nav (control-panel layout) ────────────────────────────────
+SETTINGS_NAV = [
+    {'group': 'Daily Ops', 'links': [
+        {'id': 'overview', 'label': 'Overview'},
+        {'id': 'staff', 'label': 'Staff & Access'},
+    ]},
+    {'group': 'Bot', 'links': [
+        {'id': 'bot-channels', 'label': 'Channel IDs', 'count_key': 'bot_channels'},
+        {'id': 'bot-flags', 'label': 'Feature Flags', 'count_key': 'bot_flags'},
+        {'id': 'bot-commands', 'label': 'Commands', 'count_key': 'bot_commands'},
+        {'id': 'bot-tuning', 'label': 'Tuning', 'count_key': 'bot_tuning'},
+    ]},
+    {'group': 'Web App', 'links': [
+        {'id': 'web-flags-tuning', 'label': 'Flags & Tuning', 'count_key': 'web_flags_tuning'},
+        {'id': 'web-integrations', 'label': 'Integrations', 'count_key': 'web_integrations'},
+        {'id': 'web-chronicle', 'label': 'Chronicle'},
+    ]},
+]
+VALID_SECTIONS = {item['id'] for group in SETTINGS_NAV for item in group['links']}
+
+# ── Channel ID grouping + "used by" labels for the Bot · Channel IDs pane ──
+CHANNEL_GROUPS = [
+    ('Moderation & Safety', [
+        'BOT_HONEYPOT_CHANNEL_ID', 'BOT_HONEYPOT_MOD_LOG_CHANNEL_ID',
+        'BOT_HONEYPOT_WHITELISTED_ROLE_IDS', 'BOT_MENTION_BREAKER_EXEMPT_ROLE_IDS',
+        'BOT_MENTION_BREAKER_MOD_LOG_CHANNEL_ID', 'BOT_VERIFIED_MEMBER_ROLE_ID',
+    ]),
+    ('New Member Onboarding', [
+        'BOT_CC_TICKET_CATEGORY_IDS', 'BOT_NEW_MEMBER_GATE_WELCOME_CHANNEL_ID',
+        'BOT_NEW_MEMBER_GATE_SHEET_IN_PROGRESS_ROLE_ID', 'BOT_NEW_MEMBER_GATE_LURKER_ROLE_ID',
+    ]),
+    ('In-Character Correspondence', [
+        'BOT_CORRESPONDENCE_DELIVERY_CHANNEL_ID', 'BOT_CORRESPONDENCE_CONTACT_CHANNEL_ID',
+        'BOT_CORRESPONDENCE_PRESTATION_CHANNEL_ID', 'BOT_CORRESPONDENCE_SOCIAL_CHANNEL_ID',
+        'BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID', 'BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID',
+    ]),
+    ('Announcements & Events', [
+        'BOT_ANNOUNCEMENTS_CHANNEL_ID', 'BOT_NEW_NIGHT_BROADCAST_MESSAGE',
+    ]),
+]
+USED_BY = {
+    'BOT_ANNOUNCEMENTS_CHANNEL_ID': '/lasombra broadcast',
+    'BOT_CC_TICKET_CATEGORY_IDS': 'CC Ticket Monitor',
+    'BOT_HONEYPOT_CHANNEL_ID': 'Honeypot Moderation',
+    'BOT_HONEYPOT_MOD_LOG_CHANNEL_ID': 'Honeypot Moderation',
+    'BOT_HONEYPOT_WHITELISTED_ROLE_IDS': 'Honeypot Moderation',
+    'BOT_MENTION_BREAKER_EXEMPT_ROLE_IDS': 'Mention-Spam Circuit Breaker',
+    'BOT_MENTION_BREAKER_MOD_LOG_CHANNEL_ID': 'Mention-Spam Circuit Breaker',
+    'BOT_VERIFIED_MEMBER_ROLE_ID': '/lasombra permissions audit · New Member Gate',
+    'BOT_NEW_MEMBER_GATE_WELCOME_CHANNEL_ID': 'New Member Gate',
+    'BOT_NEW_MEMBER_GATE_SHEET_IN_PROGRESS_ROLE_ID': 'New Member Gate',
+    'BOT_NEW_MEMBER_GATE_LURKER_ROLE_ID': 'New Member Gate',
+    'BOT_NEW_NIGHT_BROADCAST_MESSAGE': 'New Night Broadcast',
+    'BOT_CORRESPONDENCE_DELIVERY_CHANNEL_ID': '/deliver',
+    'BOT_CORRESPONDENCE_CONTACT_CHANNEL_ID': '/contact send · /contact reply',
+    'BOT_CORRESPONDENCE_PRESTATION_CHANNEL_ID': '/prestation owe · status · repay',
+    'BOT_CORRESPONDENCE_SOCIAL_CHANNEL_ID': '/post',
+    'BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID': '/cobweb',
+    'BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID': '/rumor',
+}
+
+
+def _redirect_to_section():
+    section = request.form.get('section', 'overview')
+    if section not in VALID_SECTIONS:
+        section = 'overview'
+    return redirect(url_for('settings.index', section=section))
+
+
 @bp.route('/')
 @require_staff
 def index():
@@ -61,6 +141,9 @@ def index():
     cfg = current_app.config
     overrides = get_all_overrides()
     can_edit = True
+    active_section = request.args.get('section', 'overview')
+    if active_section not in VALID_SECTIONS:
+        active_section = 'overview'
 
     def _eff_bool(key, env_default):
         return get_app_setting(key, env_default)
@@ -198,27 +281,42 @@ def index():
         {
             'label': 'Google Sheets backup',
             'configured': bool(cfg.get('SPREADSHEET_ID')),
+            'value_label': 'Sheet URL',
+            'value': _sheet_url(cfg.get('SPREADSHEET_ID')),
             'description': 'Mirrors writes to a Google Sheet as a backup.',
+            'why_change': "Change if you're moving to a new backup sheet or handing this off to a new spreadsheet owner.",
         },
         {
             'label': 'Bot API (legacy token)',
             'configured': bool(cfg.get('WEB_APP_API_TOKEN')),
-            'description': 'Single all-scope token for bot API access.',
+            'value_label': 'Token (masked)',
+            'value': _mask_token(cfg.get('WEB_APP_API_TOKEN')),
+            'description': 'Older single all-scope token, kept only for backward compatibility with a pre-split bot build.',
+            'why_change': 'Rotate immediately if this leaks — it grants full read+write API access with no scope limits. Otherwise, leave unset and prefer the read/write tokens below.',
         },
         {
             'label': 'Bot API read token',
             'configured': bool(cfg.get('WEB_APP_API_READ_TOKEN')),
-            'description': 'Read-scoped token for bot API access.',
+            'value_label': 'Token (masked)',
+            'value': _mask_token(cfg.get('WEB_APP_API_READ_TOKEN')),
+            'description': 'Lets the Discord bot read XP totals, characters, and periods from the web app.',
+            'why_change': 'Rotate if the token leaks (e.g. pasted in a public channel) or when swapping bot hosts.',
         },
         {
             'label': 'Bot API write token',
             'configured': bool(cfg.get('WEB_APP_API_WRITE_TOKEN')),
-            'description': 'Write-scoped token for bot API access.',
+            'value_label': 'Token (masked)',
+            'value': _mask_token(cfg.get('WEB_APP_API_WRITE_TOKEN')),
+            'description': 'Lets the bot submit claims/spends and open/close periods on behalf of players.',
+            'why_change': 'Rotate on the same schedule as the read token — treat it as more sensitive since it can write data.',
         },
         {
             'label': 'Turso (cloud database)',
             'configured': bool(cfg.get('TURSO_CONNECT_URL')),
-            'description': 'libSQL/Turso remote database (production). SQLite used when not configured.',
+            'value_label': 'Database URL',
+            'value': cfg.get('TURSO_CONNECT_URL') or None,
+            'description': 'Production database endpoint. Without this set, the app falls back to a local SQLite file (fine for dev, not for the live server). The paired auth token is never shown here.',
+            'why_change': "Change only when migrating to a new Turso database or region — this isn't something you'd rotate casually.",
         },
     ]
 
@@ -413,6 +511,7 @@ def index():
         {
             'label': 'Announcements channel',
             'key': 'BOT_ANNOUNCEMENTS_CHANNEL_ID',
+            'used_by': '/lasombra broadcast',
             'env': 'ANNOUNCEMENTS_CHANNEL_ID',
             'value': _eff_str('BOT_ANNOUNCEMENTS_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -424,6 +523,7 @@ def index():
         {
             'label': 'CC ticket category IDs',
             'key': 'BOT_CC_TICKET_CATEGORY_IDS',
+            'used_by': 'CC Ticket Monitor',
             'env': 'CC_TICKET_CATEGORY_IDS',
             'value': _eff_str('BOT_CC_TICKET_CATEGORY_IDS'),
             'placeholder': 'e.g. 123456789012345678,987654321098765432',
@@ -435,6 +535,7 @@ def index():
         {
             'label': 'Honeypot bait channel',
             'key': 'BOT_HONEYPOT_CHANNEL_ID',
+            'used_by': 'Honeypot Moderation',
             'env': 'HONEYPOT_CHANNEL_ID',
             'value': _eff_str('BOT_HONEYPOT_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -446,6 +547,7 @@ def index():
         {
             'label': 'Honeypot mod-log channel',
             'key': 'BOT_HONEYPOT_MOD_LOG_CHANNEL_ID',
+            'used_by': 'Honeypot Moderation',
             'env': 'HONEYPOT_MOD_LOG_CHANNEL_ID',
             'value': _eff_str('BOT_HONEYPOT_MOD_LOG_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -457,6 +559,7 @@ def index():
         {
             'label': 'Honeypot whitelisted role IDs',
             'key': 'BOT_HONEYPOT_WHITELISTED_ROLE_IDS',
+            'used_by': 'Honeypot Moderation',
             'env': 'HONEYPOT_WHITELISTED_ROLE_IDS',
             'value': _eff_str('BOT_HONEYPOT_WHITELISTED_ROLE_IDS'),
             'placeholder': 'e.g. 123456789012345678,987654321098765432',
@@ -468,6 +571,7 @@ def index():
         {
             'label': 'Mention breaker exempt role IDs',
             'key': 'BOT_MENTION_BREAKER_EXEMPT_ROLE_IDS',
+            'used_by': 'Mention-Spam Circuit Breaker',
             'env': 'MENTION_BREAKER_EXEMPT_ROLE_IDS',
             'value': _eff_str('BOT_MENTION_BREAKER_EXEMPT_ROLE_IDS'),
             'placeholder': 'e.g. 123456789012345678,987654321098765432',
@@ -479,6 +583,7 @@ def index():
         {
             'label': 'Mention breaker mod-log channel',
             'key': 'BOT_MENTION_BREAKER_MOD_LOG_CHANNEL_ID',
+            'used_by': 'Mention-Spam Circuit Breaker',
             'env': 'MENTION_BREAKER_MOD_LOG_CHANNEL_ID',
             'value': _eff_str('BOT_MENTION_BREAKER_MOD_LOG_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -490,6 +595,7 @@ def index():
         {
             'label': 'Verified member role',
             'key': 'BOT_VERIFIED_MEMBER_ROLE_ID',
+            'used_by': '/lasombra permissions audit · New Member Gate',
             'env': 'VERIFIED_MEMBER_ROLE_ID',
             'value': _eff_str('BOT_VERIFIED_MEMBER_ROLE_ID'),
             'placeholder': 'Discord role ID (18–19 digits)',
@@ -501,6 +607,7 @@ def index():
         {
             'label': 'New Member Gate: welcome channel',
             'key': 'BOT_NEW_MEMBER_GATE_WELCOME_CHANNEL_ID',
+            'used_by': 'New Member Gate',
             'env': 'NEW_MEMBER_GATE_WELCOME_CHANNEL_ID',
             'value': _eff_str('BOT_NEW_MEMBER_GATE_WELCOME_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -512,6 +619,7 @@ def index():
         {
             'label': 'New Member Gate: player role (Sheet in Progress)',
             'key': 'BOT_NEW_MEMBER_GATE_SHEET_IN_PROGRESS_ROLE_ID',
+            'used_by': 'New Member Gate',
             'env': 'NEW_MEMBER_GATE_SHEET_IN_PROGRESS_ROLE_ID',
             'value': _eff_str('BOT_NEW_MEMBER_GATE_SHEET_IN_PROGRESS_ROLE_ID'),
             'placeholder': 'Discord role ID (18–19 digits)',
@@ -523,6 +631,7 @@ def index():
         {
             'label': 'New Member Gate: lurker role',
             'key': 'BOT_NEW_MEMBER_GATE_LURKER_ROLE_ID',
+            'used_by': 'New Member Gate',
             'env': 'NEW_MEMBER_GATE_LURKER_ROLE_ID',
             'value': _eff_str('BOT_NEW_MEMBER_GATE_LURKER_ROLE_ID'),
             'placeholder': 'Discord role ID (18–19 digits)',
@@ -534,6 +643,7 @@ def index():
         {
             'label': 'New Night Broadcast: message',
             'key': 'BOT_NEW_NIGHT_BROADCAST_MESSAGE',
+            'used_by': 'New Night Broadcast',
             'env': 'PASSAGE_NEW_NIGHT_BROADCAST_MESSAGE',
             'value': _eff_str('BOT_NEW_NIGHT_BROADCAST_MESSAGE'),
             'placeholder': 'A GIF link or short message, e.g. https://klipy.com/gifs/africa-sunset',
@@ -545,6 +655,7 @@ def index():
         {
             'label': 'Correspondence: Deliver channel',
             'key': 'BOT_CORRESPONDENCE_DELIVERY_CHANNEL_ID',
+            'used_by': '/deliver',
             'env': 'CORRESPONDENCE_DELIVERY_CHANNEL_ID',
             'value': _eff_str('BOT_CORRESPONDENCE_DELIVERY_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -556,6 +667,7 @@ def index():
         {
             'label': 'Correspondence: Contact channel',
             'key': 'BOT_CORRESPONDENCE_CONTACT_CHANNEL_ID',
+            'used_by': '/contact send · /contact reply',
             'env': 'CORRESPONDENCE_CONTACT_CHANNEL_ID',
             'value': _eff_str('BOT_CORRESPONDENCE_CONTACT_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -567,6 +679,7 @@ def index():
         {
             'label': 'Correspondence: Prestation channel',
             'key': 'BOT_CORRESPONDENCE_PRESTATION_CHANNEL_ID',
+            'used_by': '/prestation owe · status · repay',
             'env': 'CORRESPONDENCE_PRESTATION_CHANNEL_ID',
             'value': _eff_str('BOT_CORRESPONDENCE_PRESTATION_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -578,6 +691,7 @@ def index():
         {
             'label': 'Correspondence: Social channel',
             'key': 'BOT_CORRESPONDENCE_SOCIAL_CHANNEL_ID',
+            'used_by': '/post',
             'env': 'CORRESPONDENCE_SOCIAL_CHANNEL_ID',
             'value': _eff_str('BOT_CORRESPONDENCE_SOCIAL_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -589,6 +703,7 @@ def index():
         {
             'label': 'Correspondence: Cobweb channel',
             'key': 'BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID',
+            'used_by': '/cobweb',
             'env': 'CORRESPONDENCE_COBWEB_CHANNEL_ID',
             'value': _eff_str('BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -600,6 +715,7 @@ def index():
         {
             'label': 'Correspondence: Rumor channel',
             'key': 'BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID',
+            'used_by': '/rumor',
             'env': 'CORRESPONDENCE_RUMOR_CHANNEL_ID',
             'value': _eff_str('BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID'),
             'placeholder': 'Discord channel ID (18–19 digits)',
@@ -608,6 +724,11 @@ def index():
             'editable': True,
             'description': '/rumor posts using the standard staff template here. Leave blank to disable the command.',
         },
+    ]
+    _channels_by_key = {c['key']: c for c in bot_channels}
+    bot_channel_groups = [
+        {'name': group_name, 'channels': [_channels_by_key[k] for k in keys]}
+        for group_name, keys in CHANNEL_GROUPS
     ]
 
     # ── Bot tuning (DB-backed; take effect after bot restart) ─────────────
@@ -700,6 +821,15 @@ def index():
             pass
 
     _restart_pending = 'BOT_RESTART_REQUESTED' in overrides and overrides['BOT_RESTART_REQUESTED'].value.lower() in ('true', '1', 'yes')
+
+    if bot_heartbeat_ts is None:
+        bot_status_level = 'unknown'
+    elif bot_heartbeat_age is not None and bot_heartbeat_age < 180:
+        bot_status_level = 'online'
+    elif bot_heartbeat_age is not None and bot_heartbeat_age < 600:
+        bot_status_level = 'delayed'
+    else:
+        bot_status_level = 'offline'
 
     # ── Wiki sync status ────────────────────────────────────────────────────
     _wiki_sync_requested = 'BOT_WIKI_SYNC_REQUESTED' in overrides and overrides['BOT_WIKI_SYNC_REQUESTED'].value.lower() in ('true', '1', 'yes')
@@ -849,8 +979,43 @@ def index():
         'tenets_overridden': 'CHRONICLE_TENETS' in overrides,
     }
 
+    # ── Nav counts + search index ──────────────────────────────────────────
+    nav_counts = {
+        'bot_channels': len(bot_channels),
+        'bot_flags': len(bot_flags),
+        'bot_commands': len(bot_commands),
+        'bot_tuning': len(bot_tuning),
+        'web_flags_tuning': len(web_flags) + len(web_tuning),
+        'web_integrations': len(integrations),
+    }
+
+    search_index = []
+    for f in web_flags:
+        search_index.append({'label': f['label'], 'description': f['description'], 'section': 'web-flags-tuning', 'section_label': 'Web App · Flags & Tuning'})
+    for t in web_tuning:
+        search_index.append({'label': t['label'], 'description': t['description'], 'section': 'web-flags-tuning', 'section_label': 'Web App · Flags & Tuning'})
+    for i in integrations:
+        search_index.append({'label': i['label'], 'description': i['description'], 'section': 'web-integrations', 'section_label': 'Web App · Integrations'})
+    search_index.append({'label': 'Chronicle Tenets', 'description': 'Chronicle-wide tenets shown on player sheets.', 'section': 'web-chronicle', 'section_label': 'Web App · Chronicle'})
+    for f in bot_flags:
+        search_index.append({'label': f['label'], 'description': f['description'], 'section': 'bot-flags', 'section_label': 'Bot · Feature Flags'})
+    for t in bot_tuning:
+        search_index.append({'label': t['label'], 'description': t['description'], 'section': 'bot-tuning', 'section_label': 'Bot · Tuning'})
+    for c in bot_channels:
+        search_index.append({'label': c['label'], 'description': c['description'], 'section': 'bot-channels', 'section_label': 'Bot · Channel IDs'})
+    for cmd in bot_commands:
+        search_index.append({'label': cmd['label'], 'description': cmd['description'], 'section': 'bot-commands', 'section_label': 'Bot · Commands'})
+        for sub in cmd['subcommands']:
+            search_index.append({'label': f"{cmd['label']} {sub['label']}", 'description': sub['description'], 'section': 'bot-commands', 'section_label': 'Bot · Commands'})
+
     return render_template(
         'settings/index.html',
+        active_section=active_section,
+        settings_nav=SETTINGS_NAV,
+        nav_counts=nav_counts,
+        search_index=search_index,
+        bot_channel_groups=bot_channel_groups,
+        bot_status_level=bot_status_level,
         web_flags=web_flags,
         web_tuning=web_tuning,
         integrations=integrations,
@@ -877,7 +1042,7 @@ def index():
 def request_wiki_sync():
     if not is_settings_admin():
         flash('You do not have permission to run the Wiki sync.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     from app.db import AppSetting, db
     wiki_capability = db.session.get(AppSetting, 'BOT_LIVE_WIKI_SYNC_CAPABLE')
@@ -887,7 +1052,7 @@ def request_wiki_sync():
             'Update bot .env and restart the bot before running sync.',
             'danger',
         )
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     updated_by = (
         session.get('discord_name')
@@ -896,7 +1061,7 @@ def request_wiki_sync():
     )
     set_app_setting('BOT_WIKI_SYNC_REQUESTED', 'true', updated_by)
     flash('Wiki sync queued. The bot will start it within ~60 seconds.', 'success')
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/reset-wiki-sync', methods=['POST'])
@@ -904,7 +1069,7 @@ def request_wiki_sync():
 def reset_wiki_sync():
     if not is_settings_admin():
         flash('You do not have permission to reset Wiki sync status.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     from app.db import AppSetting, db
     reset_keys = (
@@ -925,7 +1090,7 @@ def reset_wiki_sync():
     if deleted:
         db.session.commit()
     flash('Wiki sync state reset. You can safely queue a fresh run.', 'success')
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/request-restart', methods=['POST'])
@@ -933,7 +1098,7 @@ def reset_wiki_sync():
 def request_restart():
     if not is_settings_admin():
         flash('You do not have permission to restart the bot.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     updated_by = (
         session.get('discord_name')
@@ -942,7 +1107,7 @@ def request_restart():
     )
     set_app_setting('BOT_RESTART_REQUESTED', 'true', updated_by)
     flash('Restart requested. The bot will exit cleanly within ~60 seconds and Docker will restart it.', 'success')
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/request-rebuild', methods=['POST'])
@@ -950,7 +1115,7 @@ def request_restart():
 def request_rebuild():
     if not is_settings_admin():
         flash('You do not have permission to restart the bot.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     updated_by = (
         session.get('discord_name')
@@ -959,7 +1124,7 @@ def request_rebuild():
     )
     set_app_setting('BOT_RESTART_REQUESTED', 'true', updated_by)
     flash('Bot will exit within ~60s. Run the rebuild command shown below to bring it back up with the latest code.', 'info')
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/update', methods=['POST'])
@@ -967,14 +1132,14 @@ def request_rebuild():
 def update():
     if not is_settings_admin():
         flash('You do not have permission to change settings.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     key = request.form.get('key', '').strip()
     action = request.form.get('action', '').strip()  # 'set' or 'reset'
 
     if key not in EDITABLE_KEYS:
         flash(f'Unknown or non-editable setting: {key}', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     updated_by = (
         session.get('discord_name')
@@ -1042,11 +1207,11 @@ def update():
                 int(raw_value)
             except (ValueError, TypeError):
                 flash(f'Invalid value for {key}: must be an integer.', 'danger')
-                return redirect(url_for('settings.index'))
+                return _redirect_to_section()
             set_app_setting(key, raw_value, updated_by)
         flash(f'{key} updated.', 'success')
 
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/commands/toggle', methods=['POST'])
@@ -1054,17 +1219,17 @@ def update():
 def toggle_bot_command():
     if not is_settings_admin():
         flash('You do not have permission to change settings.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     token = request.form.get('token', '').strip()
     action = request.form.get('action', '').strip()  # 'disable' or 'enable'
 
     if token not in flattened_tokens():
         flash(f'Unknown command: {token}', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
     if action not in ('disable', 'enable'):
         flash('Invalid action.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
 
     updated_by = (
         session.get('discord_name')
@@ -1081,7 +1246,7 @@ def toggle_bot_command():
         flash(f'`{token}` re-enabled.', 'success')
 
     set_app_setting('BOT_DISABLED_COMMANDS', ','.join(sorted(current)), updated_by)
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/staff/add', methods=['POST'])
@@ -1089,17 +1254,17 @@ def toggle_bot_command():
 def staff_add():
     if not is_settings_admin():
         flash('Only Administrators can manage staff.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
     from app.db import AppSetting, db
     discord_id = request.form.get('discord_id', '').strip()
     role = request.form.get('role', '').strip()
     name = request.form.get('name', '').strip()
     if not discord_id or not discord_id.isdigit():
         flash('Invalid Discord ID — must be numeric.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
     if role not in ('system_helper', 'storyteller', 'moderator', 'administrator'):
         flash('Invalid role.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
     updated_by = session.get('discord_name', 'admin')
     key = f'STAFF_MEMBER_{discord_id}'
     row = AppSetting.query.get(key)
@@ -1122,7 +1287,7 @@ def staff_add():
     db.session.commit()
     display = f'{name} ({discord_id})' if name else discord_id
     flash(f'{role.capitalize()} {display} added.', 'success')
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()
 
 
 @bp.route('/staff/remove', methods=['POST'])
@@ -1130,7 +1295,7 @@ def staff_add():
 def staff_remove():
     if not is_settings_admin():
         flash('Only Administrators can manage staff.', 'danger')
-        return redirect(url_for('settings.index'))
+        return _redirect_to_section()
     from app.db import AppSetting, db
     discord_id = request.form.get('discord_id', '').strip()
     key = f'STAFF_MEMBER_{discord_id}'
@@ -1144,4 +1309,4 @@ def staff_remove():
         flash(f'Staff member {discord_id} removed.', 'success')
     else:
         flash('Staff member not found.', 'warning')
-    return redirect(url_for('settings.index'))
+    return _redirect_to_section()

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -2133,3 +2133,327 @@ body.login-page {
   font-weight: 700;
   font-family: var(--font-ui);
 }
+
+/* ══════════════════════════════════════════════
+   SETTINGS REDESIGN — control-panel layout
+   ══════════════════════════════════════════════ */
+
+.settings-topbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 54px;
+  padding-bottom: 16px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+.settings-topbar-back {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-family: var(--font-ui);
+  text-decoration: none;
+}
+.settings-topbar-back:hover { color: var(--text); }
+.settings-topbar-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--border-strong);
+}
+.settings-topbar-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: .03em;
+  color: var(--text);
+}
+
+.settings-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.settings-status-dot--online {
+  background: #4ade80;
+  box-shadow: 0 0 0 0 rgba(74,222,128,.5);
+  animation: pulse-green 2s ease-in-out infinite;
+}
+.settings-status-dot--delayed { background: var(--vtm-gold); }
+.settings-status-dot--offline { background: var(--accent); box-shadow: 0 0 8px rgba(216,58,74,.6); }
+.settings-status-dot--unknown { background: var(--text-faint); }
+
+.settings-shell {
+  display: grid;
+  grid-template-columns: 230px 1fr;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 860px) {
+  .settings-shell { grid-template-columns: 1fr; }
+}
+
+.settings-nav {
+  position: sticky;
+  top: 0;
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+  padding: 14px 10px;
+}
+.settings-search { margin-bottom: 12px; padding: 0 4px; }
+.settings-search input {
+  width: 100%;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-pill);
+  padding: 7px 14px;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+}
+.settings-search input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.settings-search input::placeholder { color: var(--text-faintest); }
+
+.settings-nav-group { margin-bottom: 4px; }
+.settings-nav-group-label {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--text-faint);
+  margin: 12px 8px 6px;
+}
+.settings-nav-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  margin-bottom: 2px;
+  border-radius: 8px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-body);
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.settings-nav-link:hover { background: rgba(255,255,255,.04); color: var(--text); }
+.settings-nav-link.is-active {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  color: var(--accent-soft);
+  font-weight: 700;
+}
+.settings-nav-link span:first-of-type { flex: 1; }
+.settings-nav-count {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--text-muted);
+  background: rgba(255,255,255,.06);
+  padding: 1px 7px;
+  border-radius: var(--r-pill);
+}
+
+.settings-main { min-width: 0; }
+.settings-pane { display: none; max-width: 920px; }
+.settings-pane.is-active { display: block; }
+.settings-pane-title {
+  font-family: var(--font-display);
+  font-size: 18px;
+  margin: 0 0 4px;
+  color: var(--text);
+}
+.settings-pane-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0 0 20px;
+}
+
+.settings-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+.settings-card-header {
+  padding: 12px 18px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--text-faint);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-ui);
+}
+.settings-group-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--text-faint);
+  margin: 0 0 8px;
+  font-family: var(--font-ui);
+}
+
+.settings-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  margin-bottom: 18px;
+}
+@media (max-width: 700px) {
+  .settings-overview-grid { grid-template-columns: 1fr; }
+}
+.settings-overview-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+  padding: 16px;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 13px 18px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.settings-row:last-child { border-bottom: none; }
+.settings-row--sub { padding-left: 40px; }
+.settings-row-label {
+  width: 230px;
+  flex-shrink: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.settings-row-desc { flex: 1; font-size: 12px; color: var(--text-muted); min-width: 200px; }
+
+.settings-channel-row { padding: 13px 18px; border-bottom: 1px solid var(--border); }
+.settings-channel-row:last-child { border-bottom: none; }
+.settings-channel-row-top { display: flex; align-items: center; gap: 16px; margin-bottom: 6px; flex-wrap: wrap; }
+.settings-channel-input { width: 210px; flex-shrink: 0; font-family: monospace; }
+
+.settings-used-by-badge {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: #7cb8f0;
+  background: rgba(124,184,240,.12);
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  font-family: var(--font-ui);
+  white-space: nowrap;
+}
+.settings-override-badge {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--vtm-gold);
+  background: rgba(212,179,82,.15);
+  padding: 2px 7px;
+  border-radius: var(--r-pill);
+  margin-left: 6px;
+}
+
+.settings-pill {
+  flex-shrink: 0;
+  min-width: 90px;
+  text-align: center;
+  font-size: 11.5px;
+  font-weight: 700;
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+}
+.settings-pill--on {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border: 1px solid var(--accent);
+  color: var(--accent-soft);
+}
+.settings-reset-link {
+  background: none;
+  border: none;
+  color: var(--text-faint);
+  font-size: 11px;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.settings-integration-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+  padding: 14px 18px;
+  margin-bottom: 12px;
+}
+.settings-integration-header { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; flex-wrap: wrap; }
+.settings-integration-name { font-size: 13.5px; font-weight: 600; color: var(--text); }
+.settings-integration-desc { font-size: 12px; color: var(--text-muted); margin-bottom: 10px; }
+.settings-integration-value-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
+.settings-integration-value-label {
+  width: 110px;
+  flex-shrink: 0;
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--text-faint);
+}
+.settings-integration-value {
+  flex: 1;
+  min-width: 200px;
+  font-size: 12px;
+  font-family: monospace;
+  color: var(--text-body);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-input);
+  padding: 7px 10px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.settings-integration-why { font-size: 11.5px; color: var(--text-faintest); font-style: italic; }
+
+.settings-search-results-count { font-size: 12px; color: var(--text-muted); margin-bottom: 16px; }
+.settings-search-result-row {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 13px 18px;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: none;
+  cursor: pointer;
+}
+.settings-search-result-row:last-child { border-bottom: none; }
+.settings-search-result-row:hover { background: rgba(255,255,255,.04); }
+.settings-search-result-top { display: flex; align-items: center; gap: 10px; margin-bottom: 3px; }
+.settings-search-result-label { font-weight: 600; font-size: 13.5px; color: var(--text); }
+.settings-search-result-section {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .03em;
+  color: var(--accent-soft);
+  background: rgba(216,58,74,.12);
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+}
+.settings-search-result-desc { font-size: 12px; color: var(--text-muted); }

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -1,878 +1,555 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container mt-4">
 
-  <div class="d-flex align-items-center justify-content-between mb-4 flex-wrap gap-2">
-    <h2 class="mb-0">Settings</h2>
-    {% if can_edit %}
-      <span class="badge bg-warning text-dark"><i class="bi bi-pencil-square"></i> Edit mode</span>
-    {% else %}
-      <span class="text-muted small">Read-only — change values in the server environment and redeploy.</span>
-    {% endif %}
+{% macro toggle_row(item, section) %}
+{% set is_overridden = item.overridden if item.overridden is defined else item.db_set %}
+<div class="settings-row">
+  <div class="settings-row-label">
+    {{ item.label }}
+    {% if is_overridden %}<span class="settings-override-badge" title="Runtime override active">DB</span>{% endif %}
+    {% if item.db_set is defined and not item.db_set and item.live_known %}<span class="settings-override-badge" title="No DB override — bot is using its .env value">ENV</span>{% endif %}
+    {% if item.db_set is defined and item.using_env %}<span class="settings-override-badge" title="Bot has not reported its state yet">?</span>{% endif %}
   </div>
-
-  {# ═══ Bot — Status ═══ #}
-  <h5 class="text-muted text-uppercase small mb-2 mt-4">Bot — Status</h5>
-  <div class="card bg-dark border-secondary mb-4">
-    <div class="card-header border-secondary d-flex align-items-center justify-content-between">
-      <h6 class="mb-0 text-light"><i class="bi bi-heart-pulse"></i> Bot Status</h6>
-      {% if can_edit %}
-        <div class="d-flex gap-2">
-          <form method="POST" action="{{ url_for('settings.request_restart') }}" class="mb-0">
-            {% if bot_restart_pending %}
-              <button type="submit" class="btn btn-sm btn-warning" disabled>
-                <i class="bi bi-arrow-clockwise"></i> Pending…
-              </button>
-            {% else %}
-              <button type="submit" class="btn btn-sm btn-outline-warning"
-                onclick="return confirm('Request bot restart? It will exit cleanly within ~60s and Docker will restart it.')">
-                <i class="bi bi-arrow-clockwise"></i> Restart
-              </button>
-            {% endif %}
-          </form>
-          <form method="POST" action="{{ url_for('settings.request_rebuild') }}" class="mb-0">
-            <button type="submit" class="btn btn-sm btn-outline-info"
-              onclick="return confirm('This will exit the bot within ~60s. Copy the rebuild command from the card, then run it in your terminal.')">
-              <i class="bi bi-hammer"></i> Rebuild
-            </button>
-          </form>
-        </div>
-      {% endif %}
-    </div>
-    <div class="card-body">
-      {% if bot_heartbeat_ts is none %}
-        <span class="badge bg-secondary">No heartbeat received yet</span>
-        <small class="text-muted ms-2">Bot has not connected since last web restart.</small>
-      {% elif bot_heartbeat_age is not none and bot_heartbeat_age < 180 %}
-        <span class="badge bg-success"><i class="bi bi-circle-fill me-1" style="font-size:0.6rem"></i>Online</span>
-        <small class="text-muted ms-2">Last seen {{ bot_heartbeat_age }}s ago</small>
-      {% elif bot_heartbeat_age is not none and bot_heartbeat_age < 600 %}
-        <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-circle me-1"></i>Delayed</span>
-        <small class="text-muted ms-2">Last seen {{ (bot_heartbeat_age // 60) }}m ago — may be slow or restarting</small>
-      {% else %}
-        <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Offline</span>
-        <small class="text-muted ms-2">Last seen {{ (bot_heartbeat_age // 60) if bot_heartbeat_age else '?' }}m ago</small>
-      {% endif %}
-
-      <div class="mt-3 pt-3 border-top border-secondary">
-        <small class="text-muted d-block mb-1">
-          <i class="bi bi-hammer me-1"></i>Rebuild command — paste into terminal:
-        </small>
-        <div class="d-flex align-items-center gap-2">
-          <code class="flex-grow-1 px-2 py-1 rounded small"
-                style="background:#111; color:#adb5bd; word-break:break-all;">
-            cd ~/Projects/mcbn-xp-tracker/apps/bot &amp;&amp; npm run ops:docker:down &amp;&amp; npm run ops:docker:up
-          </code>
-          <button class="btn btn-sm btn-outline-secondary text-nowrap" type="button"
-                  id="rebuild-copy-btn"
-                  onclick="navigator.clipboard.writeText('cd ~/Projects/mcbn-xp-tracker/apps/bot && npm run ops:docker:down && npm run ops:docker:up'); var b=document.getElementById('rebuild-copy-btn'); b.textContent='Copied!'; setTimeout(function(){b.textContent='Copy'},2000);">
-            Copy
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {# ═══ Bot — Wiki Sync ═══ #}
-  <div class="card bg-dark border-secondary mb-4">
-    <div class="card-header border-secondary d-flex align-items-center justify-content-between">
-      <h6 class="mb-0 text-light"><i class="bi bi-database-up"></i> Wiki Sync</h6>
-      {% if can_edit %}
-        <div class="d-flex align-items-center gap-2">
-        <form method="POST" action="{{ url_for('settings.request_wiki_sync') }}" class="mb-0">
-          {% if wiki_sync.capable is sameas false %}
-            <button type="submit" class="btn btn-sm btn-outline-secondary" disabled
-              title="Bot reports missing DISCORD_GUILD_ID">
-              <i class="bi bi-slash-circle"></i> Missing Prereqs
-            </button>
-          {% elif wiki_sync.requested or (wiki_sync.status == 'running' and not wiki_sync.is_stale) %}
-            <button type="submit" class="btn btn-sm btn-info" disabled>
-              <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-              {% if wiki_sync.status == 'running' %}Running…{% else %}Queued…{% endif %}
-            </button>
-          {% else %}
-            <button type="submit" class="btn btn-sm btn-outline-info"
-              onclick="return confirm('Run Discord → Wiki sync? This may take several minutes.')">
-              <i class="bi bi-arrow-repeat"></i> Run Wiki Sync
-            </button>
-          {% endif %}
-        </form>
-        {% if wiki_sync.is_stale %}
-          <form method="POST" action="{{ url_for('settings.reset_wiki_sync') }}" class="mb-0">
-            <button type="submit" class="btn btn-sm btn-outline-warning"
-              onclick="return confirm('Reset stale Wiki sync state? Use this if the bot crashed during a run.')">
-              <i class="bi bi-arrow-counterclockwise"></i> Reset Stale
-            </button>
-          </form>
-        {% endif %}
-        </div>
-      {% endif %}
-    </div>
-    <div class="card-body">
-      <p class="text-muted small mb-2">
-        Reads Discord channels and populates the Chronicle Wiki
-        (PC profiles, SPC pages, Location pages, Hunting Sites, Lore archives, Coteries, Factions).
-        Requires <code>DISCORD_GUILD_ID</code> and <code>WEB_APP_API_WRITE_TOKEN</code> in the bot's <code>.env</code>.
-      </p>
-      {% if wiki_sync.capable is sameas false %}
-        <small class="text-warning d-block mb-2">
-          <i class="bi bi-exclamation-triangle me-1"></i>
-          Bot currently reports missing sync prerequisites. Update bot <code>.env</code> and restart the bot to re-enable manual sync.
-        </small>
-      {% endif %}
-      {% if wiki_sync.status == 'running' and wiki_sync.is_stale %}
-        <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>Stale</span>
-        {% if wiki_sync.started_at %}
-          <small class="text-muted ms-2">
-            Started {{ wiki_sync.started_at[:19] | replace('T', ' ') }} UTC and appears stuck.
-          </small>
-        {% endif %}
-        <small class="text-muted d-block mt-1">
-          Running for {{ wiki_sync.running_age_seconds or '?' }}s (stale threshold: {{ wiki_sync.stale_after_seconds }}s).
-        </small>
-      {% elif wiki_sync.status == 'running' %}
-        <span class="badge bg-info text-dark"><i class="bi bi-arrow-repeat me-1"></i>Running</span>
-        {% if wiki_sync.started_at %}
-          <small class="text-muted ms-2">Started {{ wiki_sync.started_at[:19] | replace('T', ' ') }} UTC</small>
-        {% endif %}
-        {% if wiki_sync.run_id %}
-          <small class="text-muted d-block mt-1">Run ID: <code>{{ wiki_sync.run_id }}</code></small>
-        {% endif %}
-      {% elif wiki_sync.status == 'success' %}
-        <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Success</span>
-        {% if wiki_sync.finished_at %}
-          <small class="text-muted ms-2">Completed {{ wiki_sync.finished_at[:19] | replace('T', ' ') }} UTC</small>
-        {% endif %}
-        {% if wiki_sync.run_id %}
-          <small class="text-muted d-block mt-1">Run ID: <code>{{ wiki_sync.run_id }}</code></small>
-        {% endif %}
-      {% elif wiki_sync.status == 'error' %}
-        <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Error</span>
-        {% if wiki_sync.error %}
-          <small class="text-danger ms-2">{{ wiki_sync.error }}</small>
-        {% endif %}
-        {% if wiki_sync.started_at %}
-          <small class="text-muted ms-2">(started {{ wiki_sync.started_at[:19] | replace('T', ' ') }} UTC)</small>
-        {% endif %}
-        {% if wiki_sync.run_id %}
-          <small class="text-muted d-block mt-1">Run ID: <code>{{ wiki_sync.run_id }}</code></small>
-        {% endif %}
-      {% elif wiki_sync.requested %}
-        <span class="badge bg-secondary">Queued</span>
-        <small class="text-muted ms-2">Waiting for the bot to pick it up…</small>
-      {% else %}
-        <span class="badge bg-secondary">Never run</span>
-        <small class="text-muted ms-2">Click <strong>Run Wiki Sync</strong> to sync Discord channels to the Chronicle Wiki.</small>
-      {% endif %}
-
-      {% if wiki_sync_runs %}
-      <div class="mt-3 pt-3 border-top border-secondary">
-        <small class="text-muted d-block mb-2">Recent sync runs</small>
-        <div class="table-responsive">
-          <table class="table table-dark table-sm mb-0 align-middle">
-            <thead>
-              <tr>
-                <th style="width:220px">Run ID</th>
-                <th style="width:180px">Started (UTC)</th>
-                <th style="width:180px">Finished (UTC)</th>
-                <th style="width:120px">Duration</th>
-                <th style="width:100px">Source</th>
-                <th style="width:120px">Final Status</th>
-                <th>Error</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for run in wiki_sync_runs %}
-              <tr>
-                <td class="small font-monospace text-muted">{{ run.run_id if run.run_id else run.run_key }}</td>
-                <td class="small text-muted">{{ run.started_at[:19] | replace('T', ' ') if run.started_at else '—' }}</td>
-                <td class="small text-muted">{{ run.finished_at[:19] | replace('T', ' ') if run.finished_at else '—' }}</td>
-                <td class="small text-muted">{{ run.duration_display }}</td>
-                <td>
-                  {% if run.source == 'scheduled' %}
-                    <span class="badge bg-secondary">Scheduled</span>
-                  {% else %}
-                    <span class="badge bg-dark border border-secondary">Manual</span>
-                  {% endif %}
-                </td>
-                <td>
-                  {% if run.status == 'success' %}
-                    <span class="badge bg-success">Success</span>
-                  {% elif run.status == 'error' %}
-                    <span class="badge bg-danger">Error</span>
-                  {% else %}
-                    <span class="badge bg-info text-dark">Running</span>
-                  {% endif %}
-                </td>
-                <td class="small {% if run.status == 'error' and run.error %}text-danger{% else %}text-muted{% endif %}">
-                  {{ run.error if run.error else '—' }}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
-      {% endif %}
-    </div>
-  </div>
-
-  {# ═══ Bot — Retirement Automation ═══ #}
-  <div class="card bg-dark border-secondary mb-4">
-    <div class="card-header border-secondary d-flex align-items-center justify-content-between">
-      <h6 class="mb-0 text-light"><i class="bi bi-person-workspace"></i> Retirement Automation</h6>
-      <div class="d-flex align-items-center gap-2 flex-wrap">
-        <span class="badge bg-secondary">Pending Discord: {{ retirement_summary.pending_discord }}</span>
-        <span class="badge bg-info text-dark">Pending Wiki: {{ retirement_summary.pending_wiki }}</span>
-        <span class="badge bg-warning text-dark">Backoff: {{ retirement_summary.backoff }}</span>
-        {% if retirement_summary.errored %}
-          <span class="badge bg-danger">Errors: {{ retirement_summary.errored }}</span>
-        {% else %}
-          <span class="badge bg-success">Errors: 0</span>
-        {% endif %}
-      </div>
-    </div>
-    <div class="card-body">
-      <p class="text-muted small mb-3">
-        Moving cubby channels happens immediately after a character is marked retired. Wiki updates are deferred until the next successful Wiki sync batch.
-      </p>
-      {% if retirement_jobs %}
-      <div class="table-responsive">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th>Character</th>
-              <th>Requested (UTC)</th>
-              <th>Discord</th>
-              <th>Wiki</th>
-              <th>Attempts</th>
-              <th>Next Retry (UTC)</th>
-              <th>Error</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for job in retirement_jobs %}
-            {% set next_retry_at = retirement_next_retry_at(job) %}
-            <tr>
-              <td class="small">{{ job.character_name }}</td>
-              <td class="small text-muted">{{ job.requested_at.strftime('%Y-%m-%d %H:%M') if job.requested_at else '—' }}</td>
-              <td>
-                {% if job.discord_completed_at %}
-                  <span class="badge bg-success">Complete</span>
-                {% elif next_retry_at %}
-                  <span class="badge bg-warning text-dark">Backoff</span>
-                {% else %}
-                  <span class="badge bg-secondary">Pending</span>
-                {% endif %}
-              </td>
-              <td>
-                {% if job.wiki_synced_at %}
-                  <span class="badge bg-success">Synced</span>
-                {% elif job.discord_completed_at %}
-                  <span class="badge bg-info text-dark">Queued</span>
-                {% else %}
-                  <span class="badge bg-dark border border-secondary">Waiting</span>
-                {% endif %}
-              </td>
-              <td class="small text-muted">{{ job.attempt_count }}</td>
-              <td class="small text-muted">{{ next_retry_at.strftime('%Y-%m-%d %H:%M') if next_retry_at else '—' }}</td>
-              <td class="small {% if job.last_error %}text-danger{% else %}text-muted{% endif %}">
-                {{ job.last_error if job.last_error else '—' }}
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      {% else %}
-        <span class="badge bg-secondary">No retirement jobs yet</span>
-      {% endif %}
-    </div>
-  </div>
-
-  {# ═══ Staff Management ═══ #}
-  <h5 class="text-muted text-uppercase small mb-2 mt-4">Staff Management</h5>
-  <div class="card bg-dark border-secondary mb-4">
-    <div class="card-body">
-      <p class="text-muted small mb-3">
-        Staff added here are stored in the database and take effect immediately — no redeploy needed.
-        Env-var entries (<code>ALLOWED_DISCORD_IDS</code>, <code>SETTINGS_ADMIN_DISCORD_IDS</code>) are always active as a baseline and cannot be removed here.
-      </p>
-
-      {% if staff_members %}
-      <table class="table table-dark table-sm mb-3 align-middle">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Discord ID</th>
-            <th>Role</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for m in staff_members %}
-          <tr>
-            <td>{% if m.name %}{{ m.name }}{% else %}<span class="text-muted">—</span>{% endif %}</td>
-            <td><code>{{ m.discord_id }}</code></td>
-            <td>
-              <span class="badge {% if m.role == 'administrator' %}bg-warning text-dark{% elif m.role == 'moderator' %}bg-info text-dark{% elif m.role == 'storyteller' %}bg-primary{% else %}bg-secondary{% endif %}">
-                {{ m.label }}
-              </span>
-              {% if m.source == 'env' or m.has_env_access %}
-                <span class="badge bg-dark border border-secondary text-muted ms-1" title="Granted via environment variable — manage in server config">Env</span>
-              {% endif %}
-            </td>
-            <td>
-              {% if m.source == 'db' and not m.has_env_access %}
-              <form method="POST" action="{{ url_for('settings.staff_remove') }}" class="mb-0">
-                <input type="hidden" name="discord_id" value="{{ m.discord_id }}">
-                <button type="submit" class="btn btn-sm btn-outline-danger"
-                  onclick="return confirm('Remove {{ m.discord_id }} from staff?')">Remove</button>
-              </form>
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      {% else %}
-      <p class="text-muted small">No staff members found.</p>
-      {% endif %}
-
-      <form method="POST" action="{{ url_for('settings.staff_add') }}" class="row g-2 align-items-end">
-        <div class="col-auto">
-          <label class="form-label small text-muted mb-1">Display Name</label>
-          <input type="text" name="name" class="form-control form-control-sm bg-dark text-light border-secondary"
-            placeholder="e.g. Jason" style="width:160px" maxlength="80">
-        </div>
-        <div class="col-auto">
-          <label class="form-label small text-muted mb-1">Discord ID</label>
-          <input type="text" name="discord_id" class="form-control form-control-sm bg-dark text-light border-secondary"
-            placeholder="e.g. 123456789012345678" style="width:220px" required pattern="\d+">
-        </div>
-        <div class="col-auto">
-          <label class="form-label small text-muted mb-1">Role</label>
-          <select name="role" class="form-select form-select-sm bg-dark text-light border-secondary">
-            <option value="system_helper">System Helper</option>
-            <option value="storyteller">Storyteller</option>
-            <option value="moderator">Moderator</option>
-            <option value="administrator">Administrator</option>
-          </select>
-        </div>
-        <div class="col-auto">
-          <button type="submit" class="btn btn-sm btn-outline-primary">Add Staff</button>
-        </div>
-      </form>
-    </div>
-  </div>
-
-  {# ═══ Collapsible config sections ═══ #}
-
-  {# Web App — Feature Flags #}
-  <h5 class="mb-2 mt-4">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-web-flags" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Web App — Feature Flags
+  {% if can_edit and item.editable %}
+  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1 flex-wrap mb-0">
+    <input type="hidden" name="key" value="{{ item.key }}">
+    <input type="hidden" name="action" value="set">
+    <input type="hidden" name="value" value="{{ 'false' if item.enabled else 'true' }}">
+    <input type="hidden" name="section" value="{{ section }}">
+    <button type="submit" class="settings-pill {% if item.enabled %}settings-pill--on{% endif %}">
+      {{ '● Enabled' if item.enabled else '○ Disabled' }}
     </button>
-  </h5>
-  <div class="collapse mb-4" id="section-web-flags">
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th style="width:200px">Feature</th>
-              <th style="width:160px">Status</th>
-              <th>Description</th>
-              <th class="d-none d-md-table-cell text-muted" style="width:280px">Env var</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for f in web_flags %}
-            <tr>
-              <td class="fw-semibold">
-                {{ f.label }}
-                {% if f.overridden %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
-              </td>
-              <td>
-                {% if can_edit and f.editable %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1 flex-wrap">
-                    <input type="hidden" name="key" value="{{ f.key }}">
-                    <input type="hidden" name="action" value="set">
-                    <input type="hidden" name="value" value="{{ 'false' if f.enabled else 'true' }}">
-                    <button type="submit" class="btn btn-sm {% if f.enabled %}btn-success{% else %}btn-outline-secondary{% endif %}" style="min-width:90px">
-                      {% if f.enabled %}<i class="bi bi-toggle-on"></i> Enabled{% else %}<i class="bi bi-toggle-off"></i> Disabled{% endif %}
-                    </button>
-                    {% if f.overridden %}
-                    </form>
-                    <form method="POST" action="{{ url_for('settings.update') }}">
-                      <input type="hidden" name="key" value="{{ f.key }}">
-                      <input type="hidden" name="action" value="reset">
-                      <button type="submit" class="btn btn-sm btn-link text-muted p-0 ms-1" title="Reset to env default" style="font-size:.75rem">reset</button>
-                    {% endif %}
-                  </form>
-                {% else %}
-                  {% if f.enabled %}
-                    <span class="badge bg-success">Enabled</span>
-                  {% else %}
-                    <span class="badge bg-secondary">Disabled</span>
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ f.description }}</td>
-              <td class="d-none d-md-table-cell"><code class="small text-info">{{ f.env }}</code></td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Web App — Integrations #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-web-integrations" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Web App — Integrations
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-web-integrations">
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0">
-          <thead>
-            <tr>
-              <th style="width:200px">Integration</th>
-              <th style="width:120px">Status</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for i in integrations %}
-            <tr>
-              <td class="fw-semibold">{{ i.label }}</td>
-              <td>
-                {% if i.configured %}
-                  <span class="badge bg-success">Configured</span>
-                {% else %}
-                  <span class="badge bg-secondary">Not set</span>
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ i.description }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Web App — Tuning #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-web-tuning" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Web App — Tuning
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-web-tuning">
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th style="width:220px">Parameter</th>
-              <th style="width:{% if can_edit %}200{% else %}100{% endif %}px">Value</th>
-              <th>Description</th>
-              <th class="d-none d-md-table-cell text-muted" style="width:280px">Env var</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for t in web_tuning %}
-            <tr>
-              <td class="fw-semibold">
-                {{ t.label }}
-                {% if t.overridden %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
-              </td>
-              <td>
-                {% if can_edit and t.editable %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1">
-                    <input type="hidden" name="key" value="{{ t.key }}">
-                    <input type="hidden" name="action" value="set">
-                    <input type="number" name="value" value="{{ t.value }}" class="form-control form-control-sm bg-dark text-light border-secondary" style="width:80px">
-                    <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
-                  </form>
-                  {% if t.overridden %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="mt-1">
-                    <input type="hidden" name="key" value="{{ t.key }}">
-                    <input type="hidden" name="action" value="reset">
-                    <button type="submit" class="btn btn-sm btn-link text-muted p-0" title="Reset to env default" style="font-size:.75rem">reset to env</button>
-                  </form>
-                  {% endif %}
-                {% else %}
-                  <span class="badge bg-dark border border-secondary font-monospace">{{ t.value }}</span>
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ t.description }}</td>
-              <td class="d-none d-md-table-cell"><code class="small text-info">{{ t.env }}</code></td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Chronicle #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-chronicle" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Chronicle
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-chronicle">
-    <p class="text-muted small mb-2">
-      Chronicle-wide settings displayed on player sheets. One tenet per line.
-    </p>
-    <div class="card border-secondary bg-transparent">
-      <div class="card-body p-2">
-        <table class="table table-sm table-dark mb-0">
-          <thead>
-            <tr>
-              <th style="width:160px">Setting</th>
-              <th>Value</th>
-              <th class="text-muted small">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="fw-semibold">
-                Chronicle Tenets
-                {% if chronicle_settings.tenets_overridden %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
-              </td>
-              <td>
-                {% if can_edit %}
-                <form method="POST" action="{{ url_for('settings.update') }}">
-                  <input type="hidden" name="key" value="CHRONICLE_TENETS">
-                  <input type="hidden" name="action" value="set">
-                  <textarea name="value" rows="4"
-                    class="form-control form-control-sm bg-dark text-light border-secondary font-monospace mb-1"
-                    style="width:340px; resize:vertical;">{{ chronicle_settings.tenets or '' }}</textarea>
-                  <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
-                </form>
-                {% if chronicle_settings.tenets_overridden %}
-                <form method="POST" action="{{ url_for('settings.update') }}" class="mt-1">
-                  <input type="hidden" name="key" value="CHRONICLE_TENETS">
-                  <input type="hidden" name="action" value="reset">
-                  <button type="submit" class="btn btn-sm btn-link text-muted p-0" style="font-size:.75rem">reset to env</button>
-                </form>
-                {% endif %}
-                {% else %}
-                <pre class="small text-muted mb-0">{{ chronicle_settings.tenets or '(not set)' }}</pre>
-                {% endif %}
-              </td>
-              <td class="text-muted small">Displayed on player sheets and inline character view. One tenet per line.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Bot — Channel IDs #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-bot-channels" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Bot — Channel IDs
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-bot-channels">
-    <p class="text-muted small mb-2">
-      Stored in the database. Click <strong>Restart Bot</strong> above to apply. Leave blank to use the bot's <code>.env</code> value.
-    </p>
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th style="width:220px">Channel</th>
-              <th style="width:{% if can_edit %}280px{% else %}180px{% endif %}">ID</th>
-              <th>Description</th>
-              <th class="d-none d-md-table-cell text-muted" style="width:280px">Env var</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for c in bot_channels %}
-            <tr>
-              <td class="fw-semibold">
-                {{ c.label }}
-                {% if c.overridden %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
-              </td>
-              <td>
-                {% if can_edit and c.editable %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1">
-                    <input type="hidden" name="key" value="{{ c.key }}">
-                    <input type="hidden" name="action" value="set">
-                    <input type="text" name="value" value="{{ c.value or '' }}"
-                      placeholder="{{ c.placeholder }}"
-                      {% if c.input_pattern %}pattern="{{ c.input_pattern }}" title="Discord snowflake (17–20 digits)"{% endif %}
-                      class="form-control form-control-sm bg-dark text-light border-secondary font-monospace" style="width:{% if c.input_pattern %}160{% else %}280{% endif %}px">
-                    <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
-                  </form>
-                  {% if c.overridden %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="mt-1">
-                    <input type="hidden" name="key" value="{{ c.key }}">
-                    <input type="hidden" name="action" value="reset">
-                    <button type="submit" class="btn btn-sm btn-link text-muted p-0" style="font-size:.75rem">reset to env</button>
-                  </form>
-                  {% endif %}
-                {% else %}
-                  {% if c.value %}
-                    <span class="badge bg-dark border border-secondary font-monospace">{{ c.value }}</span>
-                  {% else %}
-                    <span class="text-muted small">env default</span>
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ c.description }}</td>
-              <td class="d-none d-md-table-cell"><code class="small text-info">{{ c.env }}</code></td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Bot — Tuning #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-bot-tuning" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Bot — Tuning
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-bot-tuning">
-    <p class="text-muted small mb-2">
-      Interval overrides are stored in the database. Click <strong>Restart Bot</strong> above to apply them.
-      Leave blank to use the value from the bot's <code>.env</code> file.
-    </p>
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th style="width:220px">Parameter</th>
-              <th style="width:{% if can_edit %}220px{% else %}120px{% endif %}">Value</th>
-              <th>Description</th>
-              <th class="d-none d-md-table-cell text-muted" style="width:280px">Env var</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for t in bot_tuning %}
-            <tr>
-              <td class="fw-semibold">
-                {{ t.label }}
-                {% if t.overridden %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
-              </td>
-              <td>
-                {% if can_edit and t.editable %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1">
-                    <input type="hidden" name="key" value="{{ t.key }}">
-                    <input type="hidden" name="action" value="set">
-                    <input type="number" name="value" value="{{ t.value if t.value is not none else '' }}"
-                      placeholder="{{ t.placeholder }}"
-                      class="form-control form-control-sm bg-dark text-light border-secondary" style="width:100px">
-                    <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
-                  </form>
-                  {% if t.overridden %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="mt-1">
-                    <input type="hidden" name="key" value="{{ t.key }}">
-                    <input type="hidden" name="action" value="reset">
-                    <button type="submit" class="btn btn-sm btn-link text-muted p-0" style="font-size:.75rem">reset to env</button>
-                  </form>
-                  {% endif %}
-                {% else %}
-                  {% if t.value is not none %}
-                    <span class="badge bg-dark border border-secondary font-monospace">{{ t.value }}</span>
-                  {% else %}
-                    <span class="text-muted small">env default</span>
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ t.description }}</td>
-              <td class="d-none d-md-table-cell"><code class="small text-info">{{ t.env }}</code></td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Bot — Feature Flags #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-bot-flags" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Bot — Feature Flags
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-bot-flags">
-    <p class="text-muted small mb-2">
-      Changes apply to the bot within 1 minute. If a flag has never been set here, the bot uses its own configuration file.
-    </p>
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th style="width:200px">Feature</th>
-              <th style="width:160px">Status</th>
-              <th>Description</th>
-              <th class="d-none d-md-table-cell text-muted" style="width:220px">Enable env var</th>
-              <th class="d-none d-lg-table-cell text-muted" style="width:220px">Interval env var</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for f in bot_flags %}
-            <tr>
-              <td class="fw-semibold">
-                {{ f.label }}
-                {% if f.db_set %}<span class="badge bg-warning text-dark ms-1" title="Runtime override active">DB</span>{% endif %}
-              </td>
-              <td>
-                {% if can_edit and f.editable %}
-                  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1 flex-wrap">
-                    <input type="hidden" name="key" value="{{ f.key }}">
-                    <input type="hidden" name="action" value="set">
-                    <input type="hidden" name="value" value="{{ 'false' if f.enabled else 'true' }}">
-                    <button type="submit" class="btn btn-sm {% if f.enabled %}btn-success{% else %}btn-outline-secondary{% endif %}" style="min-width:90px">
-                      {% if f.enabled %}<i class="bi bi-toggle-on"></i> ON{% else %}<i class="bi bi-toggle-off"></i> OFF{% endif %}
-                    </button>
-                    {% if not f.db_set and f.live_known %}<span class="badge bg-secondary ms-1" title="No DB override — bot is using its .env value">ENV</span>{% endif %}
-                    {% if f.using_env %}<span class="badge bg-warning text-dark ms-1" title="Bot has not reported its state yet">?</span>{% endif %}
-                    {% if f.db_set %}
-                    </form>
-                    <form method="POST" action="{{ url_for('settings.update') }}">
-                      <input type="hidden" name="key" value="{{ f.key }}">
-                      <input type="hidden" name="action" value="reset">
-                      <button type="submit" class="btn btn-sm btn-link text-muted p-0 ms-1" title="Reset to bot .env default" style="font-size:.75rem">reset</button>
-                    {% endif %}
-                  </form>
-                {% else %}
-                  {% if f.enabled %}
-                    <span class="badge bg-success">Enabled</span>
-                  {% else %}
-                    <span class="badge bg-secondary">Disabled</span>
-                  {% endif %}
-                  {% if not f.db_set and f.live_known %}<span class="badge bg-secondary ms-1">ENV</span>{% endif %}
-                  {% if f.using_env %}<span class="badge bg-warning text-dark ms-1">?</span>{% endif %}
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ f.description }}</td>
-              <td class="d-none d-md-table-cell"><code class="small text-info">{{ f.env }}</code></td>
-              <td class="d-none d-lg-table-cell">
-                {% if f.interval_env %}
-                  <code class="small text-secondary">{{ f.interval_env }}</code>
-                {% else %}
-                  <span class="text-muted">—</span>
-                {% endif %}
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  {# Bot — Commands #}
-  <h5 class="mb-2 mt-2">
-    <button class="btn btn-link text-muted text-uppercase text-decoration-none p-0 collapsed d-flex align-items-center gap-1"
-            style="font-size:0.75rem; letter-spacing:0.05em;"
-            data-bs-toggle="collapse" data-bs-target="#section-bot-commands" aria-expanded="false">
-      <i class="bi bi-chevron-right collapse-chevron" style="font-size:0.7rem; transition:transform 0.2s;"></i>
-      Bot — Commands
-    </button>
-  </h5>
-  <div class="collapse mb-4" id="section-bot-commands">
-    <p class="text-muted small mb-2">
-      Turn any Discord command (or individual subcommand) off without a redeploy. Staff (BOT_TESTER_IDS) can still
-      run a disabled command themselves; everyone else gets a polite "disabled" reply. Disabling a whole command
-      disables all of its subcommands too. Changes apply to the bot within 1 minute — the command still appears
-      in Discord's picker either way, it just won't run for non-staff users while off.
-    </p>
-    <div class="card">
-      <div class="card-body p-0">
-        <table class="table table-dark table-sm mb-0 align-middle">
-          <thead>
-            <tr>
-              <th style="width:260px">Command</th>
-              <th style="width:140px">Status</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for cmd in bot_commands %}
-            <tr>
-              <td class="fw-semibold">{{ cmd.label }}</td>
-              <td>
-                {% if can_edit %}
-                <form method="POST" action="{{ url_for('settings.toggle_bot_command') }}" class="mb-0">
-                  <input type="hidden" name="token" value="{{ cmd.token }}">
-                  <input type="hidden" name="action" value="{{ 'enable' if cmd.disabled else 'disable' }}">
-                  <button type="submit" class="btn btn-sm {% if cmd.disabled %}btn-outline-secondary{% else %}btn-success{% endif %}" style="min-width:90px">
-                    {% if cmd.disabled %}<i class="bi bi-toggle-off"></i> OFF{% else %}<i class="bi bi-toggle-on"></i> ON{% endif %}
-                  </button>
-                </form>
-                {% else %}
-                  {% if cmd.disabled %}<span class="badge bg-secondary">Disabled</span>{% else %}<span class="badge bg-success">Enabled</span>{% endif %}
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ cmd.description }}</td>
-            </tr>
-            {% for sub in cmd.subcommands %}
-            <tr>
-              <td class="text-muted small ps-4">↳ {{ sub.label }}</td>
-              <td>
-                {% if can_edit %}
-                <form method="POST" action="{{ url_for('settings.toggle_bot_command') }}" class="d-flex align-items-center gap-1 mb-0">
-                  <input type="hidden" name="token" value="{{ sub.token }}">
-                  <input type="hidden" name="action" value="{{ 'enable' if sub.own_disabled else 'disable' }}">
-                  <button type="submit" class="btn btn-sm {% if sub.disabled %}btn-outline-secondary{% else %}btn-success{% endif %}"
-                          style="min-width:90px" {% if cmd.disabled and not sub.own_disabled %}disabled{% endif %}>
-                    {% if sub.disabled %}<i class="bi bi-toggle-off"></i> OFF{% else %}<i class="bi bi-toggle-on"></i> ON{% endif %}
-                  </button>
-                  {% if sub.inherited %}<span class="badge bg-secondary ms-1" title="Disabled via the master switch above">via master</span>{% endif %}
-                </form>
-                {% else %}
-                  {% if sub.disabled %}<span class="badge bg-secondary">Disabled</span>{% else %}<span class="badge bg-success">Enabled</span>{% endif %}
-                {% endif %}
-              </td>
-              <td class="text-muted small">{{ sub.description }}</td>
-            </tr>
-            {% endfor %}
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
+  </form>
+  {% if is_overridden %}
+  <form method="POST" action="{{ url_for('settings.update') }}" class="mb-0">
+    <input type="hidden" name="key" value="{{ item.key }}">
+    <input type="hidden" name="action" value="reset">
+    <input type="hidden" name="section" value="{{ section }}">
+    <button type="submit" class="settings-reset-link" title="Reset to default">reset</button>
+  </form>
+  {% endif %}
+  {% else %}
+    <span class="settings-pill {% if item.enabled %}settings-pill--on{% endif %}" style="cursor:default">{{ '● Enabled' if item.enabled else '○ Disabled' }}</span>
+  {% endif %}
+  <div class="settings-row-desc">{{ item.description }}</div>
 </div>
+{% endmacro %}
+
+{% macro tuning_row(item, section) %}
+<div class="settings-row">
+  <div class="settings-row-label">
+    {{ item.label }}
+    {% if item.overridden %}<span class="settings-override-badge" title="Runtime override active">DB</span>{% endif %}
+  </div>
+  {% if can_edit and item.editable %}
+  <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1 mb-0">
+    <input type="hidden" name="key" value="{{ item.key }}">
+    <input type="hidden" name="action" value="set">
+    <input type="hidden" name="section" value="{{ section }}">
+    <input type="number" name="value" value="{{ item.value if item.value is not none else '' }}" placeholder="{{ item.placeholder }}"
+      class="form-control form-control-sm" style="width:100px;flex-shrink:0;">
+    <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
+  </form>
+  {% if item.overridden %}
+  <form method="POST" action="{{ url_for('settings.update') }}" class="mb-0">
+    <input type="hidden" name="key" value="{{ item.key }}">
+    <input type="hidden" name="action" value="reset">
+    <input type="hidden" name="section" value="{{ section }}">
+    <button type="submit" class="settings-reset-link">reset to env</button>
+  </form>
+  {% endif %}
+  {% else %}
+    <span class="badge bg-dark border border-secondary font-monospace">{{ item.value if item.value is not none else 'env default' }}</span>
+  {% endif %}
+  <div class="settings-row-desc">{{ item.description }}</div>
+</div>
+{% endmacro %}
+
+{% macro channel_row(item) %}
+<div class="settings-channel-row">
+  <div class="settings-channel-row-top">
+    <div class="settings-row-label" style="width:220px;">
+      {{ item.label }}
+      {% if item.overridden %}<span class="settings-override-badge" title="Runtime override active">DB</span>{% endif %}
+    </div>
+    {% if can_edit and item.editable %}
+    <form method="POST" action="{{ url_for('settings.update') }}" class="d-flex align-items-center gap-1 mb-0">
+      <input type="hidden" name="key" value="{{ item.key }}">
+      <input type="hidden" name="action" value="set">
+      <input type="hidden" name="section" value="bot-channels">
+      <input type="text" name="value" value="{{ item.value or '' }}" placeholder="{{ item.placeholder }}"
+        {% if item.input_pattern %}pattern="{{ item.input_pattern }}" title="Discord snowflake (17–20 digits)"{% endif %}
+        class="form-control form-control-sm settings-channel-input">
+      <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
+    </form>
+    {% if item.overridden %}
+    <form method="POST" action="{{ url_for('settings.update') }}" class="mb-0">
+      <input type="hidden" name="key" value="{{ item.key }}">
+      <input type="hidden" name="action" value="reset">
+      <input type="hidden" name="section" value="bot-channels">
+      <button type="submit" class="settings-reset-link">reset</button>
+    </form>
+    {% endif %}
+    {% else %}
+      <span class="badge bg-dark border border-secondary font-monospace">{{ item.value or 'env default' }}</span>
+    {% endif %}
+    <span class="settings-used-by-badge">{{ item.used_by }}</span>
+  </div>
+  <div class="settings-row-desc">{{ item.description }}</div>
+</div>
+{% endmacro %}
+
+{% macro command_row(cmd) %}
+<div class="settings-row">
+  <div class="settings-row-label" style="width:150px;font-family:monospace;">{{ cmd.label }}</div>
+  {% if can_edit %}
+  <form method="POST" action="{{ url_for('settings.toggle_bot_command') }}" class="d-flex align-items-center gap-1 mb-0">
+    <input type="hidden" name="token" value="{{ cmd.token }}">
+    <input type="hidden" name="action" value="{{ 'enable' if cmd.disabled else 'disable' }}">
+    <input type="hidden" name="section" value="bot-commands">
+    <button type="submit" class="settings-pill {% if not cmd.disabled %}settings-pill--on{% endif %}" style="min-width:70px">
+      {{ 'OFF' if cmd.disabled else 'ON' }}
+    </button>
+  </form>
+  {% else %}
+    <span class="settings-pill {% if not cmd.disabled %}settings-pill--on{% endif %}">{{ 'OFF' if cmd.disabled else 'ON' }}</span>
+  {% endif %}
+  <div class="settings-row-desc">{{ cmd.description }}</div>
+</div>
+{% for sub in cmd.subcommands %}
+<div class="settings-row settings-row--sub">
+  <div class="settings-row-label" style="width:120px;font-family:monospace;font-size:12px;color:var(--text-muted);font-weight:400;">↳ {{ sub.label }}</div>
+  {% if can_edit %}
+  <form method="POST" action="{{ url_for('settings.toggle_bot_command') }}" class="d-flex align-items-center gap-1 mb-0">
+    <input type="hidden" name="token" value="{{ sub.token }}">
+    <input type="hidden" name="action" value="{{ 'enable' if sub.own_disabled else 'disable' }}">
+    <input type="hidden" name="section" value="bot-commands">
+    <button type="submit" class="settings-pill {% if not sub.disabled %}settings-pill--on{% endif %}" style="min-width:70px"
+      {% if cmd.disabled and not sub.own_disabled %}disabled{% endif %}>
+      {{ 'OFF' if sub.disabled else 'ON' }}
+    </button>
+    {% if sub.inherited %}<span class="settings-override-badge" title="Disabled via the master switch above">via master</span>{% endif %}
+  </form>
+  {% else %}
+    <span class="settings-pill {% if not sub.disabled %}settings-pill--on{% endif %}">{{ 'OFF' if sub.disabled else 'ON' }}</span>
+  {% endif %}
+  <div class="settings-row-desc">{{ sub.description }}</div>
+</div>
+{% endfor %}
+{% endmacro %}
+
+<div class="settings-topbar">
+  <a href="{{ url_for('dashboard.index') }}" class="settings-topbar-back"><span>←</span> Dashboard</a>
+  <div class="settings-topbar-divider"></div>
+  <span class="settings-status-dot settings-status-dot--{{ bot_status_level }}" title="Bot status: {{ bot_status_level }}"></span>
+  <h1 class="settings-topbar-title">Settings</h1>
+</div>
+
+<div class="settings-shell">
+
+  <nav class="settings-nav" id="settings-nav">
+    <div class="settings-search">
+      <input type="search" id="settings-search-input" autocomplete="off" placeholder="search any setting…">
+    </div>
+    {% for group in settings_nav %}
+    <div class="settings-nav-group">
+      <div class="settings-nav-group-label">{{ group.group }}</div>
+      {% for item in group.links %}
+      <a href="{{ url_for('settings.index', section=item.id) }}"
+         class="settings-nav-link {{ 'is-active' if active_section == item.id }}"
+         data-section="{{ item.id }}">
+        <span>{{ item.label }}</span>
+        {% if item.count_key %}<span class="settings-nav-count">{{ nav_counts[item.count_key] }}</span>{% endif %}
+      </a>
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </nav>
+
+  <main class="settings-main">
+
+    <div id="settings-search-results" hidden></div>
+
+    {# ═══ OVERVIEW ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'overview' }}" data-section="overview">
+      <h3 class="settings-pane-title">Overview</h3>
+      <p class="settings-pane-subtitle">Daily operations — the stuff you actually touch most weeks.</p>
+
+      <div class="settings-overview-grid">
+
+        <div class="settings-overview-card">
+          <div class="settings-card-header" style="border:none;padding:0;margin-bottom:10px;">Bot Status</div>
+          {% if bot_heartbeat_ts is none %}
+            <span class="badge bg-secondary">No heartbeat received yet</span>
+          {% elif bot_heartbeat_age is not none and bot_heartbeat_age < 180 %}
+            <span class="badge bg-success"><i class="bi bi-circle-fill me-1" style="font-size:0.6rem"></i>Online</span>
+            <small class="text-muted ms-1">seen {{ bot_heartbeat_age }}s ago</small>
+          {% elif bot_heartbeat_age is not none and bot_heartbeat_age < 600 %}
+            <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-circle me-1"></i>Delayed</span>
+            <small class="text-muted ms-1">seen {{ (bot_heartbeat_age // 60) }}m ago</small>
+          {% else %}
+            <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Offline</span>
+            <small class="text-muted ms-1">seen {{ (bot_heartbeat_age // 60) if bot_heartbeat_age else '?' }}m ago</small>
+          {% endif %}
+          {% if can_edit %}
+          <div class="d-flex gap-2 mt-3">
+            <form method="POST" action="{{ url_for('settings.request_restart') }}" class="mb-0">
+              <input type="hidden" name="section" value="overview">
+              {% if bot_restart_pending %}
+                <button type="submit" class="btn btn-sm btn-warning" disabled><i class="bi bi-arrow-clockwise"></i> Pending…</button>
+              {% else %}
+                <button type="submit" class="btn btn-sm btn-outline-warning"
+                  onclick="return confirm('Request bot restart? It will exit cleanly within ~60s and Docker will restart it.')">
+                  <i class="bi bi-arrow-clockwise"></i> Restart
+                </button>
+              {% endif %}
+            </form>
+            <form method="POST" action="{{ url_for('settings.request_rebuild') }}" class="mb-0">
+              <input type="hidden" name="section" value="overview">
+              <button type="submit" class="btn btn-sm btn-outline-info"
+                onclick="return confirm('This will exit the bot within ~60s. Copy the rebuild command from the card, then run it in your terminal.')">
+                <i class="bi bi-hammer"></i> Rebuild
+              </button>
+            </form>
+          </div>
+          <details class="mt-2">
+            <summary class="text-muted small" style="cursor:pointer;">Rebuild command</summary>
+            <div class="d-flex align-items-center gap-2 mt-2">
+              <code class="flex-grow-1 px-2 py-1 rounded small" style="background:#111; color:#adb5bd; word-break:break-all;">
+                cd ~/Projects/mcbn-xp-tracker/apps/bot &amp;&amp; npm run ops:docker:down &amp;&amp; npm run ops:docker:up
+              </code>
+              <button class="btn btn-sm btn-outline-secondary text-nowrap" type="button" id="rebuild-copy-btn"
+                      onclick="navigator.clipboard.writeText('cd ~/Projects/mcbn-xp-tracker/apps/bot && npm run ops:docker:down && npm run ops:docker:up'); var b=document.getElementById('rebuild-copy-btn'); b.textContent='Copied!'; setTimeout(function(){b.textContent='Copy'},2000);">
+                Copy
+              </button>
+            </div>
+          </details>
+          {% endif %}
+        </div>
+
+        <div class="settings-overview-card">
+          <div class="settings-card-header" style="border:none;padding:0;margin-bottom:10px;">Wiki Sync</div>
+          {% if wiki_sync.status == 'running' and wiki_sync.is_stale %}
+            <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>Stale</span>
+          {% elif wiki_sync.status == 'running' %}
+            <span class="badge bg-info text-dark"><i class="bi bi-arrow-repeat me-1"></i>Running</span>
+          {% elif wiki_sync.status == 'success' %}
+            <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Success</span>
+            {% if wiki_sync.finished_at %}<small class="text-muted ms-1">{{ wiki_sync.finished_at[:19] | replace('T', ' ') }} UTC</small>{% endif %}
+          {% elif wiki_sync.status == 'error' %}
+            <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Error</span>
+          {% elif wiki_sync.requested %}
+            <span class="badge bg-secondary">Queued</span>
+          {% else %}
+            <span class="badge bg-secondary">Never run</span>
+          {% endif %}
+          {% if wiki_sync.capable is sameas false %}
+            <small class="text-warning d-block mt-2"><i class="bi bi-exclamation-triangle me-1"></i>Bot reports missing sync prerequisites.</small>
+          {% endif %}
+          {% if wiki_sync.status == 'error' and wiki_sync.error %}
+            <small class="text-danger d-block mt-2">{{ wiki_sync.error }}</small>
+          {% endif %}
+          {% if can_edit %}
+          <div class="d-flex align-items-center gap-2 mt-3">
+            <form method="POST" action="{{ url_for('settings.request_wiki_sync') }}" class="mb-0">
+              <input type="hidden" name="section" value="overview">
+              {% if wiki_sync.capable is sameas false %}
+                <button type="submit" class="btn btn-sm btn-outline-secondary" disabled title="Bot reports missing DISCORD_GUILD_ID">
+                  <i class="bi bi-slash-circle"></i> Missing Prereqs
+                </button>
+              {% elif wiki_sync.requested or (wiki_sync.status == 'running' and not wiki_sync.is_stale) %}
+                <button type="submit" class="btn btn-sm btn-info" disabled>
+                  <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                  {% if wiki_sync.status == 'running' %}Running…{% else %}Queued…{% endif %}
+                </button>
+              {% else %}
+                <button type="submit" class="btn btn-sm btn-outline-info"
+                  onclick="return confirm('Run Discord → Wiki sync? This may take several minutes.')">
+                  <i class="bi bi-arrow-repeat"></i> Run Wiki Sync
+                </button>
+              {% endif %}
+            </form>
+            {% if wiki_sync.is_stale %}
+            <form method="POST" action="{{ url_for('settings.reset_wiki_sync') }}" class="mb-0">
+              <input type="hidden" name="section" value="overview">
+              <button type="submit" class="btn btn-sm btn-outline-warning"
+                onclick="return confirm('Reset stale Wiki sync state? Use this if the bot crashed during a run.')">
+                <i class="bi bi-arrow-counterclockwise"></i> Reset Stale
+              </button>
+            </form>
+            {% endif %}
+          </div>
+          {% endif %}
+          {% if wiki_sync_runs %}
+          <details class="mt-2">
+            <summary class="text-muted small" style="cursor:pointer;">Recent runs</summary>
+            <div class="table-responsive mt-2">
+              <table class="table table-dark table-sm mb-0 align-middle">
+                <thead>
+                  <tr>
+                    <th>Run ID</th><th>Started</th><th>Finished</th><th>Duration</th><th>Source</th><th>Status</th><th>Error</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for run in wiki_sync_runs %}
+                  <tr>
+                    <td class="small font-monospace text-muted">{{ run.run_id if run.run_id else run.run_key }}</td>
+                    <td class="small text-muted">{{ run.started_at[:19] | replace('T', ' ') if run.started_at else '—' }}</td>
+                    <td class="small text-muted">{{ run.finished_at[:19] | replace('T', ' ') if run.finished_at else '—' }}</td>
+                    <td class="small text-muted">{{ run.duration_display }}</td>
+                    <td>{% if run.source == 'scheduled' %}<span class="badge bg-secondary">Scheduled</span>{% else %}<span class="badge bg-dark border border-secondary">Manual</span>{% endif %}</td>
+                    <td>
+                      {% if run.status == 'success' %}<span class="badge bg-success">Success</span>
+                      {% elif run.status == 'error' %}<span class="badge bg-danger">Error</span>
+                      {% else %}<span class="badge bg-info text-dark">Running</span>{% endif %}
+                    </td>
+                    <td class="small {% if run.status == 'error' and run.error %}text-danger{% else %}text-muted{% endif %}">{{ run.error if run.error else '—' }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </details>
+          {% endif %}
+        </div>
+
+        <div class="settings-overview-card">
+          <div class="settings-card-header" style="border:none;padding:0;margin-bottom:10px;">Retirement Jobs</div>
+          <div class="d-flex gap-2 flex-wrap">
+            <span class="badge bg-secondary">Discord: {{ retirement_summary.pending_discord }} pending</span>
+            <span class="badge bg-info text-dark">Wiki: {{ retirement_summary.pending_wiki }} queued</span>
+            <span class="badge bg-warning text-dark">Backoff: {{ retirement_summary.backoff }}</span>
+            {% if retirement_summary.errored %}
+              <span class="badge bg-danger">Errors: {{ retirement_summary.errored }}</span>
+            {% else %}
+              <span class="badge bg-success">Errors: 0</span>
+            {% endif %}
+          </div>
+          <p class="text-muted small mt-2 mb-0">Cubby channels move immediately; wiki updates wait for the next successful sync.</p>
+          {% if retirement_jobs %}
+          <details class="mt-2">
+            <summary class="text-muted small" style="cursor:pointer;">Recent jobs</summary>
+            <div class="table-responsive mt-2">
+              <table class="table table-dark table-sm mb-0 align-middle">
+                <thead>
+                  <tr><th>Character</th><th>Requested</th><th>Discord</th><th>Wiki</th><th>Attempts</th><th>Next Retry</th><th>Error</th></tr>
+                </thead>
+                <tbody>
+                  {% for job in retirement_jobs %}
+                  {% set next_retry_at = retirement_next_retry_at(job) %}
+                  <tr>
+                    <td class="small">{{ job.character_name }}</td>
+                    <td class="small text-muted">{{ job.requested_at.strftime('%Y-%m-%d %H:%M') if job.requested_at else '—' }}</td>
+                    <td>
+                      {% if job.discord_completed_at %}<span class="badge bg-success">Complete</span>
+                      {% elif next_retry_at %}<span class="badge bg-warning text-dark">Backoff</span>
+                      {% else %}<span class="badge bg-secondary">Pending</span>{% endif %}
+                    </td>
+                    <td>
+                      {% if job.wiki_synced_at %}<span class="badge bg-success">Synced</span>
+                      {% elif job.discord_completed_at %}<span class="badge bg-info text-dark">Queued</span>
+                      {% else %}<span class="badge bg-dark border border-secondary">Waiting</span>{% endif %}
+                    </td>
+                    <td class="small text-muted">{{ job.attempt_count }}</td>
+                    <td class="small text-muted">{{ next_retry_at.strftime('%Y-%m-%d %H:%M') if next_retry_at else '—' }}</td>
+                    <td class="small {% if job.last_error %}text-danger{% else %}text-muted{% endif %}">{{ job.last_error if job.last_error else '—' }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </details>
+          {% endif %}
+        </div>
+
+      </div>
+    </section>
+
+    {# ═══ STAFF & ACCESS ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'staff' }}" data-section="staff">
+      <h3 class="settings-pane-title">Staff &amp; Access</h3>
+      <p class="settings-pane-subtitle">Added here, they can sign in immediately — no redeploy. Env-var entries are always active and can't be removed here.</p>
+
+      <div class="settings-card">
+        {% if staff_members %}
+        <table class="table table-dark table-sm mb-0 align-middle">
+          <thead>
+            <tr><th>Name</th><th>Discord ID</th><th>Role</th><th></th></tr>
+          </thead>
+          <tbody>
+            {% for m in staff_members %}
+            <tr>
+              <td>{% if m.name %}{{ m.name }}{% else %}<span class="text-muted">—</span>{% endif %}</td>
+              <td><code>{{ m.discord_id }}</code></td>
+              <td>
+                <span class="badge {% if m.role == 'administrator' %}bg-warning text-dark{% elif m.role == 'moderator' %}bg-info text-dark{% elif m.role == 'storyteller' %}bg-primary{% else %}bg-secondary{% endif %}">{{ m.label }}</span>
+                {% if m.source == 'env' or m.has_env_access %}
+                  <span class="badge bg-dark border border-secondary text-muted ms-1" title="Granted via environment variable — manage in server config">Env</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if m.source == 'db' and not m.has_env_access %}
+                <form method="POST" action="{{ url_for('settings.staff_remove') }}" class="mb-0">
+                  <input type="hidden" name="discord_id" value="{{ m.discord_id }}">
+                  <input type="hidden" name="section" value="staff">
+                  <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Remove {{ m.discord_id }} from staff?')">Remove</button>
+                </form>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <p class="text-muted small p-3 mb-0">No staff members found.</p>
+        {% endif %}
+      </div>
+
+      <div class="settings-card" style="padding:16px 18px;">
+        <div class="settings-card-header" style="border:none;padding:0;margin-bottom:12px;">Add Staff</div>
+        <form method="POST" action="{{ url_for('settings.staff_add') }}" class="row g-2 align-items-end">
+          <input type="hidden" name="section" value="staff">
+          <div class="col-auto">
+            <label class="form-label small text-muted mb-1">Display Name</label>
+            <input type="text" name="name" class="form-control form-control-sm" placeholder="e.g. Jason" style="width:160px" maxlength="80">
+          </div>
+          <div class="col-auto">
+            <label class="form-label small text-muted mb-1">Discord ID</label>
+            <input type="text" name="discord_id" class="form-control form-control-sm" placeholder="e.g. 123456789012345678" style="width:220px" required pattern="\d+">
+          </div>
+          <div class="col-auto">
+            <label class="form-label small text-muted mb-1">Role</label>
+            <select name="role" class="form-select form-select-sm">
+              <option value="system_helper">System Helper</option>
+              <option value="storyteller">Storyteller</option>
+              <option value="moderator">Moderator</option>
+              <option value="administrator">Administrator</option>
+            </select>
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-sm btn-outline-primary">Add Staff</button>
+          </div>
+        </form>
+      </div>
+    </section>
+
+    {# ═══ BOT · CHANNEL IDS ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'bot-channels' }}" data-section="bot-channels">
+      <h3 class="settings-pane-title">Bot — Channel IDs</h3>
+      <p class="settings-pane-subtitle">Stored in the database. Restart the bot to apply. Leave blank to use the bot's <code>.env</code> value. Grouped by the feature that uses them.</p>
+      {% for grp in bot_channel_groups %}
+      <div class="settings-group-label">{{ grp.name }}</div>
+      <div class="settings-card">
+        {% for c in grp.channels %}{{ channel_row(c) }}{% endfor %}
+      </div>
+      {% endfor %}
+    </section>
+
+    {# ═══ BOT · FEATURE FLAGS ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'bot-flags' }}" data-section="bot-flags">
+      <h3 class="settings-pane-title">Bot — Feature Flags</h3>
+      <p class="settings-pane-subtitle">Changes apply to the bot within ~1 minute. If a flag has never been set here, the bot uses its own configuration file.</p>
+      <div class="settings-card">
+        {% for f in bot_flags %}{{ toggle_row(f, 'bot-flags') }}{% endfor %}
+      </div>
+    </section>
+
+    {# ═══ BOT · COMMANDS ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'bot-commands' }}" data-section="bot-commands">
+      <h3 class="settings-pane-title">Bot — Commands</h3>
+      <p class="settings-pane-subtitle">Turn any command or subcommand off without a redeploy. Staff can still run a disabled command themselves.</p>
+      <div class="settings-card">
+        {% for cmd in bot_commands %}{{ command_row(cmd) }}{% endfor %}
+      </div>
+    </section>
+
+    {# ═══ BOT · TUNING ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'bot-tuning' }}" data-section="bot-tuning">
+      <h3 class="settings-pane-title">Bot — Tuning</h3>
+      <p class="settings-pane-subtitle">Interval overrides apply after the bot restarts.</p>
+      <div class="settings-card">
+        {% for t in bot_tuning %}{{ tuning_row(t, 'bot-tuning') }}{% endfor %}
+      </div>
+    </section>
+
+    {# ═══ WEB APP · FLAGS & TUNING ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'web-flags-tuning' }}" data-section="web-flags-tuning">
+      <h3 class="settings-pane-title">Web App — Flags &amp; Tuning</h3>
+      <p class="settings-pane-subtitle">Runtime overrides for the admin/API app — no redeploy needed unless noted.</p>
+
+      <div class="settings-group-label">Feature Flags</div>
+      <div class="settings-card">
+        {% for f in web_flags %}{{ toggle_row(f, 'web-flags-tuning') }}{% endfor %}
+      </div>
+
+      <div class="settings-group-label">Tuning</div>
+      <div class="settings-card">
+        {% for t in web_tuning %}{{ tuning_row(t, 'web-flags-tuning') }}{% endfor %}
+      </div>
+    </section>
+
+    {# ═══ WEB APP · INTEGRATIONS ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'web-integrations' }}" data-section="web-integrations">
+      <h3 class="settings-pane-title">Web App — Integrations</h3>
+      <p class="settings-pane-subtitle">Configured via environment secrets — values shown read-only. Each card explains what it's for and when you'd actually need to touch it.</p>
+      {% for i in integrations %}
+      <div class="settings-integration-card">
+        <div class="settings-integration-header">
+          <div class="settings-integration-name">{{ i.label }}</div>
+          {% if i.configured %}
+            <span class="badge bg-success">Configured</span>
+          {% else %}
+            <span class="badge bg-secondary">Not set</span>
+          {% endif %}
+        </div>
+        <div class="settings-integration-desc">{{ i.description }}</div>
+        {% if i.value %}
+        <div class="settings-integration-value-row">
+          <div class="settings-integration-value-label">{{ i.value_label }}</div>
+          <div class="settings-integration-value">{{ i.value }}</div>
+        </div>
+        {% endif %}
+        <div class="settings-integration-why">Why change it: {{ i.why_change }}</div>
+      </div>
+      {% endfor %}
+    </section>
+
+    {# ═══ WEB APP · CHRONICLE ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'web-chronicle' }}" data-section="web-chronicle">
+      <h3 class="settings-pane-title">Web App — Chronicle</h3>
+      <p class="settings-pane-subtitle">Chronicle-wide tenets, displayed on every player sheet.</p>
+      <div class="settings-card" style="padding:16px 18px;">
+        <div class="settings-card-header" style="border:none;padding:0;margin-bottom:10px;">
+          Chronicle Tenets
+          {% if chronicle_settings.tenets_overridden %}<span class="settings-override-badge" title="Runtime override active">DB</span>{% endif %}
+        </div>
+        {% if can_edit %}
+        <form method="POST" action="{{ url_for('settings.update') }}">
+          <input type="hidden" name="key" value="CHRONICLE_TENETS">
+          <input type="hidden" name="action" value="set">
+          <input type="hidden" name="section" value="web-chronicle">
+          <textarea name="value" rows="5" class="form-control form-control-sm font-monospace mb-2" style="resize:vertical;">{{ chronicle_settings.tenets or '' }}</textarea>
+          <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
+        </form>
+        {% if chronicle_settings.tenets_overridden %}
+        <form method="POST" action="{{ url_for('settings.update') }}" class="mt-1">
+          <input type="hidden" name="key" value="CHRONICLE_TENETS">
+          <input type="hidden" name="action" value="reset">
+          <input type="hidden" name="section" value="web-chronicle">
+          <button type="submit" class="settings-reset-link">reset to env</button>
+        </form>
+        {% endif %}
+        {% else %}
+        <pre class="small text-muted mb-0">{{ chronicle_settings.tenets or '(not set)' }}</pre>
+        {% endif %}
+      </div>
+    </section>
+
+  </main>
+</div>
+
+<script type="application/json" id="settings-search-data">{{ search_index | tojson }}</script>
 
 {% if wiki_sync.requested or (wiki_sync.status == 'running' and not wiki_sync.is_stale) %}
 <script>setTimeout(() => location.reload(), 10000);</script>
@@ -881,16 +558,84 @@
 
 {% block scripts %}
 <script>
-document.querySelectorAll('[data-bs-toggle="collapse"]').forEach(function(btn) {
-  var target = document.querySelector(btn.dataset.bsTarget);
-  if (!target) return;
-  var chevron = btn.querySelector('.collapse-chevron');
-  target.addEventListener('show.bs.collapse', function() {
-    if (chevron) chevron.style.transform = 'rotate(90deg)';
+(function () {
+  var searchDataEl = document.getElementById('settings-search-data');
+  var searchIndex = [];
+  try { searchIndex = JSON.parse(searchDataEl.textContent || '[]'); } catch (e) {}
+
+  var searchInput = document.getElementById('settings-search-input');
+  var resultsPane = document.getElementById('settings-search-results');
+  var panes = document.querySelectorAll('.settings-pane[data-section]');
+  var navLinks = document.querySelectorAll('.settings-nav-link[data-section]');
+
+  function showSection(id) {
+    panes.forEach(function (p) { p.classList.toggle('is-active', p.dataset.section === id); });
+    navLinks.forEach(function (l) { l.classList.toggle('is-active', l.dataset.section === id); });
+    resultsPane.hidden = true;
+  }
+
+  function renderResults(query) {
+    var q = query.trim().toLowerCase();
+    var matches = searchIndex.filter(function (r) {
+      return (r.label + ' ' + r.description).toLowerCase().indexOf(q) !== -1;
+    }).slice(0, 40);
+
+    resultsPane.innerHTML = '';
+
+    var count = document.createElement('div');
+    count.className = 'settings-search-results-count';
+    count.textContent = matches.length + ' result(s) — click one to jump to its section';
+    resultsPane.appendChild(count);
+
+    var list = document.createElement('div');
+    list.className = 'settings-card';
+    matches.forEach(function (r) {
+      var row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'settings-search-result-row';
+      row.innerHTML =
+        '<div class="settings-search-result-top">' +
+          '<span class="settings-search-result-label"></span>' +
+          '<span class="settings-search-result-section"></span>' +
+        '</div>' +
+        '<div class="settings-search-result-desc"></div>';
+      row.querySelector('.settings-search-result-label').textContent = r.label;
+      row.querySelector('.settings-search-result-section').textContent = r.section_label;
+      row.querySelector('.settings-search-result-desc').textContent = r.description;
+      row.addEventListener('click', function () {
+        searchInput.value = '';
+        history.replaceState(null, '', '?section=' + r.section);
+        showSection(r.section);
+      });
+      list.appendChild(row);
+    });
+    resultsPane.appendChild(list);
+
+    panes.forEach(function (p) { p.classList.remove('is-active'); });
+    navLinks.forEach(function (l) { l.classList.remove('is-active'); });
+    resultsPane.hidden = false;
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', function () {
+      var q = searchInput.value.trim();
+      if (!q) {
+        var active = document.querySelector('.settings-nav-link.is-active') || navLinks[0];
+        showSection(active ? active.dataset.section : 'overview');
+        return;
+      }
+      renderResults(q);
+    });
+  }
+
+  navLinks.forEach(function (link) {
+    link.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (searchInput) searchInput.value = '';
+      history.pushState(null, '', link.getAttribute('href'));
+      showSection(link.dataset.section);
+    });
   });
-  target.addEventListener('hide.bs.collapse', function() {
-    if (chevron) chevron.style.transform = 'rotate(0deg)';
-  });
-});
+})();
 </script>
 {% endblock %}

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -283,7 +283,7 @@
           {% endif %}
           {% if wiki_sync_runs %}
           <details class="mt-2">
-            <summary class="text-muted small" style="cursor:pointer;">Recent runs</summary>
+            <summary class="text-muted small" style="cursor:pointer;">Recent sync runs</summary>
             <div class="table-responsive mt-2">
               <table class="table table-dark table-sm mb-0 align-middle">
                 <thead>

--- a/docs/RELEASE_2026-07-10_SETTINGS_CONTROL_PANEL.md
+++ b/docs/RELEASE_2026-07-10_SETTINGS_CONTROL_PANEL.md
@@ -1,0 +1,23 @@
+# Release: 2026-07-10 — Settings Page Control-Panel Redesign
+
+## Included
+
+### Settings page reorganization
+
+**`apps/web` — `app/templates/settings/index.html`, `app/blueprints/settings.py`, `app/static/css/style.css`**
+
+The staff Settings page (`/settings/`) is rebuilt from a single flat scroll of Bootstrap accordions into a left sub-nav "control panel" layout: a fixed 230px nav (grouped into Daily Ops / Bot / Web App) plus a main content pane showing one section at a time, and a global search box that searches every setting by label and description.
+
+All underlying data and write endpoints are unchanged — this is a reorg of the existing page, not new backend behavior, aside from the additions below.
+
+**Sections:** Overview (bot status, wiki sync, retirement jobs — the default landing view), Staff & Access, Bot · Channel IDs, Bot · Feature Flags, Bot · Commands, Bot · Tuning, Web App · Flags & Tuning, Web App · Integrations, Web App · Chronicle.
+
+**Bot — Channel IDs** are now grouped by the feature that consumes them (Moderation & Safety, New Member Onboarding, In-Character Correspondence, Announcements & Events), and every row shows a "used by" badge naming the exact command or feature that reads it (e.g. `/deliver`, `Honeypot Moderation`) — the core ask from the client, so staff can see the consequence of editing a value before they touch it.
+
+**Web App — Integrations** cards now show the actual current value (Sheet URL, masked API tokens, Turso database URL) instead of just a Configured/Not Set pill, plus a "why change it" line explaining the real scenario for touching each one (rotating a leaked token, migrating databases, handing off the backup sheet). Tokens are masked to their last 4 characters; the Turso auth token itself is never shown, only the connection URL.
+
+**Section switching** is server-driven (`?section=<id>` query param, validated against a whitelist) with client-side JS progressively enhancing nav clicks to swap panes instantly with no reload — plain `<a href>` navigation still works with JS disabled. Every write route now redirects back to the section the user was editing (via a new `_redirect_to_section()` helper reading a hidden `section` field on each form) instead of always bouncing to the top of the page.
+
+**Search** is a small vanilla-JS filter over a server-built JSON index (`search_index`, embedded in a `<script type="application/json">` tag) covering channel IDs, flags, tuning, commands/subcommands, integrations, and chronicle tenets — no framework, matching the existing `app.js` conventions.
+
+**Note:** `SETTINGS_NAV`'s per-group link list is keyed `'links'`, not `'items'` — Jinja's attribute lookup on a dict resolves `.items` to Python's `dict.items` method before falling back to key lookup, which broke nav rendering during implementation. Worth remembering for any future dict-of-dicts passed to a template.


### PR DESCRIPTION
## Summary
- Replaces the flat, single-scroll Settings page with a 230px left sub-nav (Daily Ops / Bot / Web App) + main pane, plus a global search across all settings
- Bot — Channel IDs are now grouped by the feature that consumes them, with a "used by" badge on every row (the core ask from the client design handoff)
- Web App — Integrations cards now show the actual current value (masked tokens, constructed Sheet/Turso URLs) and a "why change it" line, instead of just a Configured/Not Set pill
- Write routes now redirect back to the section being edited instead of always bouncing to the top of the page
- All underlying data and write endpoints are unchanged — this is a reorg/reskin, not new backend logic

See `docs/RELEASE_2026-07-10_SETTINGS_CONTROL_PANEL.md` for full details.

## Test plan
- [x] All 9 sections render without error (verified via Flask test client)
- [x] Nav switching, grouping, and search-and-jump-to-section verified in browser
- [x] POST round-trips (toggle flag, add/remove staff, save channel ID) preserve the active section on redirect
- [x] CSRF auto-injection still applies to all forms (panes are hidden via CSS, not removed from DOM)
- [x] No stray test data left in the dev DB
- [ ] Manual smoke test on dev deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)