### PR TITLE
Move character wish list from localStorage to DB, add one-click spend conversion

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -313,6 +313,7 @@ def character(name):
         chronicle_tenets=_get_chronicle_tenets(),
         player_coterie=player_coterie,
         player_coterie_role=player_coterie_role,
+        wish_list_items=db_service.get_wish_list_items(name),
     )
 
 
@@ -613,6 +614,144 @@ def submit_spend(name):
         flash(
             f'Spend request submitted: {trait_name} '
             f'({current_dots}→{new_dots}) for {xp_cost} XP. '
+            f'Awaiting staff review.',
+            'success',
+        )
+    except ValueError as e:
+        flash(f'Invalid spend request: {e}', 'danger')
+
+    return redirect(url_for('player.character', name=name))
+
+
+_WISH_LIST_DEFAULT_JUSTIFICATION = 'Planned via wish list'
+
+
+@bp.route('/<name>/wishlist/add', methods=['POST'])
+@require_character_owner
+@_limit("20 per minute")
+def add_wish_list_item(name):
+    """Add an item to the character's wish list."""
+    char = db_service.get_character(name)
+    if not char or not char.active:
+        abort(404)
+
+    spend_category = request.form.get('spend_category', '').strip()
+    trait_name = request.form.get('trait_name', '').strip()
+    power_name = request.form.get('power_name', '').strip()[:100]
+    justification = request.form.get('justification', '').strip()[:1000]
+
+    if not spend_category or not trait_name:
+        flash('Category and trait name are required.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
+    if spend_category not in SPEND_CATEGORIES:
+        flash('Invalid spend category.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
+    try:
+        current_dots = int(request.form.get('current_dots', 0))
+        new_dots = int(request.form.get('new_dots', 1))
+    except (ValueError, TypeError):
+        flash('Invalid dot values.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
+    is_in_clan = bool(request.form.get('is_in_clan'))
+
+    try:
+        db_service.add_wish_list_item(
+            character_name=name,
+            spend_category=spend_category,
+            trait_name=trait_name,
+            power_name=power_name,
+            current_dots=current_dots,
+            new_dots=new_dots,
+            is_in_clan=is_in_clan,
+            justification=justification or _WISH_LIST_DEFAULT_JUSTIFICATION,
+        )
+        flash(f'Added "{trait_name}" to your wish list.', 'success')
+    except ValueError as e:
+        flash(f'Could not add to wish list: {e}', 'danger')
+
+    return redirect(url_for('player.character', name=name))
+
+
+@bp.route('/<name>/wishlist/<int:item_id>/remove', methods=['POST'])
+@require_character_owner
+@_limit("20 per minute")
+def remove_wish_list_item(name, item_id):
+    """Remove an item from the character's wish list."""
+    char = db_service.get_character(name)
+    if not char or not char.active:
+        abort(404)
+
+    if db_service.delete_wish_list_item(item_id, name):
+        flash('Removed item from wish list.', 'success')
+    else:
+        flash('Wish list item not found.', 'danger')
+
+    return redirect(url_for('player.character', name=name))
+
+
+@bp.route('/<name>/wishlist/<int:item_id>/spend', methods=['POST'])
+@require_character_owner
+@_limit("10 per minute")
+def convert_wish_list_item(name, item_id):
+    """Convert a wish list item directly into a pending spend request."""
+    char = db_service.get_character(name)
+    if not char or not char.active:
+        abort(404)
+
+    item = db_service.get_wish_list_item(item_id, name)
+    if not item:
+        flash('Wish list item not found.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
+    try:
+        discord_name = session.get('discord_name', 'unknown')
+        justification = item.justification or _WISH_LIST_DEFAULT_JUSTIFICATION
+        xp_cost = db_service.submit_spend_request(
+            character_name=name,
+            spend_category=item.spend_category,
+            trait_name=item.trait_name,
+            power_name=item.power_name,
+            current_dots=item.current_dots,
+            new_dots=item.new_dots,
+            is_in_clan=item.is_in_clan,
+            justification=justification,
+        )
+        if sheets_sync:
+            sheets_sync.sync_add_spend(
+                character_name=name,
+                spend_category=item.spend_category,
+                trait_name=item.trait_name,
+                current_dots=item.current_dots,
+                new_dots=item.new_dots,
+                is_in_clan=item.is_in_clan,
+                justification=justification,
+            )
+        db_service.log_action(
+            staff_user=f'player:{discord_name}',
+            action_type='player_spend_submitted',
+            target=name,
+            details=(
+                f'{item.spend_category}: {item.trait_name} '
+                f'({item.current_dots}→{item.new_dots}) for {xp_cost} XP (from wish list)'
+            ),
+        )
+        if sheets_sync:
+            sheets_sync.sync_log_action(
+                staff_user=f'player:{discord_name}',
+                action_type='player_spend_submitted',
+                target=name,
+                details=(
+                    f'{item.spend_category}: {item.trait_name} '
+                    f'({item.current_dots}→{item.new_dots}) for {xp_cost} XP (from wish list)'
+                ),
+            )
+        db_service.delete_wish_list_item(item_id, name)
+        flash(
+            f'Spend request submitted: {item.trait_name} '
+            f'({item.current_dots}→{item.new_dots}) for {xp_cost} XP. '
             f'Awaiting staff review.',
             'success',
         )

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -648,6 +648,11 @@ def add_wish_list_item(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
+    from app.character_sheet import _DISCIPLINE_CATEGORIES
+    if spend_category in _DISCIPLINE_CATEGORIES and not power_name:
+        flash('Power name is required for discipline purchases.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
     try:
         current_dots = int(request.form.get('current_dots', 0))
         new_dots = int(request.form.get('new_dots', 1))

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -345,6 +345,24 @@ class DbCharacterBackground(db.Model):
         return max(0, (self.dots_total or 0) - (self.dots_blanked or 0))
 
 
+class DbWishListItem(db.Model):
+    __tablename__ = 'wish_list_items'
+    __table_args__ = (
+        db.Index('ix_wish_list_items_character', 'character_name'),
+    )
+    id = db.Column(Integer, primary_key=True)
+    character_name = db.Column(String(200), nullable=False)
+    spend_category = db.Column(String(100), nullable=False)
+    trait_name = db.Column(String(100), nullable=False)
+    power_name = db.Column(String(100), default='')
+    current_dots = db.Column(Integer, nullable=False, default=0)
+    new_dots = db.Column(Integer, nullable=False, default=1)
+    is_in_clan = db.Column(Boolean, default=False)
+    xp_cost = db.Column(Integer, nullable=False, default=0)
+    justification = db.Column(Text, default='')
+    created_at = db.Column(String(20), nullable=False, default='')
+
+
 class Coterie(db.Model):
     __tablename__ = 'coteries'
     __table_args__ = (

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -28,6 +28,7 @@ from app.db import (
     DbSheetsSyncError,
     DbCharacterBackground,
     DbBoon,
+    DbWishListItem,
 )
 from app.models import Character, PlayPeriod, XPClaim, SpendRequest, LedgerEntry, AuditEntry
 from app.game_calendar import next_night_after_downtime
@@ -803,6 +804,66 @@ class DBService:
         db.session.add(row)
         db.session.commit()
         return xp_cost
+
+    # ── Wish List ─────────────────────────────────────────────────────────────
+
+    def get_wish_list_items(self, character_name: str) -> list[dict]:
+        rows = DbWishListItem.query.filter(
+            func.lower(DbWishListItem.character_name) == character_name.lower(),
+        ).order_by(DbWishListItem.id.asc()).all()
+        return [{
+            'id': row.id,
+            'spend_category': row.spend_category,
+            'trait_name': row.trait_name,
+            'power_name': row.power_name or '',
+            'current_dots': row.current_dots,
+            'new_dots': row.new_dots,
+            'is_in_clan': bool(row.is_in_clan),
+            'xp_cost': row.xp_cost,
+            'justification': row.justification or '',
+            'created_at': row.created_at or '',
+        } for row in rows]
+
+    def add_wish_list_item(self, character_name: str, spend_category: str,
+                            trait_name: str, current_dots: int, new_dots: int,
+                            is_in_clan: bool = False, power_name: str = '',
+                            justification: str = '') -> int:
+        """Add a wish list item. Returns the calculated XP cost.
+
+        Raises ValueError if the cost calculation fails.
+        """
+        from app.xp_rules import calculate_xp_cost
+        xp_cost = calculate_xp_cost(spend_category, current_dots, new_dots)
+
+        row = DbWishListItem(
+            character_name=character_name,
+            spend_category=spend_category,
+            trait_name=trait_name,
+            power_name=power_name or '',
+            current_dots=current_dots,
+            new_dots=new_dots,
+            is_in_clan=bool(is_in_clan),
+            xp_cost=xp_cost,
+            justification=justification,
+            created_at=_now_str(),
+        )
+        db.session.add(row)
+        db.session.commit()
+        return xp_cost
+
+    def get_wish_list_item(self, item_id: int, character_name: str) -> Optional[DbWishListItem]:
+        return DbWishListItem.query.filter(
+            DbWishListItem.id == item_id,
+            func.lower(DbWishListItem.character_name) == character_name.lower(),
+        ).first()
+
+    def delete_wish_list_item(self, item_id: int, character_name: str) -> bool:
+        row = self.get_wish_list_item(item_id, character_name)
+        if not row:
+            return False
+        db.session.delete(row)
+        db.session.commit()
+        return True
 
     # ── XP Totals (computed) ─────────────────────────────────────────────────
 

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -336,6 +336,9 @@ class DBService:
         DbLedgerEntry.query.filter(
             func.lower(DbLedgerEntry.character_name) == old_name.lower()
         ).update({'character_name': new_name}, synchronize_session=False)
+        DbWishListItem.query.filter(
+            func.lower(DbWishListItem.character_name) == old_name.lower()
+        ).update({'character_name': new_name}, synchronize_session=False)
         _character_action_types = {
             'add_character', 'edit_character', 'activate_character',
             'deactivate_character', 'delete_character', 'rename_character',

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -1002,6 +1002,20 @@
                         <input type="number" class="form-control form-control-sm" id="wl-to" name="new_dots" min="1" max="5" value="1">
                     </div>
                 </div>
+                <div class="row g-2 mt-1 d-none" id="wl-power-name-group">
+                    <div class="col-12">
+                        <label class="form-label small fw-bold mb-1">Power Name <span class="text-muted fw-normal">(specific power being purchased)</span></label>
+                        <input type="text" class="form-control form-control-sm" name="power_name" id="wl-power-name"
+                               placeholder="e.g., Mesmerize, Prowl, Sense the Unseen">
+                        <div class="form-text">Required to update your character sheet when converted to a spend request.</div>
+                    </div>
+                </div>
+                <div class="mt-1 d-none" id="wl-in-clan-group">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="is_in_clan" id="wl-is-in-clan" value="1">
+                        <label class="form-check-label small" for="wl-is-in-clan">This is an In-Clan Discipline</label>
+                    </div>
+                </div>
                 <div class="row g-2 mt-1">
                     <div class="col-12">
                         <label class="form-label small fw-bold mb-1">Notes <span class="text-muted fw-normal">(optional)</span></label>
@@ -1478,6 +1492,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const wlTo    = document.getElementById('wl-to');
     const wlPreview = document.getElementById('wl-preview-cost');
     const wlAddBtn  = document.getElementById('wl-add-btn');
+    const wlPowerNameGroup = document.getElementById('wl-power-name-group');
+    const wlPowerNameInput = document.getElementById('wl-power-name');
+    const wlInClanGroup = document.getElementById('wl-in-clan-group');
 
     function updatePreview() {
         const cost = wlCost(wlCat.value, parseInt(wlFrom.value)||0, parseInt(wlTo.value)||0);
@@ -1492,6 +1509,16 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     wlCat?.addEventListener('change', function() {
+        const isDiscipline = wlCat.value === 'Discipline (In-Clan)' || wlCat.value === 'Discipline (Out-of-Clan)' || wlCat.value === 'Caitiff Discipline';
+        const needsPowerName = isDiscipline || wlCat.value === 'Ghoul Discipline';
+        if (wlInClanGroup) wlInClanGroup.classList.toggle('d-none', !isDiscipline);
+        if (wlPowerNameGroup) {
+            wlPowerNameGroup.classList.toggle('d-none', !needsPowerName);
+            if (wlPowerNameInput) {
+                wlPowerNameInput.required = needsPowerName;
+                if (!needsPowerName) wlPowerNameInput.value = '';
+            }
+        }
         if (wlCat.value === 'Humanity') {
             wlTrait.value = 'Humanity';
             wlTrait.readOnly = true;

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -966,18 +966,21 @@
                 <i class="bi bi-bookmark-star"></i> Wish List
                 <i class="bi bi-chevron-down float-end"></i>
             </h5>
-            <span class="text-muted small ms-3" id="wl-header-summary"></span>
+            <span class="text-muted small ms-3" id="wl-header-summary">
+                {% if wish_list_items %}{{ wish_list_items | length }} item{{ 's' if wish_list_items | length != 1 else '' }} · {{ wish_list_items | sum(attribute='xp_cost') }} XP{% endif %}
+            </span>
         </div>
     </div>
     <div class="collapse" id="wish-list">
         <div class="card-body">
 
             <!-- Add item form -->
-            <div class="wl-add-form mb-3 p-3">
+            <form class="wl-add-form mb-3 p-3" method="post"
+                  action="{{ url_for('player.add_wish_list_item', name=char.character_name) }}">
                 <div class="row g-2 align-items-end">
                     <div class="col-12 col-sm-4">
                         <label class="form-label small fw-bold mb-1">Category</label>
-                        <select class="form-select form-select-sm" id="wl-category">
+                        <select class="form-select form-select-sm" id="wl-category" name="spend_category" required>
                             <option value="">Select...</option>
                             {% for cat in spend_categories %}
                             <option value="{{ cat }}">{{ cat }}</option>
@@ -986,43 +989,90 @@
                     </div>
                     <div class="col-12 col-sm">
                         <label class="form-label small fw-bold mb-1">Trait</label>
-                        <input type="text" class="form-control form-control-sm" id="wl-trait"
-                               placeholder="e.g., Strength, Dominate">
+                        <input type="text" class="form-control form-control-sm" id="wl-trait" name="trait_name"
+                               placeholder="e.g., Strength, Dominate" required>
                     </div>
                     <div class="col-5 col-sm-auto" style="max-width:80px;">
                         <label class="form-label small fw-bold mb-1">From</label>
-                        <input type="number" class="form-control form-control-sm" id="wl-from" min="0" max="4" value="0">
+                        <input type="number" class="form-control form-control-sm" id="wl-from" name="current_dots" min="0" max="4" value="0">
                     </div>
                     <div class="col-2 col-sm-auto d-flex align-items-end justify-content-center pb-1 px-0" style="font-size:1.1rem; color:#666;">→</div>
                     <div class="col-5 col-sm-auto" style="max-width:80px;">
                         <label class="form-label small fw-bold mb-1">To</label>
-                        <input type="number" class="form-control form-control-sm" id="wl-to" min="1" max="5" value="1">
+                        <input type="number" class="form-control form-control-sm" id="wl-to" name="new_dots" min="1" max="5" value="1">
+                    </div>
+                </div>
+                <div class="row g-2 mt-1">
+                    <div class="col-12">
+                        <label class="form-label small fw-bold mb-1">Notes <span class="text-muted fw-normal">(optional)</span></label>
+                        <input type="text" class="form-control form-control-sm" name="justification"
+                               placeholder="e.g., justification for staff, used when converted to a spend request">
                     </div>
                 </div>
                 <div class="d-flex align-items-center gap-3 mt-2 flex-wrap">
                     <span class="text-muted small">Cost: <strong id="wl-preview-cost" class="text-warning">—</strong> XP</span>
-                    <button class="btn btn-sm btn-outline-warning" id="wl-add-btn" disabled>
+                    <button type="submit" class="btn btn-sm btn-outline-warning" id="wl-add-btn" disabled>
                         <i class="bi bi-plus"></i> Add to List
                     </button>
                 </div>
-            </div>
+            </form>
 
             <!-- Items list -->
-            <div id="wl-items"></div>
-
-            <!-- Summary footer -->
-            <div id="wl-summary" class="d-none mt-2">
-                <div class="wl-summary-bar d-flex justify-content-between align-items-center flex-wrap gap-2">
-                    <span id="wl-total-text" class="small"></span>
-                    <span id="wl-xp-status" class="small"></span>
+            <div id="wl-items">
+                {% for item in wish_list_items %}
+                <div class="wl-item">
+                    <div class="wl-item-body">
+                        <div class="wl-item-main">
+                            <span class="wl-item-trait">{{ item.trait_name }}</span>
+                            <span class="wl-item-cat">{{ item.spend_category }}</span>
+                        </div>
+                        <div class="wl-item-meta">
+                            <span class="wl-item-dots">{{ item.current_dots }} → {{ item.new_dots }}</span>
+                            <span class="wl-item-cost">{{ item.xp_cost }} XP</span>
+                        </div>
+                    </div>
+                    <div class="wl-item-actions">
+                        <form method="post" class="d-inline"
+                              action="{{ url_for('player.convert_wish_list_item', name=char.character_name, item_id=item.id) }}">
+                            <button type="submit" class="btn btn-sm btn-outline-success py-0" title="Submit as spend request">
+                                <i class="bi bi-send"></i>
+                            </button>
+                        </form>
+                        <form method="post" class="d-inline"
+                              action="{{ url_for('player.remove_wish_list_item', name=char.character_name, item_id=item.id) }}">
+                            <button type="submit" class="btn btn-sm btn-outline-danger py-0" title="Remove">
+                                <i class="bi bi-x"></i>
+                            </button>
+                        </form>
+                    </div>
                 </div>
+                {% endfor %}
             </div>
 
+            <!-- Summary footer -->
+            {% if wish_list_items %}
+            {% set wl_total = wish_list_items | sum(attribute='xp_cost') %}
+            <div id="wl-summary" class="mt-2">
+                <div class="wl-summary-bar d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <span id="wl-total-text" class="small">
+                        <strong>{{ wl_total }} XP</strong> planned across {{ wish_list_items | length }} item{{ 's' if wish_list_items | length != 1 else '' }}
+                    </span>
+                    <span id="wl-xp-status" class="small">
+                        {% if available_xp - wl_total >= 0 %}
+                        <span class="text-success"><i class="bi bi-check-circle"></i> {{ available_xp - wl_total }} XP remaining after all</span>
+                        {% else %}
+                        <span class="text-danger"><i class="bi bi-exclamation-triangle"></i> {{ -(available_xp - wl_total) }} XP short of full list</span>
+                        {% endif %}
+                    </span>
+                </div>
+            </div>
+            {% else %}
             <!-- Empty state -->
             <div id="wl-empty" class="text-center text-muted py-3">
                 <i class="bi bi-bookmark-star" style="font-size:1.8rem;opacity:0.25;"></i>
                 <p class="small mt-2 mb-0">No items yet. Add traits you're planning to purchase.</p>
             </div>
+            {% endif %}
 
         </div>
     </div>
@@ -1390,12 +1440,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 });
 
-// ═══ Wish List (localStorage per character) ═══
+// ═══ Wish List (server-persisted; this block only drives the add-form's live cost preview) ═══
 (function() {
-    const STORAGE_KEY = 'wl_' + {{ char.character_name | tojson }};
-    const AVAILABLE_XP = {{ available_xp | int }};
-
-    // Mirror of the server-side cost rules (same as XP_RULES above)
+    // Mirror of the server-side cost rules (same as XP_RULES above) — used only
+    // to preview cost before submit; the server recalculates authoritatively.
     const WL_RULES = {
         'Attribute':                   { multiplier: 5 },
         'Skill':                       { multiplier: 3 },
@@ -1421,111 +1469,6 @@ document.addEventListener('DOMContentLoaded', function() {
         let cost = 0;
         for (let d = from + 1; d <= to; d++) cost += d * r.multiplier;
         return cost || null;
-    }
-
-    function load() {
-        try { return JSON.parse(localStorage.getItem(STORAGE_KEY)) || []; }
-        catch(e) { return []; }
-    }
-
-    function save(items) {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
-    }
-
-    function esc(str) {
-        const d = document.createElement('div');
-        d.textContent = str;
-        return d.innerHTML;
-    }
-
-    function render() {
-        const items = load();
-        const container = document.getElementById('wl-items');
-        const emptyEl   = document.getElementById('wl-empty');
-        const summaryEl = document.getElementById('wl-summary');
-        const headerEl  = document.getElementById('wl-header-summary');
-
-        container.innerHTML = '';
-
-        if (items.length === 0) {
-            emptyEl.classList.remove('d-none');
-            summaryEl.classList.add('d-none');
-            headerEl.textContent = '';
-            return;
-        }
-
-        emptyEl.classList.add('d-none');
-        summaryEl.classList.remove('d-none');
-
-        let total = 0;
-        items.forEach(function(item, idx) {
-            total += item.cost;
-            const div = document.createElement('div');
-            div.className = 'wl-item';
-            div.innerHTML =
-                '<div class="wl-item-body">' +
-                    '<div class="wl-item-main">' +
-                        '<span class="wl-item-trait">' + esc(item.trait) + '</span>' +
-                        '<span class="wl-item-cat">' + esc(item.category) + '</span>' +
-                    '</div>' +
-                    '<div class="wl-item-meta">' +
-                        '<span class="wl-item-dots">' + item.from_dots + ' → ' + item.to_dots + '</span>' +
-                        '<span class="wl-item-cost">' + item.cost + ' XP</span>' +
-                    '</div>' +
-                '</div>' +
-                '<div class="wl-item-actions">' +
-                    '<button class="btn btn-sm btn-outline-secondary wl-fill-btn py-0" title="Pre-fill spend form" data-idx="' + idx + '">' +
-                        '<i class="bi bi-arrow-up-right-square"></i>' +
-                    '</button>' +
-                    '<button class="btn btn-sm btn-outline-danger wl-remove-btn py-0" title="Remove" data-idx="' + idx + '">' +
-                        '<i class="bi bi-x"></i>' +
-                    '</button>' +
-                '</div>';
-            container.appendChild(div);
-        });
-
-        // Bind buttons
-        container.querySelectorAll('.wl-remove-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                const list = load();
-                list.splice(parseInt(this.dataset.idx), 1);
-                save(list);
-                render();
-            });
-        });
-        container.querySelectorAll('.wl-fill-btn').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                fillSpend(load()[parseInt(this.dataset.idx)]);
-            });
-        });
-
-        // Summary
-        const xpAfter = AVAILABLE_XP - total;
-        headerEl.textContent = items.length + ' item' + (items.length !== 1 ? 's' : '') + ' · ' + total + ' XP';
-        document.getElementById('wl-total-text').innerHTML =
-            '<strong>' + total + ' XP</strong> planned across ' + items.length + ' item' + (items.length !== 1 ? 's' : '');
-        const statusEl = document.getElementById('wl-xp-status');
-        if (xpAfter >= 0) {
-            statusEl.innerHTML = '<span class="text-success"><i class="bi bi-check-circle"></i> ' + xpAfter + ' XP remaining after all</span>';
-        } else {
-            statusEl.innerHTML = '<span class="text-danger"><i class="bi bi-exclamation-triangle"></i> ' + Math.abs(xpAfter) + ' XP short of full list</span>';
-        }
-    }
-
-    function fillSpend(item) {
-        const spendEl = document.getElementById('spend-form');
-        if (spendEl) bootstrap.Collapse.getOrCreateInstance(spendEl).show();
-        const catEl   = document.getElementById('spend_category');
-        const traitEl = document.getElementById('trait_name');
-        const fromEl  = document.getElementById('current_dots');
-        const toEl    = document.getElementById('new_dots');
-        if (catEl)   { catEl.value = item.category; catEl.dispatchEvent(new Event('change')); }
-        if (traitEl) { traitEl.value = item.trait; }
-        if (fromEl)  { fromEl.value = item.from_dots; fromEl.dispatchEvent(new Event('input')); }
-        if (toEl)    { toEl.value = item.to_dots; toEl.dispatchEvent(new Event('input')); }
-        setTimeout(function() {
-            spendEl?.closest('.card')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }, 100);
     }
 
     // Add form
@@ -1567,29 +1510,7 @@ document.addEventListener('DOMContentLoaded', function() {
         updatePreview();
     });
 
-    wlAddBtn?.addEventListener('click', function() {
-        const cat   = wlCat.value;
-        const trait = wlTrait.value.trim();
-        const from  = parseInt(wlFrom.value) || 0;
-        const to    = parseInt(wlTo.value) || 0;
-        const cost  = wlCost(cat, from, to);
-        if (!cost || !trait) return;
-
-        const items = load();
-        items.push({ id: Date.now() + '_' + Math.random().toString(36).slice(2),
-                     category: cat, trait: trait, from_dots: from, to_dots: to, cost: cost });
-        save(items);
-
-        wlTrait.value = '';
-        wlCat.value = '';
-        wlFrom.value = 0;
-        wlTo.value = 1;
-        wlPreview.textContent = '—';
-        wlAddBtn.disabled = true;
-        render();
-    });
-
-    render();
+    updatePreview();
 })();
 
 (function () {

--- a/apps/web/migrations/versions/8beb375fc044_add_wish_list_items_table.py
+++ b/apps/web/migrations/versions/8beb375fc044_add_wish_list_items_table.py
@@ -1,0 +1,49 @@
+"""Add wish_list_items table
+
+Revision ID: 8beb375fc044
+Revises: 02950c13950e
+Create Date: 2026-07-16 09:34:19.461284
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8beb375fc044'
+down_revision = '02950c13950e'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name):
+    conn = op.get_bind()
+    return conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t"),
+        {'t': name},
+    ).fetchone() is not None
+
+
+def upgrade():
+    if _table_exists('wish_list_items'):
+        return
+    op.create_table(
+        'wish_list_items',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('character_name', sa.String(200), nullable=False),
+        sa.Column('spend_category', sa.String(100), nullable=False),
+        sa.Column('trait_name', sa.String(100), nullable=False),
+        sa.Column('power_name', sa.String(100), server_default=''),
+        sa.Column('current_dots', sa.Integer, nullable=False, server_default='0'),
+        sa.Column('new_dots', sa.Integer, nullable=False, server_default='1'),
+        sa.Column('is_in_clan', sa.Boolean, server_default=sa.false()),
+        sa.Column('xp_cost', sa.Integer, nullable=False, server_default='0'),
+        sa.Column('justification', sa.Text, server_default=''),
+        sa.Column('created_at', sa.String(20), nullable=False, server_default=''),
+    )
+    op.create_index('ix_wish_list_items_character', 'wish_list_items', ['character_name'])
+
+
+def downgrade():
+    op.drop_index('ix_wish_list_items_character', table_name='wish_list_items')
+    op.drop_table('wish_list_items')


### PR DESCRIPTION
## Summary
- The character wish list was implemented entirely client-side (`localStorage`, keyed by character name), so items added on one device/browser never showed up on another — even for the same logged-in account.
- Adds a `wish_list_items` table and moves the wish list to server-side storage, scoped per character like backgrounds/spend requests.
- Adds a one-click "convert to spend request" action on each wish list item — submits it directly as a Pending spend request (reusing the same cost calc and validation as the manual spend form) and removes the item from the wish list.
- Removes the localStorage IIFE from `character.html`; only the client-side live cost preview on the add form remains (cosmetic only — cost is recalculated authoritatively server-side).

## Schema
- New `wish_list_items` table (migration `8beb375fc044`). It's a brand-new table (no `ALTER TABLE`), so `db.create_all()` creates it automatically on next boot against Turso — no manual DB step needed, consistent with how prior additive schema changes have shipped.

## Test plan
- [x] Verified locally via `flask db migrate`/`upgrade` against the dev SQLite DB
- [x] End-to-end test via Flask test client: add item → renders on character page → one-click convert creates correctly-costed Pending spend request → item cleared from wish list
- [x] Verified remove route and empty-state rendering
- [x] Verified server-side cost validation matches existing spend-request rules (e.g. category min/max dots)
- [ ] Confirm on dev environment (Turso-backed) before merging to main, per team preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)