### PR TITLE
Add 270-day option to health report range picker

### DIFF
--- a/apps/web/app/blueprints/reports.py
+++ b/apps/web/app/blueprints/reports.py
@@ -281,14 +281,14 @@ def activity_csv():
     )
 
 
-HEALTH_RANGE_OPTIONS = (30, 60, 90, 180)
+HEALTH_RANGE_OPTIONS = (30, 60, 90, 180, 270)
 
 
 @bp.route('/reports/health')
 @require_staff
 def health():
     """Server-health dashboard: posting trend, participation, and a
-    "who hasn't posted" list over a rolling 30/60/90/180-day window."""
+    "who hasn't posted" list over a rolling 30/60/90/180/270-day window."""
     try:
         range_days = int(request.args.get('range', 30))
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- Follow-up to #368. A third manual \`/lasombra scan-activity\` backfill run recovered Discord activity history back to 2025-10-24 (~270 days total), so extend \`HEALTH_RANGE_OPTIONS\` in \`apps/web/app/blueprints/reports.py\` to \`(30, 60, 90, 180, 270)\`.
- No other changes needed, same as #368 — the aggregation/template code is length-agnostic.

## Test plan
- [x] \`pytest -q -k "health or activity"\` passes (44 passed)
- [ ] After deploy, load \`/reports/health?range=270\` and confirm the full trend renders using the newly-backfilled data

🤖 Generated with [Claude Code](https://claude.com/claude-code)