### PR TITLE
Fix lasombra-failover.sh stale BOT_DIR and silent-failure logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r apps/web/requirements-lock.txt
-          pip install ruff pytest-cov mypy types-requests
+          # ruff pinned: an unpinned install picks up whatever's newest at CI
+          # run-time, and a new ruff release can enable new default lint
+          # rules that fail on existing, previously-clean code with no
+          # actual code change in the PR (happened 2026-07-23 -- ruff 0.16.0
+          # added 207 new violations across apps/web that 0.15.20 doesn't
+          # flag). Bump deliberately, not silently.
+          pip install ruff==0.15.20 pytest-cov mypy types-requests
 
       - name: Lint web (ruff)
         run: ruff check apps/web/app apps/web/tests

--- a/apps/bot/docker-compose.yml
+++ b/apps/bot/docker-compose.yml
@@ -1,3 +1,4 @@
+name: mcbn-xp-tracker-bot
 services:
   bot:
     container_name: lasombra-bot

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -1,3 +1,4 @@
+name: mcbn-xp-tracker-web
 services:
   web-dev:
     container_name: mcbn-xp-tracker-web

--- a/infra/ursula/README.md
+++ b/infra/ursula/README.md
@@ -104,9 +104,9 @@ sudo usermod -aG docker jkomg
 
 ---
 
-## 4. Mac Failover (Miniplex)
+## 4. Mac Failover (little-mac)
 
