### PR TITLE
Guard spend approval against insufficient XP; add spend reversal

### DIFF
--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -283,6 +283,14 @@ def reverse(row_id):
         ).strip(),
     )
     if sheets_sync:
+        sheets_sync.sync_reverse_spend(
+            character_name=spend.character_name,
+            trait_name=spend.trait_name,
+            spend_category=spend.spend_category,
+            current_dots=spend.current_dots,
+            new_dots=spend.new_dots,
+            notes=notes,
+        )
         sheets_sync.sync_log_action(
             staff_user=staff,
             action_type='reverse_spend',

--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -151,6 +151,16 @@ def approve(row_id):
     if verified_cost < 0 or verified_cost > 200:
         flash('Verified cost must be between 0 and 200.', 'danger')
         return redirect(url_for('spends.review', row_id=row_id))
+
+    available_xp = db_service.get_xp_totals(spend.character_name)['available_xp']
+    if verified_cost > available_xp:
+        flash(
+            f'Cannot approve — insufficient XP. {spend.character_name} has '
+            f'{available_xp} XP available, this costs {verified_cost} XP.',
+            'danger',
+        )
+        return redirect(url_for('spends.review', row_id=row_id))
+
     notes = request.form.get('notes', '')[:1000]
     staff = get_staff_user()
 
@@ -245,6 +255,69 @@ def deny(row_id):
     return redirect(url_for('spends.pending'))
 
 
+@bp.route('/<int:row_id>/reverse', methods=['POST'])
+@require_staff
+def reverse(row_id):
+    """Reverse an approved spend request back to Pending, restoring its XP."""
+    spend = db_service.get_spend_by_row(row_id)
+    if not spend:
+        abort(404)
+
+    notes = request.form.get('notes', '')[:1000]
+    staff = get_staff_user()
+
+    try:
+        result = db_service.reverse_spend(row_id, staff, notes)
+    except ValueError as e:
+        flash(str(e), 'danger')
+        return redirect(url_for('spends.history'))
+
+    db_service.log_action(
+        staff_user=staff,
+        action_type='reverse_spend',
+        target=spend.character_name,
+        details=(
+            f'Reversed spend: {spend.trait_name} '
+            f'({spend.current_dots}→{spend.new_dots}), restoring {spend.verified_cost} XP. '
+            f'Originally approved by {spend.reviewed_by or "unknown"}. {notes}'
+        ).strip(),
+    )
+    if sheets_sync:
+        sheets_sync.sync_log_action(
+            staff_user=staff,
+            action_type='reverse_spend',
+            target=spend.character_name,
+            details=(
+                f'Reversed spend: {spend.trait_name} '
+                f'({spend.current_dots}→{spend.new_dots}), restoring {spend.verified_cost} XP. '
+                f'Originally approved by {spend.reviewed_by or "unknown"}. {notes}'
+            ).strip(),
+        )
+
+    if result['sheet_reverted']:
+        flash(
+            f'Reversed {spend.trait_name} spend for {spend.character_name} — '
+            f'XP restored, character sheet rolled back, and it is back in the pending queue.',
+            'success',
+        )
+    else:
+        flash(
+            f'Reversed {spend.trait_name} spend for {spend.character_name} — XP restored '
+            f'and it is back in the pending queue, but the character sheet could not be '
+            f'safely rolled back automatically (it may have changed since). Please check '
+            f'{spend.character_name}\'s sheet manually.',
+            'warning',
+        )
+    if spend.coterie_id:
+        flash(
+            f'This spend was a coterie XP donation to {spend.coterie_name or "a coterie"} — '
+            f'reversing it does not undo the coterie donation. Please check the coterie\'s '
+            f'domain/pool state manually.',
+            'warning',
+        )
+    return redirect(url_for('spends.history'))
+
+
 @bp.route('/bulk-approve', methods=['POST'])
 @require_staff
 def bulk_approve():
@@ -289,6 +362,14 @@ def bulk_approve():
             continue
 
         verified_cost = validation['correct_cost']
+
+        available_xp = db_service.get_xp_totals(spend.character_name)['available_xp']
+        if verified_cost > available_xp:
+            skipped.append(
+                f'{spend.character_name} / {spend.trait_name} '
+                f'(insufficient XP: has {available_xp}, needs {verified_cost})'
+            )
+            continue
 
         db_service.approve_spend(row_id, verified_cost, staff, '')
         patch_character_draft(spend)

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -338,13 +338,15 @@ def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name:
     if category in _DISCIPLINE_CATEGORIES:
         if not power_name:
             return False
+        # Unlike a background/merit rating, a named discipline power is a
+        # discrete, one-time purchase — it isn't "leveled up" again later
+        # under the same name. So undoing one always removes the entry,
+        # regardless of current_dots (the discipline's overall rating
+        # before this purchase), rather than reducing its level in place.
         disciplines = data.get('disciplines', [])
         for power in disciplines:
             if power.get('name', '').lower() == power_name.lower() and power.get('level') == new_dots:
-                if current_dots == 0:
-                    disciplines.remove(power)
-                else:
-                    power['level'] = current_dots
+                disciplines.remove(power)
                 return True
         return False
 

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -260,6 +260,134 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
     return False
 
 
+def reverse_character_sheet_patch(spend) -> bool:
+    """Undo an already-applied patch_character_draft() for this spend.
+
+    Only rolls back a field/entry if it still holds exactly the value this
+    spend set — if something else has changed it since (e.g. a later spend
+    raised the same trait further), skips rather than clobbering newer state.
+    Also regenerates the wiki stats section on success. Returns True if the
+    sheet was rolled back, False if there was nothing to safely undo.
+    Errors are logged but never raised — a reversal must not be blocked by this.
+    """
+    try:
+        return _do_reverse_patch(spend)
+    except Exception as exc:
+        logger.warning('character_sheet reverse-patch failed for %s: %s', spend.character_name, exc)
+        return False
+
+
+def _do_reverse_patch(spend) -> bool:
+    from app.db import db, WikiPage
+    from sqlalchemy import func
+
+    draft = _find_approved_draft(spend.character_name)
+    if not draft or not draft.character_data:
+        return False
+
+    try:
+        data = json.loads(draft.character_data)
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+    power_name = (getattr(spend, 'power_name', '') or '').strip()
+    reverted = _apply_reverse_patch(
+        data, spend.spend_category, spend.trait_name, power_name,
+        spend.current_dots, spend.new_dots,
+    )
+    if not reverted:
+        return False
+
+    draft.character_data = json.dumps(data)
+    draft.updated_at = datetime.now(timezone.utc)
+
+    wiki_page = WikiPage.query.filter(
+        WikiPage.category == 'characters',
+        func.lower(WikiPage.title) == spend.character_name.lower(),
+    ).first()
+    if wiki_page:
+        _update_wiki_stats_section(wiki_page, data)
+
+    db.session.commit()
+    return True
+
+
+def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name: str,
+                          current_dots: int, new_dots: int) -> bool:
+    """Mutate data in-place to undo a prior _apply_patch call. Returns True if reverted."""
+    trait_name = (trait_name or '').strip()
+    if not trait_name:
+        return False
+
+    if category == 'Attribute':
+        key = trait_name.lower()
+        attrs = data.get('attributes', {})
+        if attrs.get(key) == new_dots:
+            attrs[key] = current_dots
+            return True
+        return False
+
+    if category in _SKILL_CATEGORIES:
+        key = trait_name.lower()
+        skills = data.get('skills', {})
+        if skills.get(key) == new_dots:
+            skills[key] = current_dots
+            return True
+        return False
+
+    if category in _DISCIPLINE_CATEGORIES:
+        if not power_name:
+            return False
+        disciplines = data.get('disciplines', [])
+        for power in disciplines:
+            if power.get('name', '').lower() == power_name.lower() and power.get('level') == new_dots:
+                if current_dots == 0:
+                    disciplines.remove(power)
+                else:
+                    power['level'] = current_dots
+                return True
+        return False
+
+    if category in ('Blood Sorcery Ritual', 'Thin-Blood Alchemy Formula'):
+        rituals = data.get('rituals', [])
+        for r in rituals:
+            if r.get('name', '').lower() == trait_name.lower() and r.get('level') == new_dots:
+                rituals.remove(r)
+                return True
+        return False
+
+    if category == 'Advantage (Merit/Background)':
+        key = trait_name.lower()
+        for array_name in ('backgrounds', 'merits'):
+            items = data.get(array_name)
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if item.get('name', '').lower() == key and item.get('level') == new_dots:
+                    if current_dots == 0:
+                        items.remove(item)
+                    else:
+                        item['level'] = current_dots
+                    return True
+        return False
+
+    if category == 'Loresheet':
+        purchases = data.get('loresheet_purchases', [])
+        for lp in purchases:
+            if lp.get('dot') == new_dots and lp.get('loresheet_id', '').lower() == trait_name.lower():
+                purchases.remove(lp)
+                return True
+        return False
+
+    if category == 'Humanity':
+        if data.get('humanity') == new_dots:
+            data['humanity'] = current_dots
+            return True
+        return False
+
+    return False
+
+
 def _dots_str(n: int, max_dots: int = 5) -> str:
     n = max(0, min(n, max_dots))
     return _DOT * n + _EMPTY * (max_dots - n)

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -790,6 +790,27 @@ class DBService:
                 'spend and is already approved — reverse it first.'
             )
 
