### PR TITLE
Recover cloud-spend feature: land PR #378's actual content on main

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -27,6 +27,8 @@ DISCORD_REDIRECT_URI=http://127.0.0.1:5001/auth/callback
 ALLOWED_DISCORD_IDS=123456789012345678
 # Comma-separated Discord IDs allowed to edit Settings at runtime (subset of ALLOWED_DISCORD_IDS)
 SETTINGS_ADMIN_DISCORD_IDS=
+# Separate allowlist for personal billing data; normally only the owner ID.
+CLOUD_SPEND_ADMIN_DISCORD_IDS=
 
 # Shared bearer token for bot API routes under /api/*
 WEB_APP_API_TOKEN=change-me-bot-api-token
@@ -65,3 +67,8 @@ LOCAL_STATUS_LOG_LINES=120
 # GCP project the Cloud Run web service deploys to (see deploy.sh). Only
 # used to build "View in Cloud Logs" deep links on the Error Alerts page.
 # GCP_PROJECT_ID=mcbn-xp-tracker
+# Optional owner-only Cloud Spend pane. Billing export table is project.dataset.table.
+# CLOUD_SPEND_BILLING_PROJECT_ID=mcbn-xp-tracker
+# CLOUD_SPEND_BILLING_TABLE=
+# CLOUD_SPEND_CACHE_TTL_SECONDS=21600
+# CLOUD_SPEND_MAX_BYTES_BILLED=1000000000

--- a/apps/web/app/auth.py
+++ b/apps/web/app/auth.py
@@ -124,6 +124,14 @@ def is_settings_admin() -> bool:
     return _get_db_staff_role(str(discord_id)) == 'administrator'
 
 
