### PR TITLE
Embed current weather in the sunset passage-of-time announcement

### DIFF
--- a/apps/bot/src/__tests__/passageOfTimeNewNightBroadcast.test.ts
+++ b/apps/bot/src/__tests__/passageOfTimeNewNightBroadcast.test.ts
@@ -1,5 +1,12 @@
 import { ChannelType } from 'discord.js';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// passageOfTimeService.ts transitively imports commands/weather.ts, which
+// imports config.ts -- config.ts eagerly validates process.env at module
+// load, so any test importing from passageOfTimeService.ts needs this
+// mocked, even one (like this file) that never touches weather/config.
+vi.mock('../config', () => ({ config: {} }));
+
 import { filterNewNightTargets } from '../services/passageOfTimeService';
 
 const CATEGORY_A = 'category-a';

--- a/apps/bot/src/__tests__/passageOfTimeSunsetWeather.test.ts
+++ b/apps/bot/src/__tests__/passageOfTimeSunsetWeather.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockWeather = vi.hoisted(() => ({
+  fetchCurrentWeather: vi.fn(),
+  formatWeatherLine: vi.fn(),
+}));
+
+vi.mock('../commands/weather', () => mockWeather);
+
+import { appendSunsetWeather } from '../services/passageOfTimeService';
+
+beforeEach(() => {
+  mockWeather.fetchCurrentWeather.mockReset();
+  mockWeather.formatWeatherLine.mockReset();
+});
+
+describe('appendSunsetWeather', () => {
+  it('fetches weather for the given moment and appends the formatted line', async () => {
+    const now = new Date('2026-07-24T18:00:00Z');
+    const current = { temperature_2m: 80, weather_code: 0, relative_humidity_2m: 40, wind_speed_10m: 5 };
+    mockWeather.fetchCurrentWeather.mockResolvedValue(current);
+    mockWeather.formatWeatherLine.mockReturnValue("☀️ Tonight's weather in Nashville: Clear sky, 80°F");
+
+    const result = await appendSunsetWeather('The night begins.', now);
+
+    expect(mockWeather.fetchCurrentWeather).toHaveBeenCalledWith(now);
+    expect(mockWeather.formatWeatherLine).toHaveBeenCalledWith(current);
+    expect(result).toBe("The night begins.\n\n☀️ Tonight's weather in Nashville: Clear sky, 80°F");
+  });
+
+  it('returns the original content unchanged if the weather fetch fails, without throwing', async () => {
+    mockWeather.fetchCurrentWeather.mockRejectedValue(new Error('Open-Meteo request failed: 500'));
+
+    const result = await appendSunsetWeather('The night begins.', new Date());
+
+    expect(result).toBe('The night begins.');
+  });
+});

