### PR TITLE
Wish list: audit logging + Google Sheets backup mirror

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -673,6 +673,13 @@ def add_wish_list_item(name):
             is_in_clan=is_in_clan,
             justification=justification or _WISH_LIST_DEFAULT_JUSTIFICATION,
         )
+        discord_name = session.get('discord_name', 'unknown')
+        db_service.log_action(
+            staff_user=f'player:{discord_name}',
+            action_type='player_wishlist_add',
+            target=name,
+            details=f'{spend_category}: {trait_name} ({current_dots}→{new_dots})',
+        )
         flash(f'Added "{trait_name}" to your wish list.', 'success')
     except ValueError as e:
         flash(f'Could not add to wish list: {e}', 'danger')
@@ -689,7 +696,15 @@ def remove_wish_list_item(name, item_id):
     if not char or not char.active:
         abort(404)
 
-    if db_service.delete_wish_list_item(item_id, name):
+    item = db_service.get_wish_list_item(item_id, name)
+    if item and db_service.delete_wish_list_item(item_id, name):
+        discord_name = session.get('discord_name', 'unknown')
+        db_service.log_action(
+            staff_user=f'player:{discord_name}',
+            action_type='player_wishlist_remove',
+            target=name,
+            details=f'{item.spend_category}: {item.trait_name} ({item.current_dots}→{item.new_dots})',
+        )
         flash('Removed item from wish list.', 'success')
     else:
         flash('Wish list item not found.', 'danger')

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -682,6 +682,12 @@ def add_wish_list_item(name):
             details=f'{spend_category}: {trait_name} ({current_dots}→{new_dots})',
         )
         if sheets_sync:
+            sheets_sync.sync_log_action(
+                staff_user=f'player:{discord_name}',
+                action_type='player_wishlist_add',
+                target=name,
+                details=f'{spend_category}: {trait_name} ({current_dots}→{new_dots})',
+            )
             sheets_sync.sync_add_wish_list_item(
                 character_name=name,
                 spend_category=spend_category,
@@ -720,6 +726,12 @@ def remove_wish_list_item(name, item_id):
             details=f'{item.spend_category}: {item.trait_name} ({item.current_dots}→{item.new_dots})',
         )
         if sheets_sync:
+            sheets_sync.sync_log_action(
+                staff_user=f'player:{discord_name}',
+                action_type='player_wishlist_remove',
+                target=name,
+                details=f'{item.spend_category}: {item.trait_name} ({item.current_dots}→{item.new_dots})',
+            )
             sheets_sync.sync_remove_wish_list_item(
                 character_name=name,
                 spend_category=item.spend_category,

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -663,7 +663,8 @@ def add_wish_list_item(name):
     is_in_clan = bool(request.form.get('is_in_clan'))
 
     try:
-        db_service.add_wish_list_item(
+        final_justification = justification or _WISH_LIST_DEFAULT_JUSTIFICATION
+        result = db_service.add_wish_list_item(
             character_name=name,
             spend_category=spend_category,
             trait_name=trait_name,
@@ -671,7 +672,7 @@ def add_wish_list_item(name):
             current_dots=current_dots,
             new_dots=new_dots,
             is_in_clan=is_in_clan,
-            justification=justification or _WISH_LIST_DEFAULT_JUSTIFICATION,
+            justification=final_justification,
         )
         discord_name = session.get('discord_name', 'unknown')
         db_service.log_action(
@@ -680,6 +681,19 @@ def add_wish_list_item(name):
             target=name,
             details=f'{spend_category}: {trait_name} ({current_dots}→{new_dots})',
         )
+        if sheets_sync:
+            sheets_sync.sync_add_wish_list_item(
+                character_name=name,
+                spend_category=spend_category,
+                trait_name=trait_name,
+                power_name=power_name,
+                current_dots=current_dots,
+                new_dots=new_dots,
+                is_in_clan=is_in_clan,
+                xp_cost=result['xp_cost'],
+                justification=final_justification,
+                created_at=result['created_at'],
+            )
         flash(f'Added "{trait_name}" to your wish list.', 'success')
     except ValueError as e:
         flash(f'Could not add to wish list: {e}', 'danger')
@@ -705,6 +719,14 @@ def remove_wish_list_item(name, item_id):
             target=name,
             details=f'{item.spend_category}: {item.trait_name} ({item.current_dots}→{item.new_dots})',
         )
+        if sheets_sync:
+            sheets_sync.sync_remove_wish_list_item(
+                character_name=name,
+                spend_category=item.spend_category,
+                trait_name=item.trait_name,
+                current_dots=item.current_dots,
+                new_dots=item.new_dots,
+            )
         flash('Removed item from wish list.', 'success')
     else:
         flash('Wish list item not found.', 'danger')
@@ -769,6 +791,14 @@ def convert_wish_list_item(name, item_id):
                 ),
             )
         db_service.delete_wish_list_item(item_id, name)