+def is_cloud_spend_admin() -> bool:
+    """Check the separate owner allowlist for personal billing data."""
+    discord_id = session.get('discord_id', '')
+    return bool(discord_id) and str(discord_id) in current_app.config.get(
+        'CLOUD_SPEND_ADMIN_DISCORD_IDS', set()
+    )
+
+
 def is_staff() -> bool:
     """Check if the current session user is staff.
 

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from flask import (
     Blueprint, current_app, flash, redirect, render_template, request, session, url_for
 )
-from app.auth import require_staff, is_settings_admin
+from app.auth import require_staff, is_cloud_spend_admin, is_settings_admin
 from app.app_settings import (
     EDITABLE_KEYS,
     delete_app_setting,
@@ -80,6 +80,9 @@ SETTINGS_NAV = [
         {'id': 'web-integrations', 'label': 'Integrations', 'count_key': 'web_integrations'},
         {'id': 'web-chronicle', 'label': 'Chronicle'},
     ]},
+    {'group': 'Owner', 'links': [
+        {'id': 'cloud-spend', 'label': 'Cloud Spend'},
+    ]},
 ]
 VALID_SECTIONS = {item['id'] for group in SETTINGS_NAV for item in group['links']}
 
@@ -145,6 +148,9 @@ def index():
     can_edit = True
     active_section = request.args.get('section', 'overview')
     if active_section not in VALID_SECTIONS:
+        active_section = 'overview'
+    cloud_spend_admin = is_cloud_spend_admin()
+    if active_section == 'cloud-spend' and not cloud_spend_admin:
         active_section = 'overview'
 
     def _eff_bool(key, env_default):
@@ -1011,6 +1017,8 @@ def index():
     for i in integrations:
         search_index.append({'label': i['label'], 'description': i['description'], 'section': 'web-integrations', 'section_label': 'Web App · Integrations'})
     search_index.append({'label': 'Chronicle Tenets', 'description': 'Chronicle-wide tenets shown on player sheets.', 'section': 'web-chronicle', 'section_label': 'Web App · Chronicle'})
+    if cloud_spend_admin:
+        search_index.append({'label': 'Cloud Spend', 'description': 'Monthly GCP costs compared with captured application errors.', 'section': 'cloud-spend', 'section_label': 'Owner · Cloud Spend'})
     for f in bot_flags:
         search_index.append({'label': f['label'], 'description': f['description'], 'section': 'bot-flags', 'section_label': 'Bot · Feature Flags'})
     for t in bot_tuning:
@@ -1022,10 +1030,18 @@ def index():
         for sub in cmd['subcommands']:
             search_index.append({'label': f"{cmd['label']} {sub['label']}", 'description': sub['description'], 'section': 'bot-commands', 'section_label': 'Bot · Commands'})
 
+    settings_nav = SETTINGS_NAV if cloud_spend_admin else [
+        group for group in SETTINGS_NAV if group['group'] != 'Owner'
+    ]
+    cloud_spend = None
+    if cloud_spend_admin and active_section == 'cloud-spend':
+        from app.cloud_spend import build_snapshot
+        cloud_spend = build_snapshot(cfg, bot_heartbeat_ts)
+
     return render_template(
         'settings/index.html',
         active_section=active_section,
-        settings_nav=SETTINGS_NAV,
+        settings_nav=settings_nav,
         nav_counts=nav_counts,
         search_index=search_index,
         bot_channel_groups=bot_channel_groups,
@@ -1048,6 +1064,7 @@ def index():
         retirement_summary=retirement_summary,
         retirement_next_retry_at=retirement_next_retry_at,
         staff_members=staff_members,
+        cloud_spend=cloud_spend,
     )
 
 

--- a/apps/web/app/cloud_spend.py
+++ b/apps/web/app/cloud_spend.py
@@ -1,0 +1,154 @@
+"""Low-volume, owner-only cloud cost signals for the Settings page.
+
+The billing export is queried as a monthly aggregate and cached in-process.
+This deliberately avoids introducing a BigQuery client dependency or making
+hourly/daily queries from a request handler.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+
+import google.auth
+import requests
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+
+from app.db import AppLogEntry
+
+_BQ_SCOPE = 'https://www.googleapis.com/auth/bigquery'
+_TABLE_RE = re.compile(r'^[A-Za-z0-9_.-]+$')
+_CACHE: dict[str, tuple[float, dict]] = {}
+
+
+class CloudSpendUnavailable(RuntimeError):
+    """Raised when billing export data is not configured or cannot be read."""
+
+
+def _credentials(config):
+    raw = config.get('GOOGLE_CREDENTIALS_JSON', '')
+    filename = config.get('GOOGLE_CREDENTIALS_FILE', '')
+    if raw:
+        return service_account.Credentials.from_service_account_info(
+            json.loads(raw), scopes=[_BQ_SCOPE]
+        )
+    if filename:
+        try:
+            return service_account.Credentials.from_service_account_file(
+                filename, scopes=[_BQ_SCOPE]
+            )
+        except (FileNotFoundError, ValueError):
+            pass
+    credentials, _ = google.auth.default(scopes=[_BQ_SCOPE])
+    return credentials
+
+
+def fetch_monthly_gcp_costs(config, months: int = 12) -> list[dict]:
+    """Return monthly net GCP cost from a configured Billing Export table."""
+    table = str(config.get('CLOUD_SPEND_BILLING_TABLE', '')).strip().strip('`')
+    if not table or not _TABLE_RE.fullmatch(table) or table.count('.') != 2:
+        raise CloudSpendUnavailable(
+            'Set CLOUD_SPEND_BILLING_TABLE to project.dataset.table.'
+        )
+
+    project = str(config.get('CLOUD_SPEND_BILLING_PROJECT_ID', '')).strip()
+    if not project or not _TABLE_RE.fullmatch(project):
+        raise CloudSpendUnavailable('Billing project is not configured.')
+
+    query = f"""
+        SELECT FORMAT_DATE('%Y-%m', DATE(usage_start_time)) AS month,
+               SUM(cost) + SUM((SELECT COALESCE(SUM(c.amount), 0)
+                                FROM UNNEST(credits) AS c)) AS net_cost
+        FROM `{table}`
+        WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {int(months)} MONTH)
+        GROUP BY month
+        ORDER BY month
+    """
+    credentials = _credentials(config)
+    credentials.refresh(Request())
+    response = requests.post(
+        f'https://bigquery.googleapis.com/bigquery/v2/projects/{project}/queries',
+        headers={'Authorization': f'Bearer {credentials.token}'},
+        json={
+            'query': query,
+            'useLegacySql': False,
+            'timeoutMs': int(config.get('CLOUD_SPEND_QUERY_TIMEOUT_MS', 20000)),
+            'maximumBytesBilled': int(config.get('CLOUD_SPEND_MAX_BYTES_BILLED', 1_000_000_000)),
+        },
+        timeout=float(config.get('CLOUD_SPEND_HTTP_TIMEOUT_SECONDS', 25)),
+    )
+    if response.status_code >= 400:
+        raise CloudSpendUnavailable(f'Billing query failed ({response.status_code}).')
+    payload = response.json()
+    if not payload.get('jobComplete', False):
+        raise CloudSpendUnavailable('Billing query did not complete within the request budget.')
+
+    values = []
+    for row in payload.get('rows', []):
+        fields = row.get('f', [])
+        if len(fields) < 2:
+            continue
+        try:
+            amount = Decimal(fields[1].get('v') or '0')
+        except InvalidOperation:
+            continue
+        values.append({'month': fields[0].get('v', ''), 'cost': float(amount)})
+    return values
+
+
+def _cached_costs(config) -> tuple[list[dict], str | None]:
+    table = str(config.get('CLOUD_SPEND_BILLING_TABLE', '')).strip()
+    cache_key = table or 'unconfigured'
+    now = time.monotonic()
+    cached = _CACHE.get(cache_key)
+    ttl = int(config.get('CLOUD_SPEND_CACHE_TTL_SECONDS', 21600))
+    if cached and now - cached[0] < ttl:
+        return cached[1]['costs'], cached[1].get('error')
+    try:
+        costs = fetch_monthly_gcp_costs(config)
+        result = {'costs': costs, 'error': None}
+    except Exception as exc:  # The admin page must fail soft if billing is unavailable.
+        result = {'costs': [], 'error': str(exc)}
+    _CACHE[cache_key] = (now, result)
+    return result['costs'], result['error']
+
+
+def build_snapshot(config, heartbeat_ts: str | None = None, months: int = 12) -> dict:
+    """Build monthly cost/error comparison data for the owner-only pane."""
+    costs, billing_error = _cached_costs(config)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=months * 32)
+    errors = Counter()
+    for entry in AppLogEntry.query.filter(AppLogEntry.level == 'error').all():
+        created = entry.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        if created >= cutoff:
+            errors[created.strftime('%Y-%m')] += 1
+
+    now = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    month_keys = []
+    for offset in range(months - 1, -1, -1):
+        month = now.month - offset
+        year = now.year + (month - 1) // 12
+        month = (month - 1) % 12 + 1
+        month_keys.append(f'{year:04d}-{month:02d}')
+    cost_by_month = {item['month']: item['cost'] for item in costs}
+    series = [
+        {'month': key, 'cost': cost_by_month.get(key), 'errors': errors.get(key, 0)}
+        for key in month_keys
+    ]
+    return {
+        'series': series,
+        'billing_configured': not billing_error and bool(
+            str(config.get('CLOUD_SPEND_BILLING_TABLE', '')).strip()
+        ),
+        'billing_error': billing_error,
+        'turso_configured': False,
+        'heartbeat_ts': heartbeat_ts,
+        'fetched_at': datetime.now(timezone.utc).isoformat(timespec='seconds'),
+    }

