### PR TITLE
Show pending XP claims and spend requests on character page

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -294,7 +294,7 @@ def character(name):
         approved_claims=approved_claims,
         approved_spends=approved_spends,
         amend_claims=amend_claims,
-        pending_claims=pending_claims,
+        pending_claims_list=pending_claims,
         pending_claims_count=len(pending_claims),
         pending_spends_list=pending_spends_list,
         pending_spends_count=len(pending_spends),

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -294,6 +294,7 @@ def character(name):
         approved_claims=approved_claims,
         approved_spends=approved_spends,
         amend_claims=amend_claims,
+        pending_claims=pending_claims,
         pending_claims_count=len(pending_claims),
         pending_spends_list=pending_spends_list,
         pending_spends_count=len(pending_spends),

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -781,7 +781,7 @@
 </div>
 
 <!-- Pending Claims -->
-{% if pending_claims %}
+{% if pending_claims_list %}
 <div class="card mb-4" id="pending-claims">
     <div class="card-header" data-bs-toggle="collapse" data-bs-target="#pending-claims-body" role="button" style="cursor:pointer;">
         <div class="d-flex justify-content-between align-items-center">
@@ -789,7 +789,7 @@
                 <i class="bi bi-hourglass-split"></i> XP Claims In Progress
                 <i class="bi bi-chevron-down float-end"></i>
             </h5>
-            <span class="badge bg-warning text-dark">{{ pending_claims|length }} pending</span>
+            <span class="badge bg-warning text-dark">{{ pending_claims_list|length }} pending</span>
         </div>
     </div>
     <div class="collapse show" id="pending-claims-body">
@@ -804,7 +804,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for c in pending_claims %}
+                        {% for c in pending_claims_list %}
                         <tr>
                             <td>{{ c.play_period }}</td>
                             <td><span class="badge bg-secondary">{{ c.xp_claimed }} XP</span></td>

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -329,10 +329,10 @@
 <div class="alert alert-info">
     <i class="bi bi-hourglass-split"></i>
     {% if pending_claims_count > 0 %}
-        <strong>{{ pending_claims_count }}</strong> XP claim{{ 's' if pending_claims_count != 1 }} pending review.
+        <a href="#pending-claims" class="alert-link"><strong>{{ pending_claims_count }}</strong> XP claim{{ 's' if pending_claims_count != 1 }} pending review.</a>
     {% endif %}
     {% if pending_spends_count > 0 %}
-        <strong>{{ pending_spends_count }}</strong> spend request{{ 's' if pending_spends_count != 1 }} pending review.
+        <a href="#spend-requests-in-progress" class="alert-link"><strong>{{ pending_spends_count }}</strong> spend request{{ 's' if pending_spends_count != 1 }} pending review.</a>
     {% endif %}
 </div>
 {% endif %}
@@ -780,6 +780,45 @@
     </div>
 </div>
 
+<!-- Pending Claims -->
+{% if pending_claims %}
+<div class="card mb-4" id="pending-claims">
+    <div class="card-header" data-bs-toggle="collapse" data-bs-target="#pending-claims-body" role="button" style="cursor:pointer;">
+        <div class="d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">
+                <i class="bi bi-hourglass-split"></i> XP Claims In Progress
+                <i class="bi bi-chevron-down float-end"></i>
+            </h5>
+            <span class="badge bg-warning text-dark">{{ pending_claims|length }} pending</span>
+        </div>
+    </div>
+    <div class="collapse show" id="pending-claims-body">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-dark table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th>Play Period</th>
+                            <th>XP Claimed</th>
+                            <th class="d-none d-sm-table-cell">Submitted</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for c in pending_claims %}
+                        <tr>
+                            <td>{{ c.play_period }}</td>
+                            <td><span class="badge bg-secondary">{{ c.xp_claimed }} XP</span></td>
+                            <td class="d-none d-sm-table-cell">{{ c.timestamp }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Approved Claims History -->
 <div class="card mb-4" id="xp-claims-history">
     <div class="card-header" data-bs-toggle="collapse" data-bs-target="#claims-history-body" role="button" style="cursor:pointer;">
@@ -840,7 +879,7 @@
 
 <!-- Pending Spends -->
 {% if pending_spends_list %}
-<div class="card mb-4">
+<div class="card mb-4" id="spend-requests-in-progress">
     <div class="card-header" data-bs-toggle="collapse" data-bs-target="#spends-in-progress" role="button" style="cursor:pointer;">
         <div class="d-flex justify-content-between align-items-center">
             <h5 class="mb-0">


### PR DESCRIPTION
## Summary
- Character page previously showed only a plain-text count of pending XP claims/spend requests with no way to view them.
- Pending spends already had a hidden, unlinked "Spend Requests In Progress" table — gave it an anchor so the banner links to it.
- Added a matching "XP Claims In Progress" card for pending claims (play period, XP claimed, submission date), since none existed before.
- Banner counts are now links that jump to the relevant section.

## Test plan
- [x] Verified in local Docker dev container: temporarily inserted a pending claim and confirmed pending spend for a test character, confirmed both banner links and sections render correctly, then cleaned up test data.
- [x] `py_compile` on the modified blueprint.