### PR TITLE
Add 180-day option to health report range picker

### DIFF
--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -281,14 +281,14 @@ def activity_csv():
     )
 
 
-HEALTH_RANGE_OPTIONS = (30, 60, 90)
+HEALTH_RANGE_OPTIONS = (30, 60, 90, 180)
 
 
 @bp.route('/reports/health')
 @require_staff
 def health():
     """Server-health dashboard: posting trend, participation, and a
-    "who hasn't posted" list over a rolling 30/60/90-day window."""
+    "who hasn't posted" list over a rolling 30/60/90/180-day window."""
     try:
         range_days = int(request.args.get('range', 30))
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- Following the manual \`/lasombra scan-activity\` backfill runs recovering ~180 days of Discord activity history (lost due to an earlier logging error), extend \`HEALTH_RANGE_OPTIONS\` in \`apps/web/app/blueprints/reports.py\` from \`(30, 60, 90)\` to \`(30, 60, 90, 180)\`.
- No other changes needed — \`build_health_report\`/\`daterange\`/\`shift_window\` in \`activity_health.py\` are length-agnostic, and the range-picker template already loops over \`range_options\` generically.

## Test plan
- [x] \`pytest -q -k "health or activity"\` passes (44 passed)
- [ ] After deploy, load \`/reports/health?range=180\` and confirm the 180-day trend renders using the newly-backfilled data

🤖 Generated with [Claude Code](https://claude.com/claude-code)