### PR TITLE
Make a disabled cubby sync worker loud, and run it immediately on start

### DIFF
--- a/apps/bot/src/__tests__/cubbySyncWorker.test.ts
+++ b/apps/bot/src/__tests__/cubbySyncWorker.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Client } from 'discord.js';
+import { CubbySyncWorker } from '../services/cubbySyncWorker';
+import { logEvent } from '../logger';
+import type { TrackerAdapter } from '../services/adapter';
+
+vi.mock('../logger', () => ({
+  logEvent: vi.fn(),
+  errorToMessage: (err: unknown) => String(err),
+}));
+
+function makeClient(guildFetch = vi.fn().mockResolvedValue(null)) {
+  return { guilds: { fetch: guildFetch } } as unknown as Client;
+}
+
+function makeAdapter(): TrackerAdapter {
+  return {} as unknown as TrackerAdapter;
+}
+
+describe('CubbySyncWorker.start', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('logs a distinct warning and never runs a sync when disabled', async () => {
+    vi.useFakeTimers();
+    const guildFetch = vi.fn().mockResolvedValue(null);
+    const client = makeClient(guildFetch);
+    const worker = new CubbySyncWorker(makeAdapter(), client, {
+      enabled: false,
+      intervalMs: 1000,
+      guildId: 'guild-1',
+      staffChannelId: '',
+      retiredCategoryId: '',
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(logEvent).toHaveBeenCalledWith('warn', 'cubby_sync_worker_disabled', expect.anything());
+    expect(logEvent).not.toHaveBeenCalledWith('info', 'cubby_sync_worker_started', expect.anything());
+    expect(guildFetch).not.toHaveBeenCalled();
+  });
+
+  it('runs a sync immediately on start when enabled, without waiting a full interval', async () => {
+    vi.useFakeTimers();
+    const guildFetch = vi.fn().mockResolvedValue(null);
+    const client = makeClient(guildFetch);
+    const worker = new CubbySyncWorker(makeAdapter(), client, {
+      enabled: true,
+      intervalMs: 3_600_000,
+      guildId: 'guild-1',
+      staffChannelId: '',
+      retiredCategoryId: '',
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(logEvent).toHaveBeenCalledWith('info', 'cubby_sync_worker_started', expect.anything());
+    expect(guildFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('still ticks again on the regular interval after the immediate run', async () => {
+    vi.useFakeTimers();
+    const guildFetch = vi.fn().mockResolvedValue(null);
+    const client = makeClient(guildFetch);
+    const worker = new CubbySyncWorker(makeAdapter(), client, {
+      enabled: true,
+      intervalMs: 1000,
+      guildId: 'guild-1',
+      staffChannelId: '',
+      retiredCategoryId: '',
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(guildFetch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(guildFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/bot/src/services/cubbySyncWorker.ts
+++ b/apps/bot/src/services/cubbySyncWorker.ts
@@ -40,11 +40,25 @@ export class CubbySyncWorker {
 
   start() {
     if (this.timer) return;
+    if (!this.cfg.enabled) {
+      // Loud and distinct from cubby_sync_worker_started on purpose — this
+      // silently no-op'd in production for two days once before (missing
+      // CUBBY_SYNC_ENABLED in .env), with nothing but an identical-looking
+      // "started" log to suggest it was ever running.
+      logEvent('warn', 'cubby_sync_worker_disabled', {
+        hint: 'CUBBY_SYNC_ENABLED is not "true" — cubby channel backfill and retirement detection will not run.',
+      });
+      return;
+    }
     this.timer = setInterval(() => {
       void this.tick();
     }, this.cfg.intervalMs);
     this.timer.unref();
     logEvent('info', 'cubby_sync_worker_started', { intervalMs: this.cfg.intervalMs });
+    // Run once immediately rather than waiting a full interval — otherwise
+    // every bot restart leaves newly-created cubbies unlinked for up to an
+    // hour with no visible signal that anything is wrong.
+    void this.tick();
   }
 
   stop() {


### PR DESCRIPTION
## Summary
Investigating a "no cubby found" warning for a character whose cubby channel genuinely existed led to a real production regression: `CUBBY_SYNC_ENABLED` was missing from the bot's `.env`, which the cubby-sync worker treated as `false` — every tick silently no-op'd via an early `if (!enabled) return`, but `start()` still logged `cubby_sync_worker_started` unconditionally, making it look like it was running normally. For two days (confirmed via prod logs — the flag has clearly worked before, since one existing character's cubby channel was correctly linked back in June), no character's `ticket_channel_id` ever got backfilled, and the only visible symptom was a downstream "no cubby" warning on an unrelated notifier, with nothing pointing back to the actual cause.

## Fix
- `start()` now branches on `enabled` *before* setting up the interval: if disabled, it logs a distinct `cubby_sync_worker_disabled` warning (never `cubby_sync_worker_started`) and returns — no more identical-looking "started" log regardless of whether it'll ever actually do anything.
- When enabled, it now also runs once immediately on start, rather than only after the first full interval — so a bot restart doesn't leave newly-created cubbies unlinked for up to an hour with zero signal that anything's wrong.

## Immediate production fix (already done, not part of this PR)
- Added `CUBBY_SYNC_ENABLED=true` to the bot's `.env` on the host and recreated the container (`docker compose up -d bot` — a plain `docker restart` does **not** re-read `.env`, learned that the hard way mid-diagnosis).
- Directly set `ticket_channel_id` for the specific character that triggered this, to the value the worker would have set itself.

## Test plan
- [x] New `cubbySyncWorker.test.ts`: disabled worker logs the distinct warning and never calls into Discord; enabled worker runs immediately (not just on the first interval tick) and continues ticking on schedule afterward
- [x] Full test suite (317 tests, 45 files), typecheck, and lint all pass
- [x] Verified against production logs that the fix resolves the actual incident (worker now ticks and backfills correctly with the flag set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)