### PR TITLE
Turn footer credit into a mailto link; route Discord join through email

### DIFF
--- a/apps/web/app/templates/player/base.html
+++ b/apps/web/app/templates/player/base.html
@@ -65,12 +65,12 @@
                  alt="Dark Pack"
                  style="height:28px;width:auto;opacity:0.75;">
             <small class="text-muted">
-                <a href="https://discord.gg/WuU2xkHdmp" class="text-muted text-decoration-none" target="_blank" rel="noopener">
+                <a href="mailto:jay@jkomg.us?subject=Discord%20invite%20request" class="text-muted text-decoration-none">
                     Music City by Night — Vampire: The Masquerade V5
                 </a>
             </small>
         </div>
-        <small class="text-muted" style="opacity: 0.45;">created by jkomg</small>
+        <small class="text-muted" style="opacity: 0.45;">created by <a href="mailto:jay@jkomg.us" class="text-muted">jkomg</a></small>
         <br>
         <small class="text-muted" style="opacity: 0.35; font-size: 0.7em;">
             Portions of the materials are the copyrights and trademarks of Paradox Interactive AB, and are used with permission. All rights reserved.

--- a/apps/web/app/templates/wiki/base.html
+++ b/apps/web/app/templates/wiki/base.html
@@ -111,7 +111,7 @@
                         <span style="font-family:var(--font-display);font-weight:700;font-size:14px;color:var(--text);letter-spacing:.04em;">Music City by Night</span>
                     </div>
                     <p style="font-size:12px;color:var(--text-faint);margin-bottom:14px;">Vampire: The Masquerade V5 — Nashville, TN</p>
-                    <a href="https://discord.gg/WuU2xkHdmp" target="_blank" rel="noopener"
+                    <a href="mailto:jay@jkomg.us?subject=Discord%20invite%20request"
                        style="display:inline-flex;align-items:center;gap:7px;background:color-mix(in srgb,var(--accent) 14%,transparent);border:1px solid color-mix(in srgb,var(--accent) 30%,transparent);color:var(--accent-soft);border-radius:999px;padding:7px 16px;font-size:13px;font-weight:600;text-decoration:none;transition:background .15s;">
                         <i class="bi bi-discord"></i> Join the Discord
                     </a>
@@ -143,7 +143,8 @@
                 <p style="font-size:11px;color:var(--text-faintest);line-height:1.6;margin:0;">
                     Portions of the materials are the copyrights and trademarks of Paradox Interactive AB, and are used with permission. All rights reserved.
                     For more information please visit <a href="https://worldofdarkness.com" target="_blank" rel="noopener" style="color:var(--text-faint);text-decoration:underline;text-decoration-color:var(--border-strong);">worldofdarkness.com</a>.<br>
-                    Music City by Night is not official World of Darkness material and is not endorsed by Paradox Interactive AB.
+                    Music City by Night is not official World of Darkness material and is not endorsed by Paradox Interactive AB.<br>
+                    Created by <a href="mailto:jay@jkomg.us" style="color:var(--text-faint);text-decoration:underline;text-decoration-color:var(--border-strong);">jkomg</a>.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Wiki footer (`apps/web/app/templates/wiki/base.html`): added a "Created by jkomg" credit line linking to `mailto:jay@jkomg.us` (didn't exist before), and changed the "Join the Discord" button from the direct `discord.gg` invite link to a mailto asking for an invite.
- Player portal footer (`apps/web/app/templates/player/base.html`): "created by jkomg" was already present as plain text — made it a mailto link. The Discord link here is the campaign title text (no separate "Join the Discord" button on this page) — same mailto treatment for consistency.
- Both mailto links prefill a subject line (`Discord invite request`) for the join-request case.

## Test plan
- [x] `pytest -q` passes (310 passed), `ruff check` clean
- [ ] Visually confirm both footers render correctly and the mailto links open a compose window with the right address/subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)