### PR TITLE
Lock /weather to the current IC night instead of a 10-minute TTL

### DIFF
--- a/apps/bot/src/__tests__/icNightTracker.test.ts
+++ b/apps/bot/src/__tests__/icNightTracker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { currentIcNightKey } from '../services/icNightTracker';
+
+// 2026-01-06 is a Tuesday.
+const SCHEDULE = {
+  timezone: 'America/Chicago',
+  weekdayLocal: 2, // Tuesday
+  hourLocal: 12,
+  minuteLocal: 0,
+  anchorDate: '2026-01-06',
+  cadenceWeeks: 2,
+};
+
+describe('currentIcNightKey', () => {
+  it('returns null before the first sunset has ever happened', () => {
+    expect(currentIcNightKey(new Date('2026-01-01T18:00:00Z'), SCHEDULE)).toBeNull();
+  });
+
+  it('returns null on the anchor date before the sunset hour', () => {
+    // 11:59 CT on the anchor date -- sunset (noon CT) hasn't happened yet.
+    expect(currentIcNightKey(new Date('2026-01-06T17:59:00Z'), SCHEDULE)).toBeNull();
+  });
+
+  it('keys to the anchor date once the sunset hour arrives', () => {
+    expect(currentIcNightKey(new Date('2026-01-06T18:00:00Z'), SCHEDULE)).toBe('2026-01-06');
+  });
+
+  it('stays on the same night key for the rest of the cadence window', () => {
+    // 10 days later, well inside the 2-week night.
+    expect(currentIcNightKey(new Date('2026-01-16T12:00:00Z'), SCHEDULE)).toBe('2026-01-06');
+  });
+
+  it('advances to the next night key exactly at the next cadence sunset', () => {
+    expect(currentIcNightKey(new Date('2026-01-20T18:00:00Z'), SCHEDULE)).toBe('2026-01-20');
+    // Just before that sunset hour, still the previous night.
+    expect(currentIcNightKey(new Date('2026-01-20T17:59:00Z'), SCHEDULE)).toBe('2026-01-06');
+  });
+
+  it('returns null when anchorDate does not fall on weekdayLocal (mirrors the real event never firing)', () => {
+    const misconfigured = { ...SCHEDULE, anchorDate: '2026-01-07' }; // a Wednesday
+    expect(currentIcNightKey(new Date('2026-02-01T18:00:00Z'), misconfigured)).toBeNull();
+  });
+});

--- a/apps/bot/src/__tests__/weather.test.ts
+++ b/apps/bot/src/__tests__/weather.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { __resetWeatherCacheForTests, describeWeatherCode, execute } from '../commands/weather';
+
+const mockConfig = vi.hoisted(() => ({
+  passageOfTimeTimezone: 'America/Chicago',
+  passageSunsetWeekdayLocal: 2, // Tuesday
+  passageSunsetHourLocal: 12,
+  passageSunsetMinuteLocal: 0,
+  passageSunsetAnchorDate: '2026-01-06', // a Tuesday
+}));
+
+vi.mock('../config', () => ({ config: mockConfig }));
+
+import {
+  __resetWeatherCacheForTests,
+  describeWeatherCode,
+  execute,
+  fetchCurrentWeather,
+} from '../commands/weather';
 
 function makeInteraction() {
   return {
@@ -8,16 +24,19 @@ function makeInteraction() {
   };
 }
 
-function mockFetchOnce(current: Record<string, number>) {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ current }),
-    }),
-  );
+function mockFetchSequence(...currents: Record<string, number>[]) {
+  const fn = vi.fn();
+  for (const current of currents) {
+    fn.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ current }) });
+  }
+  vi.stubGlobal('fetch', fn);
+  return fn;
 }
