### PR TITLE
Fall back to text-only when a sheet-update PDF exceeds Discord's upload cap

### DIFF
--- a/apps/bot/src/__tests__/lasombraSheetUpdate.test.ts
+++ b/apps/bot/src/__tests__/lasombraSheetUpdate.test.ts
@@ -5,7 +5,7 @@ vi.mock('../config', () => ({ config: { lasombraCommandName: 'lasombra' } }));
 import { isRequestEntityTooLarge } from '../commands/lasombra';
 
 describe('isRequestEntityTooLarge', () => {
-  it('matches the error Discord throws when an attachment exceeds the guild upload cap', () => {
+  it('matches the error Discord throws when the bot re-upload exceeds the guild boost-tier cap', () => {
     expect(isRequestEntityTooLarge(new Error('Request entity too large'))).toBe(true);
     expect(isRequestEntityTooLarge(new Error('413: Request Entity Too Large'))).toBe(true);
   });

--- a/apps/bot/src/__tests__/lasombraSheetUpdate.test.ts
+++ b/apps/bot/src/__tests__/lasombraSheetUpdate.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({ config: { lasombraCommandName: 'lasombra' } }));
+
+import { isRequestEntityTooLarge } from '../commands/lasombra';
+
+describe('isRequestEntityTooLarge', () => {
+  it('matches the error Discord throws when an attachment exceeds the guild upload cap', () => {
+    expect(isRequestEntityTooLarge(new Error('Request entity too large'))).toBe(true);
+    expect(isRequestEntityTooLarge(new Error('413: Request Entity Too Large'))).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isRequestEntityTooLarge(new Error('Missing Access'))).toBe(false);
+    expect(isRequestEntityTooLarge(new Error('Unknown Channel'))).toBe(false);
+  });
+
+  it('does not throw on non-Error values', () => {
+    expect(isRequestEntityTooLarge('some string')).toBe(false);
+    expect(isRequestEntityTooLarge(null)).toBe(false);
+    expect(isRequestEntityTooLarge(undefined)).toBe(false);
+  });
+});

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -924,6 +924,16 @@ export async function handleBroadcastModal(
 
 // ── Update modal handlers ───────────────────────────────────────────────────
 
+/**
+ * Discord rejects an upload exceeding this guild's attachment-size cap
+ * (varies by boost tier; not exposed via the API) at the HTTP layer before
+ * it ever becomes a coded API error, so this is a message-text match rather
+ * than a discord.js error code check.
+ */
+export function isRequestEntityTooLarge(err: unknown): boolean {
+  return err instanceof Error && /request entity too large/i.test(err.message);
+}
+
 type SheetUpdateFlavor = {
   /** e.g. 'update' — used in the "session expired" retry hint. */
   subcommandName: string;
@@ -984,6 +994,7 @@ async function handleSheetUpdateModal(
     return;
   }
 
+  let attachmentTooLarge = false;
   try {
     const sheetsChannel = await guild.channels.fetch(sheetsChannelId);
     if (!sheetsChannel || !sheetsChannel.isTextBased() || !('send' in sheetsChannel)) {
@@ -1008,10 +1019,22 @@ async function handleSheetUpdateModal(
     }
 
     if (pdfBuffer && pdf) {
-      await (sheetsChannel as import('discord.js').TextChannel).send({
-        content,
-        files: [{ attachment: pdfBuffer, name: pdf.name }],
-      });
+      try {
+        await (sheetsChannel as import('discord.js').TextChannel).send({
+          content,
+          files: [{ attachment: pdfBuffer, name: pdf.name }],
+        });
+      } catch (err) {
+        // Discord rejects the *entire* request (text + file together) if the
+        // attachment exceeds this guild's upload cap (varies by boost tier,
+        // and Discord doesn't expose the exact limit via the API) -- fall
+        // back to posting the text confirmation alone rather than losing the
+        // update entirely. attachmentTooLarge feeds the pdfNote below so the
+        // requester knows the file needs sharing another way.
+        if (!isRequestEntityTooLarge(err)) throw err;
+        attachmentTooLarge = true;
+        await (sheetsChannel as import('discord.js').TextChannel).send({ content });
+      }
     } else {
       await (sheetsChannel as import('discord.js').TextChannel).send({ content });
     }
@@ -1025,6 +1048,7 @@ async function handleSheetUpdateModal(
     playerId,
     staffId: interaction.user.id,
     hasPdf: Boolean(pdf),
+    attachmentTooLarge,
   });
 
   // Post public confirmation in the character's channel
@@ -1034,7 +1058,9 @@ async function handleSheetUpdateModal(
     logEvent('warn', `${flavor.logEventName}_channel_confirm_failed`, { characterName, error: errorToMessage(err) });
   }
 
-  const pdfNote = pdf ? '' : ' *(no PDF found in channel)*';
+  const pdfNote = attachmentTooLarge
+    ? ' *(PDF too large for this server to upload — share it manually)*'
+    : pdf ? '' : ' *(no PDF found in channel)*';
   await interaction.editReply(`✅ Posted update for **${characterName}** to <#${sheetsChannelId}>${pdfNote}.`);
 }
 

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -925,10 +925,17 @@ export async function handleBroadcastModal(
 // ── Update modal handlers ───────────────────────────────────────────────────
 
 /**
- * Discord rejects an upload exceeding this guild's attachment-size cap
- * (varies by boost tier; not exposed via the API) at the HTTP layer before
- * it ever becomes a coded API error, so this is a message-text match rather
- * than a discord.js error code check.
+ * The player who dropped the PDF in their ticket channel may be on Nitro,
+ * which raises their personal client upload ceiling (currently 500MB)
+ * independent of the guild's boost tier. The bot re-uploading that same
+ * file is bound by the guild's own boost-tier cap instead — bots don't
+ * inherit a user's Nitro allowance, and (per Discord's own API-docs tracker,
+ * discord/discord-api-docs#6058) bot/webhook uploads may not even get the
+ * newer default bump that Discord client uploads do. So a file a player
+ * uploaded natively without issue can still bounce when the bot tries to
+ * re-post it. Discord rejects it at the HTTP layer before it ever becomes a
+ * coded API error, so this is a message-text match rather than a discord.js
+ * error code check.
  */
 export function isRequestEntityTooLarge(err: unknown): boolean {
   return err instanceof Error && /request entity too large/i.test(err.message);

--- a/apps/bot/src/commands/lasombra.ts
+++ b/apps/bot/src/commands/lasombra.ts
@@ -1059,8 +1059,11 @@ async function handleSheetUpdateModal(
   });
 
   // Post public confirmation in the character's channel
+  const publicConfirmMessage = attachmentTooLarge
+    ? `${flavor.publicConfirmMessage} *(file too large to upload — shared as text only)*`
+    : flavor.publicConfirmMessage;
   try {
-    await channel.send({ content: flavor.publicConfirmMessage });
+    await channel.send({ content: publicConfirmMessage });
   } catch (err) {
     logEvent('warn', `${flavor.logEventName}_channel_confirm_failed`, { characterName, error: errorToMessage(err) });
   }


### PR DESCRIPTION
## Summary
This is what the error the user saw ("Failed to post to #player-character-sheets: Request entity too large") actually is: `/lasombra update` downloads the character's most recent PDF and re-uploads it alongside a text confirmation to `#player-character-sheets` in a single request.

Confirmed root cause via the actual reproduction (`#dolohov`, PDF grew to 12.7MB): the player who dropped the file in their ticket channel is on Nitro, which raises a user's personal client upload ceiling (currently 500MB) independent of the guild's boost tier — that's why the upload worked fine from their side. The bot re-uploading that same file is bound by the *guild's* own boost-tier cap instead (this guild is boost Tier 1), and doesn't inherit a user's Nitro allowance. There's also a documented gap where bot/webhook uploads may not get the same higher default ceiling that Discord client uploads got (see discord/discord-api-docs#6058) — so the bot can be capped well below what a Nitro user (or even a non-boosted client) can push natively in the same channel. Previously the whole update failed, including the text confirmation, which had nothing to do with the file itself.

## Fix
Catches that specific failure (message-text match, since it's an HTTP-layer rejection with no discord.js error code) and retries with the text alone, so the update still posts. The staff member doing the update now sees `*(PDF too large for this server to upload — share it manually)*` in their ephemeral confirmation instead of a hard failure with no channel post at all. Same fix applies to `/lasombra retainer-update` (shares the same handler).

## Test plan
- [x] `npm run check` passes (lint, format, typecheck, 343 tests, build)
- [x] New unit test for the error-matching helper (exported for testability, matching this session's convention for small pure helpers)
- [ ] After deploy, reproduce with an oversized PDF in a character channel and confirm the text confirmation posts with the new note instead of failing outright

🤖 Generated with [Claude Code](https://claude.com/claude-code)