--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -546,6 +546,52 @@
       </div>
     </section>
 
+    {% if cloud_spend is not none %}
+    {# ═══ OWNER · CLOUD SPEND ═══ #}
+    <section class="settings-pane {{ 'is-active' if active_section == 'cloud-spend' }}" data-section="cloud-spend">
+      <h3 class="settings-pane-title">Owner — Cloud Spend</h3>
+      <p class="settings-pane-subtitle">Monthly GCP billing compared with captured application errors. This pane is restricted to the owner allowlist.</p>
+
+      <div class="settings-overview-grid">
+        <div class="settings-overview-card">
+          <div class="settings-card-header" style="border:none;padding:0;margin-bottom:10px;">Billing export</div>
+          {% if cloud_spend.billing_error %}
+            <span class="badge bg-secondary">Unavailable</span>
+            <p class="small text-muted mt-2 mb-0">{{ cloud_spend.billing_error }}</p>
+          {% else %}
+            <span class="badge bg-success">Monthly data loaded</span>
+            <p class="small text-muted mt-2 mb-0">Cached for several hours; the query is capped at the configured byte budget.</p>
+          {% endif %}
+        </div>
+        <div class="settings-overview-card">
+          <div class="settings-card-header" style="border:none;padding:0;margin-bottom:10px;">Turso</div>
+          <span class="badge bg-secondary">Not connected</span>
+          <p class="small text-muted mt-2 mb-0">Turso account-level billing is intentionally shown as unavailable until its account API is configured.</p>
+        </div>
+      </div>
+
+      <div class="settings-card mt-3" style="padding:16px 18px;">
+        <div class="settings-card-header" style="border:none;padding:0;margin-bottom:8px;">Monthly comparison</div>
+        <p class="small text-muted">Error counts are a correlation signal, not an uptime or causality claim. The current bot heartbeat is shown in Overview.</p>
+        <div class="table-responsive">
+          <table class="table table-sm align-middle mb-0">
+            <thead><tr><th>Month</th><th class="text-end">GCP cost</th><th class="text-end">Captured errors</th></tr></thead>
+            <tbody>
+            {% for item in cloud_spend.series %}
+              <tr>
+                <td>{{ item.month }}</td>
+                <td class="text-end">{% if item.cost is none %}—{% else %}${{ '%.2f'|format(item.cost) }}{% endif %}</td>
+                <td class="text-end">{{ item.errors }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="small text-muted mt-3">Fetched {{ cloud_spend.fetched_at }}. This view does not query hourly or daily billing detail.</div>
+      </div>
+    </section>
+    {% endif %}
+
   </main>
 </div>
 

--- a/apps/web/config.py
+++ b/apps/web/config.py
@@ -49,6 +49,26 @@ class Config:
     SETTINGS_ADMIN_DISCORD_IDS = set(
         uid.strip() for uid in _admin_ids.split(',') if uid.strip()
     )
+    # Separate owner allowlist for the Cloud Spend pane. Keep this narrower
+    # than Settings admins because it exposes personal billing-account data.
+    _cloud_spend_admin_ids = os.environ.get('CLOUD_SPEND_ADMIN_DISCORD_IDS', '')
+    CLOUD_SPEND_ADMIN_DISCORD_IDS = set(
+        uid.strip() for uid in _cloud_spend_admin_ids.split(',') if uid.strip()
+    )
+    CLOUD_SPEND_BILLING_PROJECT_ID = os.environ.get(
+        'CLOUD_SPEND_BILLING_PROJECT_ID', GCP_PROJECT_ID
+    )
+    # Fully-qualified BigQuery Billing Export table: project.dataset.table.
+    CLOUD_SPEND_BILLING_TABLE = os.environ.get('CLOUD_SPEND_BILLING_TABLE', '')
+    CLOUD_SPEND_CACHE_TTL_SECONDS = int(
+        os.environ.get('CLOUD_SPEND_CACHE_TTL_SECONDS', '21600')
+    )
+    CLOUD_SPEND_MAX_BYTES_BILLED = int(
+        os.environ.get('CLOUD_SPEND_MAX_BYTES_BILLED', '1000000000')
+    )
+    CLOUD_SPEND_HTTP_TIMEOUT_SECONDS = float(
+        os.environ.get('CLOUD_SPEND_HTTP_TIMEOUT_SECONDS', '25')
+    )
 
     # Cache TTL in seconds for Google Sheets reads
     SHEETS_CACHE_TTL = int(os.environ.get('SHEETS_CACHE_TTL', '30'))

--- a/apps/web/tests/test_settings_bot_commands.py
+++ b/apps/web/tests/test_settings_bot_commands.py
@@ -1,12 +1,12 @@
 """Tests for the per-command/subcommand kill-switch toggles on the Settings page."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from flask import Blueprint, Flask
 
 from app.blueprints.settings import bp as settings_bp
-from app.db import AppSetting, db
+from app.db import AppLogEntry, AppSetting, db
 
 _TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
 _STATIC_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
@@ -26,6 +26,7 @@ def _app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SETTINGS_ADMIN_DISCORD_IDS'] = {'12345'}
+    app.config['CLOUD_SPEND_ADMIN_DISCORD_IDS'] = set()
     app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(hours=12)
     app.jinja_env.globals['csrf_token'] = lambda: 'test-csrf'
     db.init_app(app)
@@ -109,9 +110,44 @@ def test_denied_for_non_admin():
         _set_session(client, '99999')
         res = client.post('/settings/commands/toggle', data={'token': 'xp.submit', 'action': 'disable'})
         assert res.status_code == 302
-
     assert _disabled_value(app) == ''
 
+
+def test_cloud_spend_is_owner_only(monkeypatch):
+    app = _app()
+    app.config['CLOUD_SPEND_ADMIN_DISCORD_IDS'] = {'12345'}
+    app.config['SETTINGS_ADMIN_DISCORD_IDS'] = {'12345', '99999'}
+    monkeypatch.setattr(
+        'app.cloud_spend.fetch_monthly_gcp_costs',
+        lambda config: [{'month': '2026-07', 'cost': 1.25}],
+    )
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        response = client.get('/settings/?section=cloud-spend')
+        assert response.status_code == 200
+        assert b'Monthly comparison' in response.data
+
+        _set_session(client, '99999')
+        response = client.get('/settings/?section=cloud-spend')
+        assert response.status_code == 200
+        assert b'Monthly comparison' not in response.data
+
+
+def test_cloud_spend_compares_error_counts(monkeypatch):
+    app = _app()
+    with app.app_context():
+        db.session.add(AppLogEntry(
+            ts='2026-07-24T12:00:00+00:00', source='web', level='error',
+            event='test', created_at=datetime.now(timezone.utc),
+        ))
+        db.session.commit()
+        monkeypatch.setattr(
+            'app.cloud_spend.fetch_monthly_gcp_costs',
+            lambda config: [{'month': '2026-07', 'cost': 1.25}],
+        )
+        from app.cloud_spend import build_snapshot
+        snapshot = build_snapshot(app.config)
+        assert snapshot['series'][-1]['errors'] == 1
 
 def test_settings_index_renders_bot_commands_section():
     app = _app()

--- a/docs/ENV_AND_SECRETS.md
+++ b/docs/ENV_AND_SECRETS.md
@@ -46,6 +46,29 @@ cp apps/web/.env.example apps/web/.env
 | `DISCORD_REDIRECT_URI` | Yes | — | OAuth callback URL (e.g. `http://127.0.0.1:5001/auth/callback`). |
 | `ALLOWED_DISCORD_IDS` | Yes | — | Comma-separated Discord IDs with staff access. |
 | `SETTINGS_ADMIN_DISCORD_IDS` | No | — | Subset of `ALLOWED_DISCORD_IDS` who can edit Settings at runtime. |
+| `CLOUD_SPEND_ADMIN_DISCORD_IDS` | No | — | Separate, narrower Discord-ID allowlist for the personal billing view. Keep this to the owner. |
+
+### Owner-only Cloud Spend (optional)
+
+The Settings → Owner → Cloud Spend pane is monthly by design. It compares a
+BigQuery GCP Billing Export aggregate with persisted web error counts and the
+existing bot heartbeat signal. It is disabled unless `CLOUD_SPEND_ADMIN_DISCORD_IDS`
+contains the owner's Discord ID. Turso account billing is not inferred from
+database activity and remains marked unavailable until a Turso account API is
+configured.
+
+| Var | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `CLOUD_SPEND_BILLING_PROJECT_ID` | Conditional | `GCP_PROJECT_ID` | GCP project allowed to run the billing query. |
+| `CLOUD_SPEND_BILLING_TABLE` | Conditional | — | Fully-qualified standard Billing Export table: `project.dataset.table`. |
+| `CLOUD_SPEND_CACHE_TTL_SECONDS` | No | `21600` | In-process cache duration; six hours avoids repeated BigQuery queries. |
+| `CLOUD_SPEND_MAX_BYTES_BILLED` | No | `1000000000` | BigQuery safety cap (1 GB by default). Failed queries do not fall back to uncapped reads. |
+| `CLOUD_SPEND_HTTP_TIMEOUT_SECONDS` | No | `25` | Billing API request timeout. |
+
+The Cloud Run service account needs permission to run BigQuery jobs and read
+the billing-export dataset. The billing export itself is the only additional
+Google Cloud data source; page loads use one capped monthly aggregate and the
+result is cached. Do not add the billing table or credentials to source control.
 
 ### Bot API Auth
 

--- a/docs/WEB_APP.md
+++ b/docs/WEB_APP.md
@@ -86,6 +86,16 @@ The Settings page includes web-app runtime controls plus bot operations panels.
 - Bot API legacy token, read token, write token
 - Turso cloud database
 
+## Owner-only Cloud Spend
+
+The Settings page has an optional Owner → Cloud Spend pane. It is intentionally
+monthly rather than hourly/daily: the web service runs one capped aggregate
+against a configured GCP Billing Export table, caches it for six hours, and
+compares it with captured application errors. Access uses the separate
+`CLOUD_SPEND_ADMIN_DISCORD_IDS` allowlist; Settings administrator access alone
+does not expose billing data. Turso account billing remains unavailable until a
+Turso account API integration is configured.
+
 **Tuning** — editable numeric parameters (spinners with Save buttons):
 
 | Parameter | Default | Description |


### PR DESCRIPTION
## What happened
PR #378 ("Add owner-only monthly cloud spend view", branch \`codex/cloud-spend-admin\`) was opened against \`feat/weather-in-sunset-announcement\` instead of \`main\` — that branch was itself already merged into \`main\` via PR #376 and should have been deleted/unused afterward, but a direct push (a separate "Harden deployment" commit) happened to land there too, then PR #378 branched off that same stale ref and got merged into it. GitHub shows #378 as "Merged," but it only updated the feature branch, which was never itself merged into \`main\`. Net effect: the entire cloud-spend feature (\`app/cloud_spend.py\` and everything wired to it) has never actually been in production.

This PR is exactly PR #378's original diff (9 files, same as commit \`21f4b65\`), now targeting the correct base.

## Test plan
- [ ] After merge, confirm \`app/cloud_spend.py\` exists on \`main\` and \`?section=cloud-spend\` loads for an owner without a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)