### PR TITLE
Fix Top Posters chart overlapping bars for large leaderboards

### DIFF
--- a/apps/web/app/templates/reports/health.html
+++ b/apps/web/app/templates/reports/health.html
@@ -219,7 +219,9 @@
         </div>
         <div class="card-body">
           {% if report.leaderboard %}
-          <canvas id="leaderboardChart" height="140" role="img" aria-label="Bar chart of the top 15 posters by total post count"></canvas>
+          <div style="height: {{ [report.leaderboard | length * 32, 140] | max }}px;">
+            <canvas id="leaderboardChart" role="img" aria-label="Bar chart of the top 15 posters by total post count"></canvas>
+          </div>
           {% else %}
           <p class="text-muted mb-0">No posts recorded in this window.</p>
           {% endif %}
@@ -412,6 +414,7 @@
       options: {
         indexAxis: 'y',
         responsive: true,
+        maintainAspectRatio: false,
         interaction: { mode: 'index', axis: 'y', intersect: false },
         scales: {
           x: { beginAtZero: true, grid: { color: GRIDLINE }, ticks: { precision: 0 } },


### PR DESCRIPTION
## Summary
- Follow-up to #366. The tooltip axis fix was correct, but the reported "wonky" behavior was actually caused by a separate bug: `leaderboardChart`'s canvas had a fixed `height="140"` attribute combined with Chart.js's default `maintainAspectRatio: true`, so the chart never grew to accommodate more than a few rows. With up to 15 posters in the leaderboard, bars were compressed on top of each other and category labels got clipped/merged (visible in the reported screenshot).
- Wrapper div height now scales with `report.leaderboard | length` (32px/row, 140px floor), and `maintainAspectRatio: false` lets the chart fill that container instead of preserving the old aspect ratio.

## Test plan
- [x] `pytest -q -k "health or report"` passes (40 passed)
- [ ] Load `/reports/health`, confirm each bar in Top Posters is a distinct row with no overlap, and hover tooltips still track correctly per #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)