+        if sheets_sync:
+            sheets_sync.sync_remove_wish_list_item(
+                character_name=name,
+                spend_category=item.spend_category,
+                trait_name=item.trait_name,
+                current_dots=item.current_dots,
+                new_dots=item.new_dots,
+            )
         flash(
             f'Spend request submitted: {item.trait_name} '
             f'({item.current_dots}→{item.new_dots}) for {xp_cost} XP. '

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -889,13 +889,14 @@ class DBService:
     def add_wish_list_item(self, character_name: str, spend_category: str,
                             trait_name: str, current_dots: int, new_dots: int,
                             is_in_clan: bool = False, power_name: str = '',
-                            justification: str = '') -> int:
-        """Add a wish list item. Returns the calculated XP cost.
+                            justification: str = '') -> dict:
+        """Add a wish list item. Returns {'xp_cost': int, 'created_at': str}.
 
         Raises ValueError if the cost calculation fails.
         """
         from app.xp_rules import calculate_xp_cost
         xp_cost = calculate_xp_cost(spend_category, current_dots, new_dots)
+        created_at = _now_str()
 
         row = DbWishListItem(
             character_name=character_name,
@@ -907,11 +908,11 @@ class DBService:
             is_in_clan=bool(is_in_clan),
             xp_cost=xp_cost,
             justification=justification,
-            created_at=_now_str(),
+            created_at=created_at,
         )
         db.session.add(row)
         db.session.commit()
-        return xp_cost
+        return {'xp_cost': xp_cost, 'created_at': created_at}
 
     def get_wish_list_item(self, item_id: int, character_name: str) -> Optional[DbWishListItem]:
         return DbWishListItem.query.filter(

--- a/apps/web/app/sheets.py
+++ b/apps/web/app/sheets.py
@@ -88,6 +88,7 @@ TAB_XP_RESPONSES = 'XP Responses'
 TAB_SPEND_REQUESTS = 'Spend Requests'
 TAB_XP_LEDGER = 'XP Ledger'
 TAB_AUDIT_LOG = 'Audit Log'
+TAB_WISH_LIST_ITEMS = 'Wish List Items'
 
 # Header rows for each tab
 ROSTER_HEADERS = [
@@ -128,6 +129,11 @@ XP_LEDGER_HEADERS = [
 
 AUDIT_LOG_HEADERS = [
     'timestamp', 'staff_user', 'action_type', 'target_character', 'details',
+]
+
+WISH_LIST_ITEMS_HEADERS = [
+    'created_at', 'character_name', 'spend_category', 'trait_name', 'power_name',
+    'current_dots', 'new_dots', 'is_in_clan', 'xp_cost', 'justification',
 ]
 
 
@@ -296,6 +302,7 @@ class SheetsClient:
             TAB_SPEND_REQUESTS: SPEND_REQUESTS_HEADERS,
             TAB_XP_LEDGER: XP_LEDGER_HEADERS,
             TAB_AUDIT_LOG: AUDIT_LOG_HEADERS,
+            TAB_WISH_LIST_ITEMS: WISH_LIST_ITEMS_HEADERS,
         }
         import logging
         log = logging.getLogger(__name__)
@@ -400,6 +407,7 @@ class SheetsClient:
             TAB_SPEND_REQUESTS: SPEND_REQUESTS_HEADERS,
             TAB_XP_LEDGER: XP_LEDGER_HEADERS,
             TAB_AUDIT_LOG: AUDIT_LOG_HEADERS,
+            TAB_WISH_LIST_ITEMS: WISH_LIST_ITEMS_HEADERS,
         }
 
         for tab_name, headers in tabs.items():
@@ -909,6 +917,36 @@ class SheetsClient:
             review_date=str(row.get('review_date', '')),
             st_notes=str(row.get('st_notes', '')),
         )
+
+    # ── Wish List Items (backup mirror only — app never reads this back) ──────
+
+    def add_wish_list_item(self, character_name: str, spend_category: str,
+                            trait_name: str, power_name: str, current_dots: int,
+                            new_dots: int, is_in_clan: bool, xp_cost: int,
+                            justification: str, created_at: str) -> None:
+        row = [
+            created_at,
+            character_name,
+            spend_category,
+            trait_name,
+            power_name,
+            current_dots,
+            new_dots,
+            'TRUE' if is_in_clan else 'FALSE',
+            xp_cost,
+            justification,
+        ]
+        self._safe_append_row(TAB_WISH_LIST_ITEMS, row)
+
+    def get_all_wish_list_items(self) -> list[dict]:
+        rows = self._get_all_rows(TAB_WISH_LIST_ITEMS)
+        return [dict(row, row_index=i) for i, row in enumerate(rows)
+                if row.get('character_name')]
+
+    def remove_wish_list_item_row(self, row_index: int) -> None:
+        ws = self._ws(TAB_WISH_LIST_ITEMS)
+        ws.delete_rows(row_index + 2)  # +1 header, +1 for 1-indexed
+        self._cache.invalidate(TAB_WISH_LIST_ITEMS)
 
     # ── XP Totals (computed) ─────────────────────────────────────────────────
 

--- a/apps/web/app/sheets_sync.py
+++ b/apps/web/app/sheets_sync.py
@@ -230,6 +230,50 @@ class SheetsSyncWorker:
                 logger.warning('sheets_sync_failed: reverse_spend — %s', exc)
         _executor.submit(_task)
 
+    def sync_add_wish_list_item(self, character_name: str, spend_category: str,
+                                trait_name: str, power_name: str, current_dots: int,
+                                new_dots: int, is_in_clan: bool, xp_cost: int,
+                                justification: str, created_at: str) -> None:
+        def _task():
+            try:
+                self._sheets.add_wish_list_item(
+                    character_name=character_name,
+                    spend_category=spend_category,
+                    trait_name=trait_name,
+                    power_name=power_name,
+                    current_dots=current_dots,
+                    new_dots=new_dots,
+                    is_in_clan=is_in_clan,
+                    xp_cost=xp_cost,
+                    justification=justification,
+                    created_at=created_at,
+                )
+            except Exception as exc:
+                logger.warning('sheets_sync_failed: add_wish_list_item — %s', exc)
+        _executor.submit(_task)
+
+    def sync_remove_wish_list_item(self, character_name: str, spend_category: str,
+                                   trait_name: str, current_dots: int, new_dots: int) -> None:
+        def _task():
+            try:
+                match = next(
+                    (r for r in self._sheets.get_all_wish_list_items()
+                     if r.get('character_name', '').lower() == character_name.lower()
+                     and r.get('trait_name') == trait_name
+                     and r.get('spend_category') == spend_category
+                     and str(r.get('current_dots')) == str(current_dots)
+                     and str(r.get('new_dots')) == str(new_dots)),
+                    None,
+                )
+                if match is None:
+                    logger.warning('sheets_sync: remove_wish_list_item no match for %s / %s',
+                                   character_name, trait_name)
+                    return
+                self._sheets.remove_wish_list_item_row(match['row_index'])
+            except Exception as exc:
+                logger.warning('sheets_sync_failed: remove_wish_list_item — %s', exc)
+        _executor.submit(_task)
+
     def sync_deny_spend(self, character_name: str, trait_name: str,
                         spend_category: str, current_dots: int, new_dots: int,
                         reviewer: str, notes: str = '') -> None:


### PR DESCRIPTION
## Summary
Two related follow-ups from investigating a production report of lost wish-list data on a character:

1. **Audit logging** (`apps/web/app/blueprints/player.py`): the wish-list add/remove routes never called `log_action()` — only convert-to-spend did. This meant there was no trace to check whether a removal was a bug, normal use, or something else. Now logs `player_wishlist_add`/`player_wishlist_remove`, matching the convention used for every other player-initiated mutation.

2. **Google Sheets backup mirror**: the app already mirrors claims, spends, and ledger entries to Sheets as a best-effort backup (per `CLAUDE.md` — "synced in the background after every write, never read for primary data"). Wish list items never did. A thorough investigation into the lost-data report found no app-level code path that could delete more than one character's wish-list rows — the cause was outside the app (most likely a direct DB operation against Turso). Regardless of root cause, having a second copy going forward is cheap insurance.
   - New "Wish List Items" tab (`SheetsClient.add_wish_list_item` / `get_all_wish_list_items` / `remove_wish_list_item_row`), mirroring the existing Spend Requests tab's append/delete pattern exactly.
   - Wired into add/remove/convert-to-spend via `sync_add_wish_list_item` / `sync_remove_wish_list_item`.
   - Write-only from the app's side, same as every other Sheets mirror — never read back for primary data.

## Action needed before this is useful
The "Wish List Items" tab isn't auto-created on boot (matching how every other tab already works — there's no create-tabs-on-startup logic in this codebase). Before deploying, either:
- Run `SheetsClient.setup_sheets()` once (it's idempotent — safe to run even though other tabs already exist), or
- Manually add a tab named **Wish List Items** to the live spreadsheet with this header row: `created_at, character_name, spend_category, trait_name, power_name, current_dots, new_dots, is_in_clan, xp_cost, justification`

## Test plan
- [x] Verified locally: add/remove/convert routes call the correct `sheets_sync` methods with the correct arguments (mocked `SheetsClient`, since local dev has no real Google credentials)
- [x] Verified adding and removing a wish list item creates matching `DbAuditLog` rows
- [ ] Add the "Wish List Items" tab to the real spreadsheet (see above) before/at deploy time

🤖 Generated with [Claude Code](https://claude.com/claude-code)