### PR TITLE
Fix unstyled custom classes across the player/staff theme

### DIFF
--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -2139,6 +2139,135 @@ body.login-page {
   font-family: var(--font-ui);
 }
 
+/* ── Wish list items ── */
+.wl-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+  background: var(--surface);
+  margin-bottom: 8px;
+}
+.wl-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+.wl-item-main {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.wl-item-trait {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+.wl-item-cat {
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.wl-item-cat::before { content: '— '; }
+.wl-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+}
+.wl-item-dots {
+  color: var(--text-body);
+}
+.wl-item-cost {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent-soft);
+  border-radius: var(--r-pill);
+  padding: 1px 8px;
+  font-weight: 700;
+  font-family: var(--font-ui);
+}
+.wl-item-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.wl-add-form {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+}
+.wl-summary-bar {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  margin-top: 4px;
+}
+
+/* ── Claim period pills (Claim XP header) ── */
+.period-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: var(--r-pill);
+  padding: 3px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+}
+.period-pill.claimed {
+  background: rgba(74,222,128,.12);
+  border: 1px solid rgba(74,222,128,.25);
+  color: #4ade80;
+}
+.period-pill.unclaimed {
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  color: var(--text-faint);
+}
+
+/* ── XP balance sign coloring (dashboard/roster lists) ── */
+.xp-positive { color: #4ade80; }
+.xp-negative { color: var(--accent-soft); }
+.xp-zero     { color: var(--text-faint); }
+
+/* ── Spend cost validation (staff spend review) ── */
+.cost-match    { color: #4ade80; }
+.cost-mismatch { color: var(--accent-soft); }
+
+/* ── Approved spends list (player character page) ── */
+.spend-category-heading {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--text-faint);
+  font-family: var(--font-ui);
+  margin: 14px 0 6px;
+}
+.spend-category-heading:first-child { margin-top: 0; }
+.spend-entry {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.spend-entry:last-child { border-bottom: none; }
+.spend-entry .spend-trait-name { flex: 1; min-width: 120px; }
+.spend-date {
+  font-size: 11px;
+  color: var(--text-faint);
+  font-family: var(--font-ui);
+}
+
 /* ══════════════════════════════════════════════
    SETTINGS REDESIGN — control-panel layout
    ══════════════════════════════════════════════ */


### PR DESCRIPTION
## Summary
Same root cause in every case: templates/JS build proper separate elements with project-specific classes, but the CSS for those classes was never written, so the browser falls back to default inline/block rendering with no spacing or color.

- **Wish list items** — trait/category text ran together with no separator (e.g. "2 → 3" dots immediately followed by "3 XP" cost read as "2 → 33 XP", the original report).
- **Claim-period pills** (Claim XP header) — rendered as bare inline text with no pill shape; multiple pills unreadable next to each other.
- **Cost validation on staff spend review** — no color coding, so a real cost mismatch (the thing this UI exists to flag) looked identical to a match.
- **XP balance sign** (dashboard/roster lists) — positive/negative/zero all rendered the same color.
- **Approved spends list** (player character page) — entries stacked as unstyled blocks with no row separation; dates had no styling.

Audited ~40 other custom classes with no obvious CSS match; all either already have rules (a naive class-name regex mis-parsed Jinja-embedded strings) or are pure JS/semantic hooks on elements Bootstrap already styles (badge variants riding on `bg-success` etc.), so those were left alone.

## Test plan
- [x] `pytest apps/web/tests/` — 306 passed
- [x] Balanced-brace check on the CSS file
- [x] Visual before/after preview built and reviewed for all 5 fixes
- [ ] Staff: spot-check the wish list, Claim XP period pills, a spend review with a cost mismatch, dashboard/roster XP coloring, and the Approved Spends list on a real character

🤖 Generated with [Claude Code](https://claude.com/claude-code)