+        # Catch sequential purchases of the same trait that were submitted
+        # independently (depends_on is optional in the submission UI) — e.g.
+        # a 1→2 and a later 2→3 both approved with no declared link between
+        # them. Without this, reversing the 1→2 spend would restore its XP
+        # and leave the 2→3 spend approved on top of a purchase that's now
+        # nominally un-approved.
+        implicit_dependent = DbSpendRequest.query.filter(
+            DbSpendRequest.id != row_index,
+            func.lower(DbSpendRequest.character_name) == row.character_name.lower(),
+            DbSpendRequest.spend_category == row.spend_category,
+            func.lower(DbSpendRequest.trait_name) == (row.trait_name or '').lower(),
+            DbSpendRequest.current_dots == row.new_dots,
+            func.lower(DbSpendRequest.status) == 'approved',
+        ).first()
+        if implicit_dependent:
+            raise ValueError(
+                f'{implicit_dependent.character_name} / {implicit_dependent.trait_name} '
+                f'({implicit_dependent.current_dots}→{implicit_dependent.new_dots}) was approved '
+                'assuming this spend already applied — reverse it first.'
+            )
+
         spend = _row_to_spend(row)
         sheet_reverted = reverse_character_sheet_patch(spend)
 

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -764,6 +764,44 @@ class DBService:
         row.st_notes = notes
         db.session.commit()
 