+
+const NIGHT_1 = new Date('2026-01-06T18:00:00Z'); // sunset hour on the anchor date
+const NIGHT_1_LATER = new Date('2026-01-16T12:00:00Z'); // still inside the same 2-week night
+const NIGHT_2 = new Date('2026-01-20T18:00:00Z'); // next cadence sunset
+const BEFORE_FIRST_NIGHT = new Date('2026-01-01T18:00:00Z'); // no IC night has started yet
 
 beforeEach(() => {
   __resetWeatherCacheForTests();
@@ -45,14 +64,46 @@ describe('describeWeatherCode', () => {
   });
 });
 
+describe('fetchCurrentWeather — locked to the current IC night', () => {
+  it('fetches once and reuses the cached snapshot for a later call within the same IC night', async () => {
+    const fetchMock = mockFetchSequence({ temperature_2m: 70, weather_code: 0, relative_humidity_2m: 40, wind_speed_10m: 5 });
+
+    const first = await fetchCurrentWeather(NIGHT_1);
+    const second = await fetchCurrentWeather(NIGHT_1_LATER);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it('refetches once the next IC night starts', async () => {
+    const fetchMock = mockFetchSequence(
+      { temperature_2m: 70, weather_code: 0, relative_humidity_2m: 40, wind_speed_10m: 5 },
+      { temperature_2m: 45, weather_code: 61, relative_humidity_2m: 80, wind_speed_10m: 12 },
+    );
+
+    const night1 = await fetchCurrentWeather(NIGHT_1);
+    const night2 = await fetchCurrentWeather(NIGHT_2);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(night2).not.toEqual(night1);
+  });
+
+  it('fetches live every call when no IC night has started yet (nothing to lock to)', async () => {
+    const fetchMock = mockFetchSequence(
+      { temperature_2m: 70, weather_code: 0, relative_humidity_2m: 40, wind_speed_10m: 5 },
+      { temperature_2m: 71, weather_code: 0, relative_humidity_2m: 41, wind_speed_10m: 5 },
+    );
+
+    await fetchCurrentWeather(BEFORE_FIRST_NIGHT);
+    await fetchCurrentWeather(BEFORE_FIRST_NIGHT);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('/weather execute', () => {
   it('defers, fetches current conditions, and edits the reply with an embed', async () => {
-    mockFetchOnce({
-      temperature_2m: 78.4,
-      weather_code: 1,
-      relative_humidity_2m: 55.2,
-      wind_speed_10m: 6.8,
-    });
+    mockFetchSequence({ temperature_2m: 78.4, weather_code: 1, relative_humidity_2m: 55.2, wind_speed_10m: 6.8 });
 
     const interaction = makeInteraction();
     await execute(interaction as never);

--- a/apps/bot/src/commands/weather.ts
+++ b/apps/bot/src/commands/weather.ts
@@ -1,12 +1,18 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import type { ChatInputCommandInteraction } from 'discord.js';
+import { config } from '../config';
+import { currentIcNightKey } from '../services/icNightTracker';
 
 // Nashville, TN — the only location this command supports for now.
 const LATITUDE = 36.1627;
 const LONGITUDE = -86.7816;
 
-const CACHE_TTL_MS = 10 * 60 * 1000;
-let cache: { fetchedAt: number; data: OpenMeteoCurrent } | null = null;
+// An IC night runs 2 weeks IRL (matches the sunset passage-of-time event —
+// see PASSAGE_SUNSET_MESSAGE), so refetching weather on every call would let
+// it swing wildly within a single "night," breaking the narrative. Instead
+// the weather is locked in at the start of each IC night and held steady
+// until the next one, keyed by currentIcNightKey rather than a wall-clock TTL.
+let cache: { nightKey: string; data: OpenMeteoCurrent } | null = null;
 
 // https://open-meteo.com/en/docs — WMO weather interpretation codes.
 const WEATHER_CODES: Record<number, { label: string; emoji: string }> = {
@@ -56,11 +62,18 @@ export function __resetWeatherCacheForTests() {
   cache = null;
 }
 
-async function fetchCurrentWeather(): Promise<OpenMeteoCurrent> {
-  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
-    return cache.data;
-  }
+function sunsetSchedule() {
+  return {
+    timezone: config.passageOfTimeTimezone,
+    weekdayLocal: config.passageSunsetWeekdayLocal,
+    hourLocal: config.passageSunsetHourLocal,
+    minuteLocal: config.passageSunsetMinuteLocal,
+    anchorDate: config.passageSunsetAnchorDate,
+    cadenceWeeks: 2,
+  };
+}
 
+async function fetchOpenMeteo(): Promise<OpenMeteoCurrent> {
   const url =
     `https://api.open-meteo.com/v1/forecast?latitude=${LATITUDE}&longitude=${LONGITUDE}` +
     '&current=temperature_2m,weather_code,relative_humidity_2m,wind_speed_10m' +
@@ -71,8 +84,27 @@ async function fetchCurrentWeather(): Promise<OpenMeteoCurrent> {
     throw new Error(`Open-Meteo request failed: ${res.status}`);
   }
   const body = (await res.json()) as { current: OpenMeteoCurrent };
-  cache = { fetchedAt: Date.now(), data: body.current };
   return body.current;
+}
+
+/**
+ * Returns weather locked to the current IC night, refetching only when the
+ * night key changes. If no IC night has started yet (fresh install, or
+ * `now` predates the sunset anchor date), there's nothing to lock to, so
+ * this falls back to fetching live every call.
+ */
+export async function fetchCurrentWeather(now: Date = new Date()): Promise<OpenMeteoCurrent> {
+  const nightKey = currentIcNightKey(now, sunsetSchedule());
+
+  if (nightKey && cache && cache.nightKey === nightKey) {
+    return cache.data;
+  }
+
+  const data = await fetchOpenMeteo();
+  if (nightKey) {
+    cache = { nightKey, data };
+  }
+  return data;
 }
 
 export const data = new SlashCommandBuilder()
@@ -102,7 +134,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
       { name: 'Wind', value: `${Math.round(current.wind_speed_10m)} mph`, inline: true },
     )
     .setColor(0x3987e5)
-    .setFooter({ text: 'via Open-Meteo' });
+    .setFooter({ text: "Locked in for tonight's IC night • via Open-Meteo" });
 
   await interaction.editReply({ embeds: [embed] });
 }

--- a/apps/bot/src/services/icNightTracker.ts
+++ b/apps/bot/src/services/icNightTracker.ts
@@ -1,0 +1,60 @@
+import { daysBetweenUtc, localParts, toDateOnly } from './passageOfTimeService';
+
+export type SunsetSchedule = {
+  timezone: string;
+  weekdayLocal: number;
+  hourLocal: number;
+  minuteLocal: number;
+  anchorDate: string;
+  cadenceWeeks: number;
+};
+
+/**
+ * The local calendar date (YYYY-MM-DD) of the most recent sunset event at or
+ * before `now`, or null if the first sunset hasn't happened yet (fresh
+ * install, or `now` predates anchorDate). Sunset starts an IC night that
+ * runs for `cadenceWeeks` weeks (see PASSAGE_SUNSET_MESSAGE) -- this key
+ * changes exactly when a new IC night begins, so anything that should stay
+ * stable for the length of a night (e.g. cached weather) can key off it
+ * instead of a wall-clock TTL.
+ */
+export function currentIcNightKey(now: Date, schedule: SunsetSchedule): string | null {
+  const local = localParts(now, schedule.timezone);
+  const today = toDateOnly(local.dateKey);
+  const anchor = toDateOnly(schedule.anchorDate);
+  if (!today || !anchor || schedule.cadenceWeeks < 1) {
+    return null;
+  }
+
+  // Mirrors PassageOfTimeService's tick guard (parts.weekday !== event.weekdayLocal):
+  // every cadence-cycle date shares anchor's weekday (cycles are multiples of
+  // 7 days), so if anchor itself doesn't land on weekdayLocal, the real
+  // sunset event never fires and there's no night to key off.
+  if (anchor.getUTCDay() !== schedule.weekdayLocal) {
+    return null;
+  }
+
+  const delta = daysBetweenUtc(today, anchor);
+  if (delta < 0) {
+    return null;
+  }
+
+  const cycleDays = schedule.cadenceWeeks * 7;
+  let daysIntoCycle = delta % cycleDays;
+
+  const beforeSunsetTimeToday =
+    daysIntoCycle === 0 &&
+    (local.hour < schedule.hourLocal || (local.hour === schedule.hourLocal && local.minute < schedule.minuteLocal));
+
+  if (beforeSunsetTimeToday) {
+    // Today is a cadence day, but the sunset hour hasn't happened yet --
+    // the current night (if any) is still the previous cycle.
+    if (delta - cycleDays < 0) {
+      return null;
+    }
+    daysIntoCycle += cycleDays;
+  }
+
+  const nightStart = new Date(today.getTime() - daysIntoCycle * 24 * 60 * 60 * 1000);
+  return nightStart.toISOString().slice(0, 10);
+}

--- a/apps/bot/src/services/passageOfTimeService.ts
+++ b/apps/bot/src/services/passageOfTimeService.ts
@@ -79,7 +79,7 @@ function writeState(state: ServiceState) {
   fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
 }
 
-function toDateOnly(value: string): Date | null {
+export function toDateOnly(value: string): Date | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     return null;
   }
@@ -87,12 +87,12 @@ function toDateOnly(value: string): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function daysBetweenUtc(a: Date, b: Date): number {
+export function daysBetweenUtc(a: Date, b: Date): number {
   const msPerDay = 24 * 60 * 60 * 1000;
   return Math.floor((a.getTime() - b.getTime()) / msPerDay);
 }
 
-function localParts(now: Date, timezone: string): { dateKey: string; weekday: number; hour: number; minute: number } {
+export function localParts(now: Date, timezone: string): { dateKey: string; weekday: number; hour: number; minute: number } {
   const parts = new Intl.DateTimeFormat('en-CA', {
     timeZone: timezone,
     year: 'numeric',


### PR DESCRIPTION
## Summary
- An IC night runs 2 IRL weeks (see `PASSAGE_SUNSET_MESSAGE`), so the previous 10-minute wall-clock cache would let `/weather` swing wildly within a single night — breaking the narrative. Weather is now fetched once at the start of each IC night and held steady until the next one.
- Adds `icNightTracker.ts` (`currentIcNightKey`), a pure function computing the local calendar date of the most recent sunset event — reusing the exact same cadence logic `passageOfTimeService` already uses to actually announce nights (anchor date + 2-week cadence + weekday/hour/minute guards), rather than duplicating it. Exported `toDateOnly`/`daysBetweenUtc`/`localParts` from `passageOfTimeService.ts` for reuse.
- `weather.ts` now caches by night key instead of timestamp. Before any IC night has started (fresh install, or `now` predates the sunset anchor date), there's nothing to lock to, so it falls back to fetching live every call.
- Verified prod env (`PASSAGE_SUNSET_*` on ursula) is already configured, so this engages immediately on deploy.

## Test plan
- [x] `npm run check` passes (lint, format, typecheck, 337 tests, build)
- [x] New `icNightTracker.test.ts`: night key stability across a full cadence window, transition at the next sunset, pre-anchor/misconfigured-weekday edge cases
- [x] New `weather.test.ts` cases: same-night calls share one fetch, crossing into the next night triggers a refetch, pre-first-night falls back to always-live
- [ ] After deploy, run `/weather` and confirm the footer reads "Locked in for tonight's IC night"

🤖 Generated with [Claude Code](https://claude.com/claude-code)