### PR TITLE
Mirror inline wiki-body Discord images to GCS

### DIFF
--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1400,11 +1400,14 @@ def upsert_wiki_page():
     if not slug or not title:
         return jsonify({'error': 'slug and title are required'}), 400
 
-    from app.gcs import resolve_cover_url
+    from app.gcs import resolve_cover_url, mirror_markdown_images
     from flask import current_app as _app
 
     def _resolve_cover(url: str, page_slug: str) -> str:
         return resolve_cover_url(url, page_slug, _app.config)
+
+    def _resolve_body(body: str, page_slug: str) -> str:
+        return mirror_markdown_images(body, page_slug, _app.config)
 
     from app.db import WikiSyncBlock
     p = WikiPage.query.filter_by(slug=slug).first()
@@ -1419,7 +1422,7 @@ def upsert_wiki_page():
             }), 423
         p.title = title
         if 'body_markdown' in data:
-            p.body_markdown = data['body_markdown']
+            p.body_markdown = _resolve_body(data['body_markdown'], slug)
         if 'category' in data:
             p.category = data['category']
         if 'cover_image_url' in data:
@@ -1439,7 +1442,7 @@ def upsert_wiki_page():
     p = WikiPage(
         slug=slug,
         title=title,
-        body_markdown=data.get('body_markdown', ''),
+        body_markdown=_resolve_body(data.get('body_markdown', ''), slug),
         category=data.get('category', ''),
         cover_image_url=_resolve_cover(data.get('cover_image_url', ''), slug),
         source=data.get('source', 'api-sync'),

--- a/apps/web/app/blueprints/wiki.py
+++ b/apps/web/app/blueprints/wiki.py
@@ -15,7 +15,7 @@ from flask import (
 )
 from app.auth import require_staff, get_staff_user, is_staff as _is_staff
 from app.db import db, WikiPage, WikiSyncBlock, DbCharacter, DbSpendRequest
-from app.gcs import resolve_cover_url, is_discord_cdn_url
+from app.gcs import resolve_cover_url, mirror_markdown_images, is_discord_cdn_url
 
 bp = Blueprint('wiki', __name__)
 
@@ -400,7 +400,7 @@ def new_page():
             slug=slug,
             title=title,
             summary=request.form.get('summary', '').strip(),
-            body_markdown=request.form.get('body_markdown', ''),
+            body_markdown=mirror_markdown_images(request.form.get('body_markdown', ''), slug, current_app.config),
             category=request.form.get('category', '').strip(),
             cover_image_url=cover_url,
             status=new_status,
@@ -426,7 +426,7 @@ def edit_page(slug):
         p.title = request.form.get('title', p.title).strip() or p.title
         p.summary = request.form.get('summary', '').strip()
         p.category = request.form.get('category', p.category).strip()
-        p.body_markdown = request.form.get('body_markdown', '')
+        p.body_markdown = mirror_markdown_images(request.form.get('body_markdown', ''), p.slug, current_app.config)
         raw_cover = request.form.get('cover_image_url', '').strip()
         p.cover_image_url = resolve_cover_url(raw_cover, p.slug, current_app.config)
         new_status = request.form.get('status', p.status).strip()

--- a/apps/web/app/gcs.py
+++ b/apps/web/app/gcs.py
@@ -43,6 +43,7 @@ def mirror_to_gcs(
     bucket_name: str,
     credentials_json: str = '',
     credentials_file: str = '',
+    object_prefix: str = 'wiki-covers',
 ) -> str:
     """Download *url* from Discord CDN and upload to GCS. Returns the public GCS URL.
 
@@ -79,7 +80,7 @@ def mirror_to_gcs(
         ext = _ext_from_url(url)
         # Sanitize slug for use as an object name
         safe_slug = re.sub(r'[^a-z0-9\-_]', '-', slug.lower())
-        object_name = f'wiki-covers/{safe_slug}{ext}'
+        object_name = f'{object_prefix}/{safe_slug}{ext}'
 
         blob = bucket.blob(object_name)
         blob.upload_from_string(resp.content, content_type=content_type)
@@ -91,6 +92,52 @@ def mirror_to_gcs(
     except Exception as exc:
         logger.warning('GCS mirror failed for slug=%s: %s', slug, exc)
         return url
+
+
+_MARKDOWN_IMAGE_RE = re.compile(r'!\[([^\]]*)\]\((https?://[^)\s]+)\)')
+
+
+def _stable_image_key(url: str) -> str:
+    """Hash the URL path (stable) rather than the full URL (its signature
+    query params rotate on every re-fetch), so re-syncing the same Discord
+    attachment reuses the same GCS object instead of re-uploading it."""
+    import hashlib
+
+    path = urlparse(url).path
+    return hashlib.sha1(path.encode()).hexdigest()[:16]
+
+
+def mirror_markdown_images(markdown: str, slug: str, config) -> str:
+    """Mirror any Discord CDN image links embedded in markdown image syntax
+    (`![](url)`) to permanent GCS storage, rewriting the markdown in place.
+
+    Synced wiki pages embed Discord message attachments this way (see
+    apps/bot/src/scripts/notionSync/wikiSyncHelpers.ts), and those signed
+    CDN URLs expire in ~24-48h just like cover images — this covers the
+    same failure mode for inline body images.
+    """
+    if not markdown or not _MARKDOWN_IMAGE_RE.search(markdown):
+        return markdown
+
+    bucket_name = config.get('GCS_BUCKET_NAME', 'mcbn-wiki-images')
+    credentials_json = config.get('GOOGLE_CREDENTIALS_JSON', '')
+    credentials_file = config.get('GOOGLE_CREDENTIALS_FILE', '')
+
+    def _replace(match: 're.Match[str]') -> str:
+        alt, url = match.group(1), match.group(2)
+        if not is_discord_cdn_url(url):
+            return match.group(0)
+        mirrored = mirror_to_gcs(
+            url=url,
+            slug=_stable_image_key(url),
+            bucket_name=bucket_name,
+            credentials_json=credentials_json,
+            credentials_file=credentials_file,
+            object_prefix=f'wiki-body/{re.sub(r"[^a-z0-9\-_]", "-", slug.lower())}',
+        )
+        return f'![{alt}]({mirrored})'
+
+    return _MARKDOWN_IMAGE_RE.sub(_replace, markdown)
 
 
 def resolve_cover_url(url: str, slug: str, config) -> str:

--- a/apps/web/tests/test_gcs_markdown_images.py
+++ b/apps/web/tests/test_gcs_markdown_images.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+from app.gcs import mirror_markdown_images
+
+
+def test_leaves_non_discord_urls_unchanged():
+    markdown = 'Text\n\n![](https://example.com/pic.png)\n\nMore text'
+    assert mirror_markdown_images(markdown, 'loc-test', {}) == markdown
+
+
+def test_leaves_markdown_with_no_images_unchanged():
+    markdown = 'Just some **text** with no images at all.'
+    assert mirror_markdown_images(markdown, 'loc-test', {}) == markdown
+
+
+def test_mirrors_discord_cdn_images_and_rewrites_links():
+    markdown = (
+        '### Alice · 2026-07-01\n\n'
+        'check this out\n\n'
+        '![](https://cdn.discordapp.com/attachments/1/2/photo.png?ex=abc)\n\n'
+        '---\n\n'
+        '### Bob · 2026-07-02\n\n'
+        '![](https://media.discordapp.net/attachments/3/4/other.jpg?ex=def)'
+    )
+    config = {'GCS_BUCKET_NAME': 'mcbn-wiki-images'}
+    with patch('app.gcs.mirror_to_gcs') as mocked:
+        mocked.side_effect = [
+            'https://storage.googleapis.com/mcbn-wiki-images/wiki-body/loc-test/aaa.png',
+            'https://storage.googleapis.com/mcbn-wiki-images/wiki-body/loc-test/bbb.jpg',
+        ]
+        result = mirror_markdown_images(markdown, 'loc-test', config)
+
+    assert mocked.call_count == 2
+    assert 'https://storage.googleapis.com/mcbn-wiki-images/wiki-body/loc-test/aaa.png' in result
+    assert 'https://storage.googleapis.com/mcbn-wiki-images/wiki-body/loc-test/bbb.jpg' in result
+    assert 'cdn.discordapp.com' not in result
+    assert 'media.discordapp.net' not in result
+    # Non-image text is untouched
+    assert '### Alice · 2026-07-01' in result
+    assert 'check this out' in result
+
+
+def test_falls_back_to_original_url_when_mirroring_fails():
+    markdown = '![](https://cdn.discordapp.com/attachments/1/2/photo.png?ex=abc)'
+    config = {'GCS_BUCKET_NAME': 'mcbn-wiki-images'}
+    with patch('app.gcs.mirror_to_gcs') as mocked:
+        mocked.return_value = 'https://cdn.discordapp.com/attachments/1/2/photo.png?ex=abc'
+        result = mirror_markdown_images(markdown, 'loc-test', config)
+    assert result == markdown


### PR DESCRIPTION
## Summary
- Root cause of the wiki losing images again: PR #311 fixed `cover_image_url` falling back to expiring Discord CDN links, but never touched inline images embedded in synced page **bodies** — `wikiSyncHelpers.ts`'s `messagesToMarkdown()` embeds archived Discord attachments as `![](url)`, and those signed CDN URLs expire in ~24-48h same as covers did.
- Adds `mirror_markdown_images()` in `app/gcs.py`: finds every Discord CDN image link in a page's markdown body and mirrors it to GCS (stable per-attachment object naming so re-syncs don't re-upload), rewriting the link in place.
- Wires it into the bot-sync endpoint (`api.py::upsert_wiki_page`, both create and update paths) and the staff manual `new_page`/`edit_page` routes in `wiki.py`, mirroring the existing cover-image pattern.

## Important: recovery step after merge
Already-broken links in existing pages are 404 now — mirroring can't resurrect a dead signed URL. After this deploys, trigger a wiki rebuild (Settings → Rebuild Wiki, or the nightly sync) so the bot re-fetches messages from Discord and gets fresh signed URLs — this time those will get mirrored to GCS permanently instead of expiring again.

## Test plan
- [x] `pytest apps/web/tests/` — 296 passed, no regressions
- [x] New tests for `mirror_markdown_images` (leaves non-Discord/no-image markdown alone, mirrors + rewrites multiple images, falls back safely on mirror failure)
- [ ] After deploy: trigger a wiki rebuild and spot-check a page that previously had inline images to confirm links now point at `storage.googleapis.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)