### PR TITLE
Fix Cloud Spend nav link showing a blank pane (Codex finding on #378/#379)

### DIFF
--- a/apps/web/app/templates/settings/index.html
+++ b/apps/web/app/templates/settings/index.html
@@ -614,6 +614,19 @@
   var panes = document.querySelectorAll('.settings-pane[data-section]');
   var navLinks = document.querySelectorAll('.settings-nav-link[data-section]');
 
+  // Some panes (e.g. Cloud Spend) are only server-rendered when
+  // active_section already matches on the initial request, to avoid firing
+  // an external API call on every settings page load regardless of which
+  // tab is open. If a pane wasn't rendered, there's nothing in the DOM for
+  // the client-side toggle below to activate -- fall back to a real
+  // navigation instead of silently showing a blank pane.
+  function paneExists(id) {
+    for (var i = 0; i < panes.length; i++) {
+      if (panes[i].dataset.section === id) return true;
+    }
+    return false;
+  }
+
   function showSection(id) {
     panes.forEach(function (p) { p.classList.toggle('is-active', p.dataset.section === id); });
     navLinks.forEach(function (l) { l.classList.toggle('is-active', l.dataset.section === id); });
@@ -649,6 +662,10 @@
       row.querySelector('.settings-search-result-section').textContent = r.section_label;
       row.querySelector('.settings-search-result-desc').textContent = r.description;
       row.addEventListener('click', function () {
+        if (!paneExists(r.section)) {
+          window.location.href = '?section=' + encodeURIComponent(r.section);
+          return;
+        }
         searchInput.value = '';
         history.replaceState(null, '', '?section=' + r.section);
         showSection(r.section);
@@ -676,10 +693,14 @@
 
   navLinks.forEach(function (link) {
     link.addEventListener('click', function (e) {
+      var id = link.dataset.section;
+      if (!paneExists(id)) {
+        return; // let the browser follow the link's real href
+      }
       e.preventDefault();
       if (searchInput) searchInput.value = '';
       history.pushState(null, '', link.getAttribute('href'));
-      showSection(link.dataset.section);
+      showSection(id);
     });
   });
 })();

--- a/apps/web/tests/test_settings_bot_commands.py
+++ b/apps/web/tests/test_settings_bot_commands.py
@@ -133,6 +133,32 @@ def test_cloud_spend_is_owner_only(monkeypatch):
         assert b'Monthly comparison' not in response.data
 
 
+def test_cloud_spend_pane_is_lazy_but_nav_link_href_is_still_correct(monkeypatch):
+    """Regression test: cloud_spend is only computed when active_section is
+    already 'cloud-spend' (avoids firing the GCP billing API on every
+    settings page load), so the <section data-section="cloud-spend"> HTML
+    is absent on a plain page load. The client-side nav JS does
+    preventDefault() + client-side pane toggling with no fetch, so if that
+    JS ever stops falling back to a real navigation for absent panes, this
+    at least locks in that the link's href still points to the right place
+    for that fallback to work.
+    """
+    app = _app()
+    app.config['CLOUD_SPEND_ADMIN_DISCORD_IDS'] = {'12345'}
+    monkeypatch.setattr(
+        'app.cloud_spend.fetch_monthly_gcp_costs',
+        lambda config: [{'month': '2026-07', 'cost': 1.25}],
+    )
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        response = client.get('/settings/')
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert '<section class="settings-pane' in html  # other panes did render
+        assert 'Monthly comparison' not in html  # cloud-spend pane body did not
+        assert 'section=cloud-spend' in html  # nav link href still present
+
+
 def test_cloud_spend_compares_error_counts(monkeypatch):
     app = _app()
     with app.app_context():


### PR DESCRIPTION
## Summary
Fixes the bug Codex flagged on both #378 and #379: the Cloud Spend pane's data is only computed server-side when `active_section` already equals `cloud-spend` — deliberately, to avoid firing the GCP billing API on every settings page load regardless of which tab is open. But the settings page's nav script does `preventDefault()` and only toggles CSS on already-rendered `.settings-pane` elements, with no fetch. So clicking Owner → Cloud Spend from any other section (or via search) updated the URL but left the pane area blank until a manual page reload.

## Fix
Both the nav-link click handler and the search-result click handler now check whether the target pane actually exists in the DOM before doing the client-side toggle. If it doesn't, they fall back to a real navigation (`window.location.href` for search results, letting the browser follow the link's real `href` for nav clicks) instead of silently showing nothing. This is generic — not hardcoded to `cloud-spend` — so it self-heals for any future similarly lazily-rendered pane.

## Test plan
- [x] `pytest -q` passes (310 passed)
- [x] `ruff check app tests` passes
- [x] New regression test confirms the cloud-spend pane is absent from a plain page load's HTML (locking in *why* the bug was possible) while the nav link's href is still correct (so the fallback navigation lands in the right place)
- [ ] After deploy, land on `/settings/` as an owner, click Owner → Cloud Spend, confirm the pane now loads instead of going blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)