### PR TITLE
Add /weather command; skip bot redeploy on unrelated changes

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -35,6 +35,12 @@ jobs:
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Capture currently-deployed SHA
+        id: prev
+        run: |
+          cd ${{ secrets.URSULA_BOT_DIR }}
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Pull latest code
         run: |
           cd ${{ secrets.URSULA_BOT_DIR }}
@@ -42,7 +48,32 @@ jobs:
           git checkout main
           git pull origin main
 
+      # workflow_run can't use a native `paths:` filter (that only works on
+      # `push`), so this diffs the previously-deployed SHA against the new
+      # one and skips the rebuild when nothing the bot actually depends on
+      # changed (apps/bot or the shared packages/ it imports). Manual
+      # dispatch always deploys regardless, since that's an explicit ask.
+      # Fails open (relevant=true) on any error in the diff itself, since a
+      # spurious redeploy is cheaper than silently never deploying.
+      - name: Check whether bot-relevant paths changed
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cd ${{ secrets.URSULA_BOT_DIR }}
+          diff_output=$(git diff --name-only "${{ steps.prev.outputs.sha }}" "${{ steps.sha.outputs.sha }}") || diff_output="__DIFF_FAILED__"
+          if [ "$diff_output" = "__DIFF_FAILED__" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          elif echo "$diff_output" | grep -qE '^(apps/bot/|packages/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Rebuild and restart bot
+        if: steps.check.outputs.relevant != 'false'
         run: |
           cd ${{ secrets.URSULA_BOT_DIR }}/apps/bot
           docker compose -f docker-compose.yml build
@@ -50,7 +81,7 @@ jobs:
           npm run ops:docker:up
 
       - name: Notify Discord
-        if: always()
+        if: always() && steps.check.outputs.relevant != 'false'
         continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}

--- a/apps/bot/src/__tests__/weather.test.ts
+++ b/apps/bot/src/__tests__/weather.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { __resetWeatherCacheForTests, describeWeatherCode, execute } from '../commands/weather';
+
+function makeInteraction() {
+  return {
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function mockFetchOnce(current: Record<string, number>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ current }),
+    }),
+  );
+}
+
+beforeEach(() => {
+  __resetWeatherCacheForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('describeWeatherCode', () => {
+  it('maps a known WMO code to a label and emoji', () => {
+    expect(describeWeatherCode(0)).toEqual({ label: 'Clear sky', emoji: '☀️' });
+    expect(describeWeatherCode(95)).toEqual({ label: 'Thunderstorm', emoji: '⛈️' });
+  });
+
+  it('falls back to an unknown-conditions placeholder for an unrecognized code', () => {
+    expect(describeWeatherCode(-1)).toEqual({ label: 'Unknown conditions', emoji: '❓' });
+  });
+});
+
+describe('/weather execute', () => {
+  it('defers, fetches current conditions, and edits the reply with an embed', async () => {
+    mockFetchOnce({
+      temperature_2m: 78.4,
+      weather_code: 1,
+      relative_humidity_2m: 55.2,
+      wind_speed_10m: 6.8,
+    });
+
+    const interaction = makeInteraction();
+    await execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: expect.any(Array) }),
+    );
+  });
+
+  it('reports a friendly error when the weather service is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const interaction = makeInteraction();
+    await execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.stringContaining('Could not reach the weather service'),
+    );
+  });
+});