--- a/apps/bot/src/__tests__/weather.test.ts
+++ b/apps/bot/src/__tests__/weather.test.ts
@@ -15,6 +15,7 @@ import {
   describeWeatherCode,
   execute,
   fetchCurrentWeather,
+  formatWeatherLine,
 } from '../commands/weather';
 
 function makeInteraction() {
@@ -61,6 +62,18 @@ describe('describeWeatherCode', () => {
 
   it('falls back to an unknown-conditions placeholder for an unrecognized code', () => {
     expect(describeWeatherCode(-1)).toEqual({ label: 'Unknown conditions', emoji: '❓' });
+  });
+});
+
+describe('formatWeatherLine', () => {
+  it('formats a short flavor-text line for the sunset announcement', () => {
+    const line = formatWeatherLine({
+      temperature_2m: 58.6,
+      weather_code: 61,
+      relative_humidity_2m: 70,
+      wind_speed_10m: 8,
+    });
+    expect(line).toBe("🌧️ Tonight's weather in Nashville: Slight rain, 59°F");
   });
 });
 

--- a/apps/bot/src/commands/weather.ts
+++ b/apps/bot/src/commands/weather.ts
@@ -57,6 +57,12 @@ export function describeWeatherCode(code: number): { label: string; emoji: strin
   return WEATHER_CODES[code] ?? { label: 'Unknown conditions', emoji: '❓' };
 }
 
+/** Short flavor-text line for embedding in the sunset passage-of-time announcement. */
+export function formatWeatherLine(current: OpenMeteoCurrent): string {
+  const { label, emoji } = describeWeatherCode(current.weather_code);
+  return `${emoji} Tonight's weather in Nashville: ${label}, ${Math.round(current.temperature_2m)}°F`;
+}
+
 /** Test-only: the module-level cache otherwise leaks across test cases. */
 export function __resetWeatherCacheForTests() {
   cache = null;

--- a/apps/bot/src/commands/xp.ts
+++ b/apps/bot/src/commands/xp.ts
@@ -14,7 +14,7 @@ import { errorToMessage, logEvent } from '../logger';
 import { SPEND_CATEGORY_CHOICES } from '../sharedContract';
 import { buildClaimReminderActionRow, buildClaimReminderText } from '../services/claimReminderService';
 import { findCubbyChannel, normalizeChannelName } from '../services/cubbyChannels';
-import { getPassageMessage } from '../services/passageOfTimeService';
+import { appendSunsetWeather, getPassageMessage } from '../services/passageOfTimeService';
 import type { XpClaimCategory, XpSpendCategory } from '../types';
 import { parseMessageLink } from '../utils/linkValidator';
 import { calculateXpCost } from '../xpRules';
@@ -583,7 +583,11 @@ export async function execute(interaction: ChatInputCommandInteraction, { adapte
     }
     const eventName = interaction.options.getString('event', true) as 'sunrise' | 'sunset' | 'downtime';
     try {
-      await target.send({ content: getPassageMessage(eventName) });
+      let content = getPassageMessage(eventName);
+      if (eventName === 'sunset') {
+        content = await appendSunsetWeather(content, new Date());
+      }
+      await target.send({ content });
     } catch (error) {
       await interaction.reply({
         content:

--- a/apps/bot/src/services/dateCadence.ts
+++ b/apps/bot/src/services/dateCadence.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure local-timezone date helpers shared by passageOfTimeService.ts and
+ * icNightTracker.ts. Kept in a separate neutral module so neither of those
+ * two needs to import from the other -- passageOfTimeService.ts also needs
+ * to import from commands/weather.ts (to embed weather in the sunset
+ * announcement), and weather.ts imports icNightTracker.ts, so
+ * passageOfTimeService -> icNightTracker -> passageOfTimeService would be a
+ * circular import if these lived in passageOfTimeService.ts.
+ */
+
+export function toDateOnly(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function daysBetweenUtc(a: Date, b: Date): number {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.floor((a.getTime() - b.getTime()) / msPerDay);
+}
+
+export function localParts(now: Date, timezone: string): { dateKey: string; weekday: number; hour: number; minute: number } {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(now);
+  const pick = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
+  const dateKey = `${pick('year')}-${pick('month')}-${pick('day')}`;
+  const hour = Number.parseInt(pick('hour'), 10);
+  const minute = Number.parseInt(pick('minute'), 10);
+  const weekdayMap: Record<string, number> = {
+    sun: 0,
+    mon: 1,
+    tue: 2,
+    wed: 3,
+    thu: 4,
+    fri: 5,
+    sat: 6,
+  };
+  const weekday = weekdayMap[pick('weekday').toLowerCase()] ?? -1;
+  return {
+    dateKey,
+    weekday,
+    hour: Number.isFinite(hour) ? hour : 0,
+    minute: Number.isFinite(minute) ? minute : 0,
+  };
+}

--- a/apps/bot/src/services/icNightTracker.ts
+++ b/apps/bot/src/services/icNightTracker.ts
@@ -1,4 +1,4 @@
-import { daysBetweenUtc, localParts, toDateOnly } from './passageOfTimeService';
+import { daysBetweenUtc, localParts, toDateOnly } from './dateCadence';
 
 export type SunsetSchedule = {
   timezone: string;

--- a/apps/bot/src/services/passageOfTimeService.ts
+++ b/apps/bot/src/services/passageOfTimeService.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { AttachmentBuilder, ChannelType, type Client, type GuildTextBasedChannel, type TextChannel, type NewsChannel } from 'discord.js';
+import { fetchCurrentWeather, formatWeatherLine } from '../commands/weather';
 import { errorToMessage, logEvent } from '../logger';
 import { liveConfig } from '../liveConfig';
+import { daysBetweenUtc, localParts, toDateOnly } from './dateCadence';
 
 type ScheduledEventConfig = {
   name: 'sunrise' | 'sunset' | 'downtime';
@@ -79,52 +81,6 @@ function writeState(state: ServiceState) {
   fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
 }
 
-export function toDateOnly(value: string): Date | null {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return null;
-  }
-  const date = new Date(`${value}T00:00:00.000Z`);
-  return Number.isNaN(date.getTime()) ? null : date;
-}
-
-export function daysBetweenUtc(a: Date, b: Date): number {
-  const msPerDay = 24 * 60 * 60 * 1000;
-  return Math.floor((a.getTime() - b.getTime()) / msPerDay);
-}
-
-export function localParts(now: Date, timezone: string): { dateKey: string; weekday: number; hour: number; minute: number } {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    weekday: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).formatToParts(now);
-  const pick = (type: string) => parts.find((p) => p.type === type)?.value ?? '';
-  const dateKey = `${pick('year')}-${pick('month')}-${pick('day')}`;
-  const hour = Number.parseInt(pick('hour'), 10);
-  const minute = Number.parseInt(pick('minute'), 10);
-  const weekdayMap: Record<string, number> = {
-    sun: 0,
-    mon: 1,
-    tue: 2,
-    wed: 3,
-    thu: 4,
-    fri: 5,
-    sat: 6,
-  };
-  const weekday = weekdayMap[pick('weekday').toLowerCase()] ?? -1;
-  return {
-    dateKey,
-    weekday,
-    hour: Number.isFinite(hour) ? hour : 0,
-    minute: Number.isFinite(minute) ? minute : 0,
-  };
-}
-
 function isCadenceDate(localDateKey: string, anchorDate: string, cadenceWeeks: number): boolean {
   const localDate = toDateOnly(localDateKey);
   const anchor = toDateOnly(anchorDate);
@@ -141,6 +97,24 @@ function isCadenceDate(localDateKey: string, anchorDate: string, cadenceWeeks: n
 function roleMentions(roleIds: string[]): string {
   const ids = roleIds.map((v) => String(v).trim()).filter((v) => /^\d{17,20}$/.test(v));
   return ids.map((id) => `<@&${id}>`).join(' ');
+}
+
+/**
+ * Appends a current-conditions line to the sunset announcement, fetching
+ * weather at the exact moment the new IC night begins (rather than lazily
+ * on whoever first runs /weather) -- see icNightTracker.ts. Best-effort: a
+ * weather-service hiccup must never block or fail the sunset announcement
+ * itself, so any error here is logged and swallowed, returning the
+ * original content unchanged.
+ */
+export async function appendSunsetWeather(content: string, now: Date): Promise<string> {
+  try {
+    const current = await fetchCurrentWeather(now);
+    return `${content}\n\n${formatWeatherLine(current)}`;
+  } catch (err) {
+    logEvent('warn', 'passage_sunset_weather_failed', { error: errorToMessage(err) });
+    return content;
+  }
 }
 
 function isSendableChannelType(type: ChannelType): boolean {
@@ -322,7 +296,10 @@ export class PassageOfTimeService {
         }
 
         const mentionPrefix = this.config.testMode ? '' : roleMentions(this.config.mentionRoleIds);
-        const content = mentionPrefix ? `${mentionPrefix}\n\n${event.body}` : event.body;
+        let content = mentionPrefix ? `${mentionPrefix}\n\n${event.body}` : event.body;
+        if (event.name === 'sunset') {
+          content = await appendSunsetWeather(content, now);
+        }
 
         if (event.imageFile && fs.existsSync(event.imageFile)) {
           const filename = path.basename(event.imageFile);


### PR DESCRIPTION
## Summary
- Weather now fetches at the exact moment the sunset event fires (not lazily whenever someone first runs `/weather`) and is embedded as a flavor-text line in the sunset announcement itself, e.g.: `🌧️ Tonight's weather in Nashville: Slight rain, 59°F`.
- This fetch *is* the cache-populating call for the night (`fetchCurrentWeather`'s night-locked cache from #374), so `/weather` and the sunset announcement now always agree on "tonight's weather" — whichever fires first for a given night populates the cache the other reads from.
- Best-effort: a weather-service hiccup is logged (`passage_sunset_weather_failed`) and swallowed rather than blocking the sunset announcement from posting.
- Also wired into `/xp test-passage`'s sunset case, so staff testing the announcement see the same content players will.

## A refactor this required
Having `passageOfTimeService.ts` import `commands/weather.ts` would have created a circular import (`weather.ts → icNightTracker.ts → passageOfTimeService.ts → weather.ts`), since `weather.ts` already depends on `icNightTracker.ts`, which depends on `passageOfTimeService.ts`'s date-math helpers. Extracted `toDateOnly`/`daysBetweenUtc`/`localParts` into a new neutral `dateCadence.ts` that both now import from, breaking the cycle. Verified clean at runtime (not just via tsc/vitest module resolution) by `require()`-ing the compiled output in both possible load orders.

## Test plan
- [x] `npm run check` passes (lint, format, typecheck, 340 tests, build)
- [x] New `formatWeatherLine` test, new `appendSunsetWeather` tests (success + weather-fetch-failure paths)
- [x] Fixed `passageOfTimeNewNightBroadcast.test.ts`, which broke from the new transitive `../config` dependency (config.ts validates env eagerly at module load) — added the same mock pattern already used elsewhere
- [x] Manually verified no circular-import breakage by requiring the compiled dist output in both orders
- [ ] After deploy, trigger `/xp test-passage event:sunset` in #bot-testing and confirm the weather line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)