### PR TITLE
Fix Top Posters chart tooltip axis correlation

### DIFF
--- a/apps/web/app/templates/reports/health.html
+++ b/apps/web/app/templates/reports/health.html
@@ -412,13 +412,14 @@
       options: {
         indexAxis: 'y',
         responsive: true,
+        interaction: { mode: 'index', axis: 'y', intersect: false },
         scales: {
           x: { beginAtZero: true, grid: { color: GRIDLINE }, ticks: { precision: 0 } },
           y: { grid: { display: false } },
         },
         plugins: {
           legend: { display: false },
-          tooltip: { intersect: false },
+          tooltip: { mode: 'index', axis: 'y', intersect: false },
         },
       },
     });


### PR DESCRIPTION
## Summary
- `leaderboardChart` on `/reports/health` is a horizontal bar chart (`indexAxis: 'y'`), but its tooltip/interaction options never set `axis: 'y'`, so Chart.js was correlating hover position against the x-axis by default — hovering over a bar showed the wrong tooltip.
- Added `interaction: { mode: 'index', axis: 'y', intersect: false }` at the chart level and matched `axis: 'y'` in `plugins.tooltip`.

## Test plan
- [ ] Load `/reports/health`, hover over bars in the Top Posters chart, confirm tooltip matches the bar under the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)