--- a/apps/bot/src/commands/weather.ts
+++ b/apps/bot/src/commands/weather.ts
@@ -1,0 +1,101 @@
+import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+
+// Nashville, TN — the only location this command supports for now.
+const LATITUDE = 36.1627;
+const LONGITUDE = -86.7816;
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+let cache: { fetchedAt: number; data: OpenMeteoCurrent } | null = null;
+
+// https://open-meteo.com/en/docs — WMO weather interpretation codes.
+const WEATHER_CODES: Record<number, { label: string; emoji: string }> = {
+  0: { label: 'Clear sky', emoji: '☀️' },
+  1: { label: 'Mainly clear', emoji: '🌤️' },
+  2: { label: 'Partly cloudy', emoji: '⛅' },
+  3: { label: 'Overcast', emoji: '☁️' },
+  45: { label: 'Fog', emoji: '🌫️' },
+  48: { label: 'Depositing rime fog', emoji: '🌫️' },
+  51: { label: 'Light drizzle', emoji: '🌦️' },
+  53: { label: 'Moderate drizzle', emoji: '🌦️' },
+  55: { label: 'Dense drizzle', emoji: '🌦️' },
+  61: { label: 'Slight rain', emoji: '🌧️' },
+  63: { label: 'Moderate rain', emoji: '🌧️' },
+  65: { label: 'Heavy rain', emoji: '🌧️' },
+  71: { label: 'Slight snow', emoji: '🌨️' },
+  73: { label: 'Moderate snow', emoji: '🌨️' },
+  75: { label: 'Heavy snow', emoji: '🌨️' },
+  80: { label: 'Slight rain showers', emoji: '🌦️' },
+  81: { label: 'Moderate rain showers', emoji: '🌦️' },
+  82: { label: 'Violent rain showers', emoji: '⛈️' },
+  95: { label: 'Thunderstorm', emoji: '⛈️' },
+  96: { label: 'Thunderstorm with slight hail', emoji: '⛈️' },
+  99: { label: 'Thunderstorm with heavy hail', emoji: '⛈️' },
+};
+
+interface OpenMeteoCurrent {
+  temperature_2m: number;
+  weather_code: number;
+  relative_humidity_2m: number;
+  wind_speed_10m: number;
+}
+
+export function describeWeatherCode(code: number): { label: string; emoji: string } {
+  return WEATHER_CODES[code] ?? { label: 'Unknown conditions', emoji: '❓' };
+}
+
+/** Test-only: the module-level cache otherwise leaks across test cases. */
+export function __resetWeatherCacheForTests() {
+  cache = null;
+}
+
+async function fetchCurrentWeather(): Promise<OpenMeteoCurrent> {
+  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.data;
+  }
+
+  const url =
+    `https://api.open-meteo.com/v1/forecast?latitude=${LATITUDE}&longitude=${LONGITUDE}` +
+    '&current=temperature_2m,weather_code,relative_humidity_2m,wind_speed_10m' +
+    '&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=America%2FChicago';
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Open-Meteo request failed: ${res.status}`);
+  }
+  const body = (await res.json()) as { current: OpenMeteoCurrent };
+  cache = { fetchedAt: Date.now(), data: body.current };
+  return body.current;
+}
+
+export const data = new SlashCommandBuilder()
+  .setName('weather')
+  .setDescription("Current weather in Nashville");
+
+export const name = 'weather';
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  await interaction.deferReply();
+
+  let current: OpenMeteoCurrent;
+  try {
+    current = await fetchCurrentWeather();
+  } catch {
+    await interaction.editReply('Could not reach the weather service — try again in a bit.');
+    return;
+  }
+
+  const { label, emoji } = describeWeatherCode(current.weather_code);
+  const embed = new EmbedBuilder()
+    .setTitle(`${emoji} Nashville Weather`)
+    .setDescription(label)
+    .addFields(
+      { name: 'Temperature', value: `${Math.round(current.temperature_2m)}°F`, inline: true },
+      { name: 'Humidity', value: `${Math.round(current.relative_humidity_2m)}%`, inline: true },
+      { name: 'Wind', value: `${Math.round(current.wind_speed_10m)} mph`, inline: true },
+    )
+    .setColor(0x3987e5)
+    .setFooter({ text: 'via Open-Meteo' });
+
+  await interaction.editReply({ embeds: [embed] });
+}

--- a/docs/BOT.md
+++ b/docs/BOT.md
@@ -13,6 +13,7 @@ The bot calls the web app's REST API (`/api/*`) using a bearer token. It never w
 | Command | Who Can Use | Description |
 |---------|-------------|-------------|
 | `/ping` | Everyone | Basic liveness check |
+| `/weather` | Everyone | Current weather in Nashville (via Open-Meteo) |
 | `/xp submit` | Players | Redirect to the web player portal claim flow |
 | `/xp claim` | Players | Redirect to the web player portal claim flow |
 | `/xp spend` | Players | Redirect to the web player portal spend flow |


### PR DESCRIPTION
## Summary
- Closes #362: adds `/weather` — current Nashville conditions (temp/humidity/wind + condition) via [Open-Meteo](https://open-meteo.com), which needs no API key or account. New command is auto-registered by the existing `commands/` directory scan in `registerCommands.ts` — no wiring needed. A small in-memory cache (10 min TTL) keeps repeated invocations from hammering the API.
- Fixes an infra issue discovered while running Discord history backfills today: `deploy-bot.yml` redeploys the bot after **every** successful CI run on `main`, regardless of whether the change touched the bot. Since `workflow_run` can't use a native `paths:` filter, this adds a diff-based guard step (previously-deployed SHA vs. new SHA) that skips the rebuild unless `apps/bot/` or `packages/` (which the bot imports) actually changed. `workflow_dispatch` always deploys (explicit ask). The diff fails open (deploys) on any error in the diff itself.
- Added `/weather` to the command table in `docs/BOT.md` for consistency with `/ping`.

## Test plan
- [x] `npm run check` passes (lint, format, typecheck, 327 tests, build)
- [x] New `weather.test.ts`: WMO-code-to-label mapping, embed reply on success, friendly error message when the fetch fails
- [ ] After deploy, run `/weather` in Discord and confirm it replies with current Nashville conditions
- [ ] Confirm the next `apps/web`-only PR merge does *not* recreate `lasombra-bot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)