+    def reverse_spend(self, row_index: int, staff: str, notes: str = '') -> dict:
+        """Reverse an approved spend request back to Pending, restoring its XP.
+
+        Also attempts to roll back the character sheet patch that approval
+        applied. Raises ValueError if the spend isn't found, isn't currently
+        Approved, or has an already-approved dependent that must be reversed
+        first. Returns {'spend': SpendRequest, 'sheet_reverted': bool}.
+        """
+        from app.character_sheet import reverse_character_sheet_patch
+
+        row = db.session.get(DbSpendRequest, row_index)
+        if not row:
+            raise ValueError(f'Spend request not found: {row_index}')
+        if row.status.lower() != 'approved':
+            raise ValueError('Only an approved spend request can be reversed.')
+
+        dependent = DbSpendRequest.query.filter(
+            DbSpendRequest.depends_on == row_index,
+            func.lower(DbSpendRequest.status) == 'approved',
+        ).first()
+        if dependent:
+            raise ValueError(
+                f'{dependent.character_name} / {dependent.trait_name} depends on this '
+                'spend and is already approved — reverse it first.'
+            )
+
+        spend = _row_to_spend(row)
+        sheet_reverted = reverse_character_sheet_patch(spend)
+
+        row.status = 'Pending'
+        row.verified_cost = 0
+        row.reviewed_by = ''
+        row.review_date = ''
+        row.st_notes = notes
+        db.session.commit()
+
+        return {'spend': spend, 'sheet_reverted': sheet_reverted}
+
     def get_spend_dependents(self, row_index: int) -> list[SpendRequest]:
         """Return pending spends that declare they depend on row_index."""
         rows = DbSpendRequest.query.filter(

--- a/apps/web/app/sheets.py
+++ b/apps/web/app/sheets.py
@@ -838,6 +838,21 @@ class SheetsClient:
         )
         self._cache.invalidate(TAB_SPEND_REQUESTS)
 