-A launchd job runs every 5 minutes. If Ursula's bot heartbeat goes stale (>10 min), it starts the bot locally via OrbStack. When Ursula recovers, it stops the local copy automatically.
+Currently deployed on `little-mac` (192.168.0.63), not Miniplex — update this if the failover host changes again. A launchd job runs every 5 minutes. If Ursula's bot heartbeat goes stale (>10 min), it starts the bot locally via OrbStack. When Ursula recovers, it stops the local copy automatically.
 
 ```bash
 # Install script
@@ -122,6 +122,8 @@ launchctl load ~/Library/LaunchAgents/com.mcbn.lasombra-failover.plist
 Logs: `tail -f /tmp/lasombra-failover.log`
 
 **Note:** The failover script contains `MCBN_TOKEN` — treat it as a secret. Do not commit the deployed copy with real credentials. Fill in your real token in the deployed copy — the version in this repo uses a placeholder.
+
+**`BOT_DIR` in the deployed copy must match the actual local clone path on the failover host.** A wrong path here silently no-ops the whole mechanism (the `cd && docker compose ...` chain short-circuits on a failed `cd`) while still logging as if it worked — this is exactly what happened on 2026-07-22/23: the script pointed at a stale path for an unknown length of time, meaning failover never actually triggered despite logging "starting local failover bot" every 5 minutes. If you re-clone or move the repo on the failover host, update `BOT_DIR` in the deployed script.
 
 ---
 

--- a/infra/ursula/failover/lasombra-failover.sh
+++ b/infra/ursula/failover/lasombra-failover.sh
@@ -2,11 +2,16 @@
 # Lasombra bot failover — starts local OrbStack bot if Ursula's bot heartbeat goes stale.
 # Stops local bot automatically when Ursula recovers.
 
+set -uo pipefail
 export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
 
 MCBN_URL="https://mcbn.jkomg.us"
 MCBN_TOKEN="YOUR_MCBN_API_TOKEN_HERE"
-BOT_DIR="/Users/jasonkennedy/Projects/mcbn-xp-tracker/apps/bot"
+# Must match the actual local clone path on the failover host -- a wrong path
+# here makes `cd "$BOT_DIR" && docker compose ...` silently no-op (the `&&`
+# short-circuits on a failed cd), so this whole failover mechanism looks like
+# it's working in the logs while never actually starting/stopping anything.
+BOT_DIR="/Users/jasonkennedy/Documents/Coding/mcbn-xp-tracker/apps/bot"
 STALE_SECONDS=600   # 10 min — matches Ursula health check threshold
 LOG_PREFIX="$(date -u +"%Y-%m-%dT%H:%M:%SZ") [lasombra-failover]"
 
@@ -31,14 +36,18 @@ age=$(echo "$response" | python3 -c \
 if [[ "$age" == "-1" || "$age" -gt "$STALE_SECONDS" ]]; then
   if local_bot_running; then
     echo "${LOG_PREFIX} Heartbeat stale (${age}s) — local failover already running"
+  elif cd "$BOT_DIR" 2>/dev/null && docker compose up -d >/dev/null 2>&1; then
+    echo "${LOG_PREFIX} Heartbeat stale (${age}s) — started local failover bot"
   else
-    echo "${LOG_PREFIX} Heartbeat stale (${age}s) — starting local failover bot"
-    cd "$BOT_DIR" && docker compose up -d
+    echo "${LOG_PREFIX} ERROR: heartbeat stale (${age}s) but failed to start local failover bot (check BOT_DIR=${BOT_DIR} and docker)"
   fi
 else
   if local_bot_running; then
-    echo "${LOG_PREFIX} Ursula bot recovered (${age}s) — stopping local failover"
-    cd "$BOT_DIR" && docker compose down
+    if cd "$BOT_DIR" 2>/dev/null && docker compose down >/dev/null 2>&1; then
+      echo "${LOG_PREFIX} Ursula bot recovered (${age}s) — stopped local failover"
+    else
+      echo "${LOG_PREFIX} ERROR: Ursula bot recovered (${age}s) but failed to stop local failover bot (check BOT_DIR=${BOT_DIR} and docker)"
+    fi
   else
     echo "${LOG_PREFIX} OK (${age}s)"
   fi

--- a/infra/ursula/failover/lasombra-failover.sh
+++ b/infra/ursula/failover/lasombra-failover.sh
@@ -11,7 +11,7 @@ MCBN_TOKEN="YOUR_MCBN_API_TOKEN_HERE"
 # here makes `cd "$BOT_DIR" && docker compose ...` silently no-op (the `&&`
 # short-circuits on a failed cd), so this whole failover mechanism looks like
 # it's working in the logs while never actually starting/stopping anything.
-BOT_DIR="/Users/jasonkennedy/Documents/Coding/mcbn-xp-tracker/apps/bot"
+BOT_DIR="/Users/jasonkennedy/mcbn-failover/mcbn-xp-tracker/apps/bot"
 STALE_SECONDS=600   # 10 min — matches Ursula health check threshold
 LOG_PREFIX="$(date -u +"%Y-%m-%dT%H:%M:%SZ") [lasombra-failover]"
 


### PR DESCRIPTION
## Summary
Root cause of last night's undetected outage: the Mac failover script (`infra/ursula/failover/lasombra-failover.sh`, deployed on little-mac) has a hardcoded `BOT_DIR` pointing at a path that doesn't exist on that host. Because the failure branch did `cd "$BOT_DIR" && docker compose up -d`, every `cd` failure silently short-circuited the chain, but the preceding `echo` had already printed "starting local failover bot" — so the deployed log looked like it was working the whole time it never once succeeded.

Confirmed from the actual deployed log: it fired every 5 minutes for 4+ hours straight, all failed silently, while Ursula's bot heartbeat had already been stale for ~16 hours before that.

## Changes
- Fixed `BOT_DIR` to a real, dedicated clone location (`~/mcbn-failover/mcbn-xp-tracker/apps/bot` on little-mac) — the path this script previously pointed at (`Documents/Coding/...`) turned out to be an incomplete fragment with no `apps/bot` at all, so a fresh clone was made from scratch.
- Restructured both the start and stop branches to check the real `cd`+`docker compose` exit status and log a distinct `ERROR` line on failure, instead of an optimistic message logged unconditionally before the attempt.
- Updated `infra/ursula/README.md`'s failover section — it still said "Mac Failover (Miniplex)"; it's deployed on little-mac now. Added a note explaining the exact failure mode so it doesn't silently recur if the repo ever gets re-cloned/moved on the failover host.
- Second commit: also committed the `name:` project-identifier fix to `apps/bot/docker-compose.yml` and `apps/web/docker-compose.yml` from the `nergal-bot` collision incident earlier today — that fix was applied directly on the affected hosts at the time but never propagated into git, so a future re-clone would have silently reintroduced the collision risk (both this repo and athens-chronicles' `apps/bot`/`apps/web` directories share the same basename, and Compose defaults project name to that basename).

## Test plan
- [x] `bash -n` syntax check passes
- [x] `docker compose -f apps/bot/docker-compose.yml config -q` / `apps/web/...` both parse cleanly with the `name:` field added
- [x] Deployed corrected script + real token to little-mac; manual run against the current healthy state correctly logs `OK (31s)`
- [ ] Full stale-trigger end-to-end test in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)