+    def reverse_spend(self, row_index: int, notes: str = '') -> None:
+        """Reset a previously-approved row back to Pending (mirrors reverse_spend)."""
+        ws = self._ws(TAB_SPEND_REQUESTS)
+        row_num = row_index + 2
+
+        status_col = SPEND_REQUESTS_HEADERS.index('status') + 1
+        end_col = status_col + 4
+        ws.update(
+            f'{gspread.utils.rowcol_to_a1(row_num, status_col)}:'
+            f'{gspread.utils.rowcol_to_a1(row_num, end_col)}',
+            [['Pending', '', '', '', notes]],
+            value_input_option='RAW',
+        )
+        self._cache.invalidate(TAB_SPEND_REQUESTS)
+
     def submit_spend_request(self, character_name: str, spend_category: str,
                               trait_name: str, current_dots: int,
                               new_dots: int, is_in_clan: bool,

--- a/apps/web/app/sheets_sync.py
+++ b/apps/web/app/sheets_sync.py
@@ -206,6 +206,30 @@ class SheetsSyncWorker:
                 logger.warning('sheets_sync_failed: approve_spend — %s', exc)
         _executor.submit(_task)
 
+    def sync_reverse_spend(self, character_name: str, trait_name: str,
+                           spend_category: str, current_dots: int, new_dots: int,
+                           notes: str = '') -> None:
+        def _task():
+            try:
+                match = next(
+                    (s for s in self._sheets.get_all_spends()
+                     if s.character_name.lower() == character_name.lower()
+                     and s.trait_name == trait_name
+                     and s.spend_category == spend_category
+                     and s.current_dots == current_dots
+                     and s.new_dots == new_dots
+                     and s.status.lower() == 'approved'),
+                    None,
+                )
+                if match is None:
+                    logger.warning('sheets_sync: reverse_spend no match for %s / %s',
+                                   character_name, trait_name)
+                    return
+                self._sheets.reverse_spend(match.row_index, notes)
+            except Exception as exc:
+                logger.warning('sheets_sync_failed: reverse_spend — %s', exc)
+        _executor.submit(_task)
+
     def sync_deny_spend(self, character_name: str, trait_name: str,
                         spend_category: str, current_dots: int, new_dots: int,
                         reviewer: str, notes: str = '') -> None:
@@ -360,6 +384,13 @@ class SheetsSyncWorker:
                         self._sheets.deny_spend(
                             ss.row_index, ds.reviewed_by, ds.st_notes or ''
                         )
+                        summary['spends_status_updated'] += 1
+                    elif ds.status.lower() == 'pending' and ss.status.lower() == 'approved':
+                        # A reversed spend — DB is back to Pending after
+                        # having been Approved. sync_reverse_spend() should
+                        # have already caught this at reversal time; this is
+                        # the self-heal path if that call was missed/failed.
+                        self._sheets.reverse_spend(ss.row_index, ds.st_notes or '')
                         summary['spends_status_updated'] += 1
                 except Exception as exc:
                     summary['errors'].append(

--- a/apps/web/app/templates/spends/history.html
+++ b/apps/web/app/templates/spends/history.html
@@ -34,24 +34,44 @@
     <div style="width:70px;flex-shrink:0;">Cost</div>
     <div style="width:100px;flex-shrink:0;">Status</div>
     <div style="flex:1;">Reviewer / Notes</div>
+    <div style="width:90px;flex-shrink:0;"></div>
   </div>
   {% for spend in spends %}
-  <div class="dp-row history-row" style="cursor:default;" data-search="{{ (spend.character_name ~ ' ' ~ spend.trait_name) | lower }}">
-    <div style="width:150px;flex-shrink:0;" class="dp-cell-name">{{ spend.character_name }}</div>
-    <div style="width:180px;flex-shrink:0;font-size:12.5px;color:var(--text-body);">
-      {{ spend.trait_name }} <span style="color:var(--text-faint);">({{ spend.current_dots }}→{{ spend.new_dots }})</span>
+  <div>
+    <div class="dp-row history-row" style="cursor:default;" data-search="{{ (spend.character_name ~ ' ' ~ spend.trait_name) | lower }}">
+      <div style="width:150px;flex-shrink:0;" class="dp-cell-name">{{ spend.character_name }}</div>
+      <div style="width:180px;flex-shrink:0;font-size:12.5px;color:var(--text-body);">
+        {{ spend.trait_name }} <span style="color:var(--text-faint);">({{ spend.current_dots }}→{{ spend.new_dots }})</span>
+      </div>
+      <div style="width:70px;flex-shrink:0;" class="dp-cell-muted">{{ spend.verified_cost or spend.xp_cost }} XP</div>
+      <div style="width:100px;flex-shrink:0;">
+        {% if spend.status|lower == 'approved' %}
+        <span class="dp-pill dp-pill--green">Approved</span>
+        {% elif spend.status|lower == 'denied' %}
+        <span class="dp-pill dp-pill--red">Denied</span>
+        {% else %}
+        <span class="dp-pill dp-pill--neutral">{{ spend.status }}</span>
+        {% endif %}
+      </div>
+      <div style="flex:1;min-width:0;" class="dp-cell-muted">{{ spend.reviewed_by }}{{ ' — ' ~ spend.st_notes if spend.st_notes }}</div>
+      <div style="width:90px;flex-shrink:0;text-align:right;">
+        {% if spend.status|lower == 'approved' %}
+        <button type="button" class="dp-btn reverse-toggle" data-target="reverse-detail-{{ spend.row_index }}">Reverse ▾</button>
+        {% endif %}
+      </div>
     </div>
-    <div style="width:70px;flex-shrink:0;" class="dp-cell-muted">{{ spend.verified_cost or spend.xp_cost }} XP</div>
-    <div style="width:100px;flex-shrink:0;">
-      {% if spend.status|lower == 'approved' %}
-      <span class="dp-pill dp-pill--green">Approved</span>
-      {% elif spend.status|lower == 'denied' %}
-      <span class="dp-pill dp-pill--red">Denied</span>
-      {% else %}
-      <span class="dp-pill dp-pill--neutral">{{ spend.status }}</span>
-      {% endif %}
+    {% if spend.status|lower == 'approved' %}
+    <div id="reverse-detail-{{ spend.row_index }}" class="dp-detail" style="display:none;">
+      <form method="POST" action="{{ url_for('spends.reverse', row_id=spend.row_index) }}"
+            onsubmit="return confirm('Reverse this approved spend? This restores the XP and puts it back in the pending queue.');">
+        <div style="margin-bottom:8px;">
+          <label for="reverse_notes-{{ spend.row_index }}" class="dp-detail-label" style="display:block;margin-bottom:4px;">Reason <span style="text-transform:none;font-weight:400;">(optional)</span></label>
+          <textarea class="form-control form-control-sm" id="reverse_notes-{{ spend.row_index }}" name="notes" rows="2" style="max-width:420px;"></textarea>
+        </div>
+        <button type="submit" class="dp-btn" style="color:#e2a53d;border-color:rgba(226,165,61,.4);background:rgba(226,165,61,.1);">Reverse Spend</button>
+      </form>
     </div>
-    <div style="flex:1;min-width:0;" class="dp-cell-muted">{{ spend.reviewed_by }}{{ ' — ' ~ spend.st_notes if spend.st_notes }}</div>
+    {% endif %}
   </div>
   {% endfor %}
 </div>
@@ -62,12 +82,22 @@
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const search = document.getElementById('history-search');
-    if (!search) return;
-    const rows = document.querySelectorAll('.history-row');
-    search.addEventListener('input', function () {
-        const q = search.value.toLowerCase();
-        rows.forEach(function (row) {
-            row.style.display = (!q || row.dataset.search.includes(q)) ? '' : 'none';
+    if (search) {
+        const rows = document.querySelectorAll('.history-row');
+        search.addEventListener('input', function () {
+            const q = search.value.toLowerCase();
+            rows.forEach(function (row) {
+                row.style.display = (!q || row.dataset.search.includes(q)) ? '' : 'none';
+            });
+        });
+    }
+
+    document.querySelectorAll('.reverse-toggle').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const panel = document.getElementById(btn.dataset.target);
+            const isOpen = panel.style.display !== 'none';
+            panel.style.display = isOpen ? 'none' : 'block';
+            btn.textContent = isOpen ? 'Reverse ▾' : 'Collapse ▴';
         });
     });
 });

--- a/apps/web/app/templates/spends/history.html
+++ b/apps/web/app/templates/spends/history.html
@@ -37,8 +37,8 @@
     <div style="width:90px;flex-shrink:0;"></div>
   </div>
   {% for spend in spends %}
-  <div>
-    <div class="dp-row history-row" style="cursor:default;" data-search="{{ (spend.character_name ~ ' ' ~ spend.trait_name) | lower }}">
+  <div class="history-wrapper" data-search="{{ (spend.character_name ~ ' ' ~ spend.trait_name) | lower }}">
+    <div class="dp-row history-row" style="cursor:default;">
       <div style="width:150px;flex-shrink:0;" class="dp-cell-name">{{ spend.character_name }}</div>
       <div style="width:180px;flex-shrink:0;font-size:12.5px;color:var(--text-body);">
         {{ spend.trait_name }} <span style="color:var(--text-faint);">({{ spend.current_dots }}→{{ spend.new_dots }})</span>
@@ -83,11 +83,18 @@
 document.addEventListener('DOMContentLoaded', function () {
     const search = document.getElementById('history-search');
     if (search) {
-        const rows = document.querySelectorAll('.history-row');
+        const wrappers = document.querySelectorAll('.history-wrapper');
         search.addEventListener('input', function () {
             const q = search.value.toLowerCase();
-            rows.forEach(function (row) {
-                row.style.display = (!q || row.dataset.search.includes(q)) ? '' : 'none';
+            wrappers.forEach(function (wrapper) {
+                const match = !q || wrapper.dataset.search.includes(q);
+                wrapper.style.display = match ? '' : 'none';
+                if (!match) {
+                    const panel = wrapper.querySelector('.dp-detail');
+                    const toggle = wrapper.querySelector('.reverse-toggle');
+                    if (panel) panel.style.display = 'none';
+                    if (toggle) toggle.textContent = 'Reverse ▾';
+                }
             });
         });
     }


### PR DESCRIPTION
## Summary
- **Bug fix**: approving 3 pending spends for a character put them at -1 available XP. Neither `approve()` nor `bulk_approve()` in `apps/web/app/blueprints/spends.py` ever checked `available_xp` — only that the submitted cost matched the correct V5 cost formula. Now both check the character's actual balance before approving. `bulk_approve()` re-derives `available_xp` fresh before each item in its loop (confirmed safe — uncached SQL aggregate, and each `approve_spend()` commits immediately), so a batch of individually-affordable spends that collectively overdraw the budget now gets the offending one(s) skipped with a clear reason instead of silently going negative.
- **New feature**: staff can now reverse an approved spend from XP Spends → History (previously fully read-only, with no way to undo a mistaken approval short of a disconnected manual ledger adjustment). Reversal:
  - Resets the spend to Pending and restores the XP.
  - Best-effort rolls back the character-sheet patch that approval applied (new `reverse_character_sheet_patch()` in `character_sheet.py`, mirroring `_apply_patch`'s per-category branches inverted) — with a staleness guard: only rolls back a field/list-entry if it still holds exactly what this spend set, so a later, unrelated sheet change is never clobbered. If it can't safely roll back, the spend is still reversed but staff get a warning flash to check the sheet manually (unlike approval's silent-swallow-on-failure, since accuracy matters more on an undo).
  - Blocked if another already-approved spend depends on this one (mirrors the existing forward-direction dependency guard on approval).
  - Flags (doesn't attempt to unwind) coterie XP-donation state if the spend had one — out of scope for this pass.

## Scope
Spends only, matching the actual incident. Claims have the same read-only-history gap but don't touch the character sheet, so reversing a claim would be simpler — a natural fast follow, not bundled here.

## Test plan (all verified locally against dev SQLite)
- [x] Bulk-approve 3 spends whose combined cost exceeds available XP — 2 approved, 1 skipped with an "insufficient XP" message, balance never goes negative
- [x] Approve a Discipline spend (patches the sheet) → reverse it → spend back to Pending, XP restored, sheet discipline entry removed, confirmed via the actual character_data JSON
- [x] Approve + reverse a Loresheet purchase → confirmed the specific list entry is removed
- [x] Attempt to reverse a spend with an already-approved dependent → blocked with a clear message; reversing in dependency order (child then parent) succeeds
- [x] Simulate a later manual sheet edit to the same field, then reverse → sheet rollback correctly skipped (newer value preserved), spend still reversed, warning surfaced
- [x] Attempt to reverse a Denied/Pending spend → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)