### PR TITLE
Add structured per-faction sub-category tracking for Status (backend)

### DIFF
--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -528,14 +528,6 @@ def submit_spend(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
-    from app.character_sheet import _SUBCATEGORY_ADVANTAGES
-    if trait_name.lower() in _SUBCATEGORY_ADVANTAGES and not power_name:
-        flash(
-            f'{_SUBCATEGORY_ADVANTAGES[trait_name.lower()]} is required for {trait_name} purchases.',
-            'danger',
-        )
-        return redirect(url_for('player.character', name=name))
-
     try:
         current_dots = int(request.form.get('current_dots', 0))
         new_dots = int(request.form.get('new_dots', 1))
@@ -656,15 +648,9 @@ def add_wish_list_item(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
-    from app.character_sheet import _DISCIPLINE_CATEGORIES, _SUBCATEGORY_ADVANTAGES
+    from app.character_sheet import _DISCIPLINE_CATEGORIES
     if spend_category in _DISCIPLINE_CATEGORIES and not power_name:
         flash('Power name is required for discipline purchases.', 'danger')
-        return redirect(url_for('player.character', name=name))
-    if trait_name.lower() in _SUBCATEGORY_ADVANTAGES and not power_name:
-        flash(
-            f'{_SUBCATEGORY_ADVANTAGES[trait_name.lower()]} is required for {trait_name} purchases.',
-            'danger',
-        )
         return redirect(url_for('player.character', name=name))
 
     try:

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -528,6 +528,14 @@ def submit_spend(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
+    from app.character_sheet import _SUBCATEGORY_ADVANTAGES
+    if trait_name.lower() in _SUBCATEGORY_ADVANTAGES and not power_name:
+        flash(
+            f'{_SUBCATEGORY_ADVANTAGES[trait_name.lower()]} is required for {trait_name} purchases.',
+            'danger',
+        )
+        return redirect(url_for('player.character', name=name))
+
     try:
         current_dots = int(request.form.get('current_dots', 0))
         new_dots = int(request.form.get('new_dots', 1))
@@ -648,9 +656,15 @@ def add_wish_list_item(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
-    from app.character_sheet import _DISCIPLINE_CATEGORIES
+    from app.character_sheet import _DISCIPLINE_CATEGORIES, _SUBCATEGORY_ADVANTAGES
     if spend_category in _DISCIPLINE_CATEGORIES and not power_name:
         flash('Power name is required for discipline purchases.', 'danger')
+        return redirect(url_for('player.character', name=name))
+    if trait_name.lower() in _SUBCATEGORY_ADVANTAGES and not power_name:
+        flash(
+            f'{_SUBCATEGORY_ADVANTAGES[trait_name.lower()]} is required for {trait_name} purchases.',
+            'danger',
+        )
         return redirect(url_for('player.character', name=name))
 
     try:

--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -41,7 +41,9 @@ def pending():
         )
         char_data = dashboard_data.get(spend.character_name.lower())
         depends_on_spend = by_row.get(spend.depends_on) if spend.depends_on else None
-        sheet_match = find_trait_sheet_match(spend.character_name, spend.spend_category, spend.trait_name)
+        sheet_match = find_trait_sheet_match(
+            spend.character_name, spend.spend_category, spend.trait_name, spend.power_name,
+        )
         days = _days_waiting(spend.timestamp)
         rows.append({
             'spend': spend,
@@ -89,7 +91,9 @@ def review(row_id):
     # Warn staff if the trait name doesn't exactly match an existing sheet
     # entry — e.g. "Status" submitted when the sheet has "Status (Tremere)" —
     # since approving as-is creates a stray duplicate instead of raising it.
-    sheet_match = find_trait_sheet_match(spend.character_name, spend.spend_category, spend.trait_name)
+    sheet_match = find_trait_sheet_match(
+        spend.character_name, spend.spend_category, spend.trait_name, spend.power_name,
+    )
 
     return render_template(
         'spends/review.html',

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -21,6 +21,17 @@ _DISCIPLINE_CATEGORIES = frozenset({
 
 _SKILL_CATEGORIES = frozenset({'Skill', 'New Skill'})
 
+# Advantages (Merits/Backgrounds) that track a required sub-category/faction
+# via a parenthetical suffix on the plain sheet name — e.g. "Status (Tremere)"
+# is the existing informal convention already present in sheet data, not a
+# new field. Maps lowercased trait_name -> player-facing label for that
+# sub-category (used by later PRs' form UI/staff-review display). Adding a
+# future trigger trait is a one-line change here; deliberately scoped to
+# Status only for now — Contacts/Mentor/Allies/Retainer are out of scope.
+_SUBCATEGORY_ADVANTAGES = {
+    'status': 'Faction / Group',
+}
+
 _SHEET_MARKER_START = '<!-- CHARACTER_SHEET -->'
 _SHEET_MARKER_END = '<!-- /CHARACTER_SHEET -->'
 
@@ -76,7 +87,28 @@ def _load_approved_sheet_data(character_name: str) -> dict | None:
         return None
 
 
-def find_trait_sheet_match(character_name: str, category: str, trait_name: str) -> dict | None:
+def _effective_advantage_name(trait_name: str, power_name: str) -> str:
+    """Compute the sheet-storage/match name for an Advantage (Merit/Background) spend.
+
+    Some Advantages (see _SUBCATEGORY_ADVANTAGES) track a required
+    sub-category/faction via a parenthetical suffix on the plain name, e.g.
+    "Status (Tremere)" — this is the existing informal convention already
+    present in sheet data, not a new field. When the trait is one of these
+    and a sub-category is given via power_name (dual-purpose: discipline
+    power name OR advantage sub-category), fold it into the name. Otherwise
+    (legacy calls with no power_name, or non-triggering traits) the plain
+    trait_name is used unchanged.
+    """
+    trait_name = (trait_name or '').strip()
+    power_name = (power_name or '').strip()
+    if power_name and trait_name.lower() in _SUBCATEGORY_ADVANTAGES:
+        return f'{trait_name} ({power_name})'
+    return trait_name
+
+
+def find_trait_sheet_match(
+    character_name: str, category: str, trait_name: str, power_name: str = '',
+) -> dict | None:
     """Check a pending spend's trait name against the character's current sheet.
 
     Only meaningful for 'Advantage (Merit/Background)': these are the traits
@@ -84,30 +116,54 @@ def find_trait_sheet_match(character_name: str, category: str, trait_name: str) 
     spend submitted as plain "Status" can silently miss an existing entry and
     create a stray duplicate instead of raising it — the bug that hit Marcus.
 
+    power_name carries the sub-category/faction for triggering traits (see
+    _SUBCATEGORY_ADVANTAGES), e.g. trait_name="Status", power_name="Tremere"
+    matches/folds to "Status (Tremere)", the same convention _apply_patch uses.
+
     Returns None if there's nothing to check (wrong category, no sheet, blank
     trait name). Otherwise returns {'exact': bool, 'close_matches': [...]} —
     close_matches lists existing entries whose name starts with trait_name
-    but isn't an exact match, e.g. trait_name="Status" surfaces an existing
-    "Status (Tremere)" entry as a likely-intended match.
+    but isn't an exact match, e.g. trait_name="Status" (no power_name)
+    surfaces an existing "Status (Tremere)" entry as a likely-intended match.
+
+    When the current spend already specifies a structured sub-category (e.g.
+    "Status"/"Tremere"), other existing entries that are themselves distinct
+    structured sub-categories of the same trait (e.g. "Status (Anarch
+    Movement)") are NOT surfaced as close matches — two different factions
+    of Status are independent, unambiguous entries, not a warning-worthy
+    near-miss of each other.
     """
     if category != 'Advantage (Merit/Background)':
         return None
     trait_name = (trait_name or '').strip()
     if not trait_name:
         return None
+    power_name = (power_name or '').strip()
 
     data = _load_approved_sheet_data(character_name)
     if data is None:
         return None
 
-    key = trait_name.lower()
+    base_key = trait_name.lower()
+    effective_name = _effective_advantage_name(trait_name, power_name)
+    key = effective_name.lower()
+    has_subcategory = bool(power_name) and base_key in _SUBCATEGORY_ADVANTAGES
+    structured_prefix = f'{base_key} ('
+
     entries = list(data.get('backgrounds') or []) + list(data.get('merits') or [])
     exact = any((e.get('name') or '').lower() == key for e in entries)
-    close_matches = [
-        {'name': e.get('name', ''), 'level': e.get('level', 0)}
-        for e in entries
-        if (e.get('name') or '').lower() != key and (e.get('name') or '').lower().startswith(key)
-    ]
+
+    close_matches = []
+    for e in entries:
+        name_lower = (e.get('name') or '').lower()
+        if name_lower == key or not name_lower.startswith(base_key):
+            continue
+        if has_subcategory and name_lower.startswith(structured_prefix) and name_lower.endswith(')'):
+            # Independent structured sub-category (different faction) — not
+            # an ambiguous close match against the current spend's faction.
+            continue
+        close_matches.append({'name': e.get('name', ''), 'level': e.get('level', 0)})
+
     return {'exact': exact, 'close_matches': close_matches}
 
 
@@ -215,7 +271,13 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         return True
 
     if category == 'Advantage (Merit/Background)':
-        key = trait_name.lower()
+        # power_name is dual-purpose: specific power/ritual name for
+        # discipline spends (above), or the required sub-category/faction
+        # for triggering Advantages like Status (see _SUBCATEGORY_ADVANTAGES)
+        # — folded into the stored name as "Status (Tremere)", matching the
+        # existing informal convention already present in sheet data.
+        effective_name = _effective_advantage_name(trait_name, power_name)
+        key = effective_name.lower()
         # Schema v7+ splits Backgrounds (Status, Resources, Contacts, Haven,
         # etc.) into their own array, separate from Merits — but both use the
         # same entry shape (`type` is always 'merit', it's just stored under
@@ -236,7 +298,7 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         # full background-name catalog here (a maintenance/drift risk), so
         # default to merits, matching this function's original behavior.
         data.setdefault('merits', []).append({
-            'name': trait_name,
+            'name': effective_name,
             'level': new_dots,
             'summary': '',
             'excludes': [],
@@ -359,7 +421,8 @@ def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name:
         return False
 
     if category == 'Advantage (Merit/Background)':
-        key = trait_name.lower()
+        effective_name = _effective_advantage_name(trait_name, power_name)
+        key = effective_name.lower()
         for array_name in ('backgrounds', 'merits'):
             items = data.get(array_name)
             if not isinstance(items, list):

--- a/apps/web/app/db.py
+++ b/apps/web/app/db.py
@@ -112,7 +112,11 @@ class DbSpendRequest(db.Model):
     reviewed_by = db.Column(String(100), default='')
     review_date = db.Column(String(20), default='')
     st_notes = db.Column(Text, default='')
-    power_name = db.Column(String(100), default='')   # specific power/ritual name for discipline spends
+    # Dual-purpose: specific power/ritual name for discipline spends, OR the
+    # required faction/sub-category name for repeatable Advantages like
+    # Status (e.g. "Tremere"), folded into the sheet as "Status (Tremere)" —
+    # see app.character_sheet._SUBCATEGORY_ADVANTAGES.
+    power_name = db.Column(String(100), default='')
     depends_on = db.Column(Integer, nullable=True)  # FK to another spend request id
     coterie_id = db.Column(Integer, db.ForeignKey('coteries.id'), nullable=True, index=True)
     coterie = db.relationship('Coterie', foreign_keys=[coterie_id], lazy='joined')

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -132,3 +132,112 @@ def test_find_trait_sheet_match_ignored_for_other_categories(app_ctx):
 
 def test_find_trait_sheet_match_none_when_no_approved_sheet(app_ctx):
     assert find_trait_sheet_match('Nobody', 'Advantage (Merit/Background)', 'Status') is None
+
+
+# --- Status sub-category (power_name reused as faction/group) ---
+
+
+def test_status_spend_with_faction_creates_folded_entry():
+    """A new Status spend with a faction sub-category creates a single
+    "Status (Tremere)" entry, matching the existing informal sheet convention."""
+    data = {'backgrounds': [], 'merits': []}
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Status', 'Tremere', 1)
+
+    assert patched is True
+    assert data['merits'] == [
+        {'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
+def test_status_spend_with_same_faction_updates_existing_entry_in_place():
+    """Raising Status/Tremere a second time updates the existing "Status
+    (Tremere)" entry's level rather than creating a duplicate."""
+    data = {
+        'backgrounds': [{'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+        'merits': [],
+    }
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Status', 'Tremere', 2)
+
+    assert patched is True
+    assert data['backgrounds'] == [
+        {'name': 'Status (Tremere)', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+    assert data['merits'] == []
+
+
+def test_non_triggering_trait_unaffected_by_subcategory_logic():
+    """Regression check: a plain, non-Status Advantage (e.g. Contacts) is
+    completely unaffected by the new sub-category folding logic, even if a
+    power_name happens to be passed."""
+    data = {'backgrounds': [], 'merits': []}
+    patched = _apply_patch(data, 'Advantage (Merit/Background)', 'Contacts', 'Some Value', 1)
+
+    assert patched is True
+    assert data['merits'] == [
+        {'name': 'Contacts', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
+def test_two_different_status_factions_coexist_as_distinct_entries():
+    """Two different factions of Status don't clobber each other — each is
+    its own distinct entry in the backgrounds/merits array."""
+    data = {'backgrounds': [], 'merits': []}
+    _apply_patch(data, 'Advantage (Merit/Background)', 'Status', 'Tremere', 1)
+    _apply_patch(data, 'Advantage (Merit/Background)', 'Status', 'Anarch Movement', 2)
+
+    assert sorted(data['merits'], key=lambda e: e['name']) == [
+        {'name': 'Status (Anarch Movement)', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'},
+        {'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+    # Raising the Tremere entry again must not touch the Anarch Movement one.
+    _apply_patch(data, 'Advantage (Merit/Background)', 'Status', 'Tremere', 3)
+    assert sorted(data['merits'], key=lambda e: e['name']) == [
+        {'name': 'Status (Anarch Movement)', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'},
+        {'name': 'Status (Tremere)', 'level': 3, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
+def test_find_trait_sheet_match_exact_for_structured_status_faction(app_ctx):
+    _seed_approved_character('Marcus', {
+        'merits': [{'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+
+    result = find_trait_sheet_match('Marcus', 'Advantage (Merit/Background)', 'Status', 'Tremere')
+
+    assert result == {'exact': True, 'close_matches': []}
+
+
+def test_find_trait_sheet_match_two_structured_factions_not_flagged_as_close_matches(app_ctx):
+    """Two distinct structured Status factions are independent, unambiguous
+    entries — checking one against the sheet must not surface the other as
+    a "close match" warning."""
+    _seed_approved_character('Marcus', {
+        'merits': [
+            {'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'},
+            {'name': 'Status (Anarch Movement)', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'},
+        ],
+    })
+
+    result = find_trait_sheet_match('Marcus', 'Advantage (Merit/Background)', 'Status', 'Tremere')
+
+    assert result == {'exact': True, 'close_matches': []}
+
+
+def test_find_trait_sheet_match_legacy_bare_status_still_warns_against_structured_factions(app_ctx):
+    """A legacy/bare "Status" spend (no power_name) submitted against a sheet
+    that only has structured faction entries should still be flagged — the
+    original Marcus-bug protection must keep working."""
+    _seed_approved_character('Marcus', {
+        'merits': [
+            {'name': 'Status (Tremere)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'},
+            {'name': 'Status (Anarch Movement)', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'},
+        ],
+    })
+
+    result = find_trait_sheet_match('Marcus', 'Advantage (Merit/Background)', 'Status')
+
+    assert result['exact'] is False
+    assert sorted(m['name'] for m in result['close_matches']) == [
+        'Status (Anarch Movement)', 'Status (Tremere)',
+    ]

--- a/apps/web/tests/test_player_status_subcategory_validation.py
+++ b/apps/web/tests/test_player_status_subcategory_validation.py
@@ -1,5 +1,9 @@
-"""Status spends require a faction/sub-category (power_name) — mirrors the
-existing discipline power_name-required validation in the same routes."""
+"""Status spends with a faction/sub-category (power_name) still work fine at
+this layer. Note: power_name is NOT hard-required here yet — that requirement
+ships in a later PR (#388) bundled with the player-facing form UI that lets
+players actually supply a faction value. See GitHub issue #386 / PR #387
+discussion for why the requirement was deliberately deferred rather than
+added in this PR standalone."""
 
 import os
 
@@ -74,22 +78,6 @@ def _base_form(**overrides):
     return form
 
 
-def test_submit_spend_rejects_status_without_faction():
-    app = _app()
-    _seed(app)
-    client = _client(app)
-
-    resp = client.post(
-        '/player/Faction Fred/spend', data=_base_form(), follow_redirects=True,
-    )
-
-    assert resp.status_code == 200
-    body = resp.get_data(as_text=True)
-    assert 'Faction / Group is required for Status purchases.' in body
-    with app.app_context():
-        assert DbSpendRequest.query.count() == 0
-
-
 def test_submit_spend_accepts_status_with_faction():
     app = _app()
     _seed(app)
@@ -107,22 +95,6 @@ def test_submit_spend_accepts_status_with_faction():
         assert len(rows) == 1
         assert rows[0].trait_name == 'Status'
         assert rows[0].power_name == 'Tremere'
-
-
-def test_wishlist_add_rejects_status_without_faction():
-    app = _app()
-    _seed(app)
-    client = _client(app)
-
-    resp = client.post(
-        '/player/Faction Fred/wishlist/add', data=_base_form(), follow_redirects=True,
-    )
-
-    assert resp.status_code == 200
-    body = resp.get_data(as_text=True)
-    assert 'Faction / Group is required for Status purchases.' in body
-    with app.app_context():
-        assert DbWishListItem.query.count() == 0
 
 
 def test_wishlist_add_accepts_status_with_faction():
@@ -162,3 +134,41 @@ def test_submit_spend_unaffected_for_non_triggering_trait():
         rows = DbSpendRequest.query.all()
         assert len(rows) == 1
         assert rows[0].trait_name == 'Contacts'
+
+
+def test_submit_spend_accepts_status_without_faction():
+    """Confirms the hard requirement is NOT enforced at this layer yet (that
+    lands in PR #388, together with the form UI that supplies power_name for
+    Status). A bare Status spend must still be accepted here."""
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/spend', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Status'
+        assert not rows[0].power_name
+
+
+def test_wishlist_add_accepts_status_without_faction():
+    """Same as above, for the wishlist-add route."""
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/wishlist/add', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbWishListItem.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Status'
+        assert not rows[0].power_name

--- a/apps/web/tests/test_player_status_subcategory_validation.py
+++ b/apps/web/tests/test_player_status_subcategory_validation.py
@@ -1,0 +1,164 @@
+"""Status spends require a faction/sub-category (power_name) — mirrors the
+existing discipline power_name-required validation in the same routes."""
+
+import os
+
+from flask import Blueprint, Flask
+from flask_wtf.csrf import CSRFProtect
+
+import app as app_module
+from app.blueprints import player as player_module
+from app.db import DbCharacter, DbSpendRequest, DbWishListItem, db
+from app.db_service import DBService
+
+_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), '..', 'app', 'templates')
+_STATIC_DIR = os.path.join(os.path.dirname(__file__), '..', 'app', 'static')
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__, template_folder=_TEMPLATES_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test'
+    app.config['ALLOWED_DISCORD_IDS'] = set()
+    app.config['WTF_CSRF_ENABLED'] = False
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    service = DBService()
+    app_module.db_service = service
+    player_module.db_service = service
+    player_module.sheets_sync = None
+    app.register_blueprint(player_module.bp, url_prefix='/player')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(app, discord_id='111'):
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='Faction Fred',
+            player_discord=discord_id,
+            active=True,
+            status='active',
+        ))
+        db.session.commit()
+
+
+def _client(app, discord_id='111'):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['discord_id'] = discord_id
+    return client
+
+
+def _base_form(**overrides):
+    form = {
+        'spend_category': 'Advantage (Merit/Background)',
+        'trait_name': 'Status',
+        'power_name': '',
+        'justification': 'Recognition from the Camarilla',
+        'current_dots': '0',
+        'new_dots': '1',
+    }
+    form.update(overrides)
+    return form
+
+
+def test_submit_spend_rejects_status_without_faction():
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/spend', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Faction / Group is required for Status purchases.' in body
+    with app.app_context():
+        assert DbSpendRequest.query.count() == 0
+
+
+def test_submit_spend_accepts_status_with_faction():
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/spend',
+        data=_base_form(power_name='Tremere'),
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Status'
+        assert rows[0].power_name == 'Tremere'
+
+
+def test_wishlist_add_rejects_status_without_faction():
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/wishlist/add', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'Faction / Group is required for Status purchases.' in body
+    with app.app_context():
+        assert DbWishListItem.query.count() == 0
+
+
+def test_wishlist_add_accepts_status_with_faction():
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/wishlist/add',
+        data=_base_form(power_name='Anarch Movement'),
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbWishListItem.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Status'
+        assert rows[0].power_name == 'Anarch Movement'
+
+
+def test_submit_spend_unaffected_for_non_triggering_trait():
+    """Regression check: a plain Contacts spend with no power_name still
+    goes through fine — Contacts is deliberately out of scope."""
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/spend',
+        data=_base_form(trait_name='Contacts'),
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Contacts'


### PR DESCRIPTION
## Summary

Bug this fixes: staff approving a plain "Status" spend against a character whose sheet already has "Status (Tremere)" would silently create a stray duplicate `Status` entry instead of raising the existing one (the "Marcus" bug, previously documented in `find_trait_sheet_match`'s docstring but never fully closed for the multi-faction case). Status is tracked per-faction/clan/cult in-game, but the app only ever modeled it as a flat Advantage/Background.

## Approach

- Reuses the **existing** `power_name` column on `DbSpendRequest`/`DbWishListItem` as the sub-category field — no new column, no migration. `power_name` is now dual-purpose: discipline power name (existing use) OR Advantage sub-category/faction (new use).
- Folds `trait_name` + `power_name` into a single stored name, e.g. `trait_name="Status"`, `power_name="Tremere"` → `"Status (Tremere)"` — exactly the informal convention already present in existing sheet data, so legacy sheets keep working unchanged with no backfill.
- New extensible trigger dict `_SUBCATEGORY_ADVANTAGES = {'status': 'Faction / Group'}` in `apps/web/app/character_sheet.py` — adding a future trigger trait (a later issue) is a one-line change.
- `find_trait_sheet_match()` gained a `power_name` param and a related fix: two distinct structured Status factions (e.g. `"Status (Tremere)"` vs `"Status (Anarch Movement)"`) are no longer flagged as an ambiguous "close match" against each other — they're independent, unambiguous entries. The original Marcus-bug protection (a bare `"Status"` spend with no faction missing an existing `"Status (Tremere)"` entry) still works and is covered by a regression test.

**Out of scope by design:** Contacts, Mentor, Allies, Retainer are untouched. This is Status only.

This is **PR 1 of 3** for #386 — backend only. Form UI (faction input field) and staff-review display (surfacing the faction/close-match info) are separate follow-up PRs. Related to #386.

## Scope correction (post-Codex-review)

This PR originally also made `submit_spend`/`add_wish_list_item` in `player.py` hard-reject any Status submission missing `power_name`. Automated review (Codex) correctly flagged this as a **deployment-order hazard**: the player-facing form that lets a player supply a faction value doesn't exist yet — it ships in PR #388, which stacks on top of this one. Since PRs merge/deploy independently, this PR merging to `main` on its own would have shipped backend code that rejects every ordinary Status purchase, because the current form only ever surfaces `power_name` for discipline categories.

**Fix:** removed the hard-required check entirely from this PR. It will be reintroduced in PR #388, bundled together with the form UI that actually satisfies it, so the requirement and the UI that meets it ship in the same deploy. This PR is now **matching-logic only** — the `_SUBCATEGORY_ADVANTAGES` trigger dict, the folded-name logic in `_apply_patch`/`_apply_reverse_patch`, and the `find_trait_sheet_match` ambiguity fix — all purely additive/optional and safe to merge and deploy standalone at any time, independent of #388/#389.

Codex also flagged a second, related issue: the bot-facing `POST /api/spends` route (`apps/web/app/blueprints/api.py:1084-1175`) parses `powerName` from the JSON payload (line 1101) but never requires it, and the bot's `SpendPayload` TypeScript type (`apps/bot/src/types.ts:40-48`) doesn't even expose a `powerName` field — so once #388 makes the requirement land in the human-facing web form, a bot (or any other service-token API caller) could still submit a bare "Status" spend with no faction and re-trigger the exact duplicate-entry ambiguity this effort exists to fix. That gap is **not fixed in this PR** (there's no required-check pattern here yet to extend) — it's deferred to PR #388, which is the one establishing "power_name is required for Status" as an invariant, and should extend it to the API route (and the bot payload shape) at the same time.

## Test plan

- [x] `apps/web/tests/test_character_sheet_patch.py` — extended with: new Status+faction spend creates a folded entry; a second same-faction spend updates in place (no duplicate); a non-triggering trait (Contacts) is unaffected; two different factions coexist as distinct entries; `find_trait_sheet_match` no longer flags two structured factions as close matches to each other, while the legacy bare-"Status" Marcus-bug warning still fires.
- [x] `apps/web/tests/test_player_status_subcategory_validation.py` — route-level tests: `submit_spend` and `add_wish_list_item` both accept Status with a faction (happy path) and *also* accept it with no faction (confirms the requirement is deliberately NOT enforced at this layer yet); a plain Contacts spend is unaffected.
- [x] Full web suite: `324 passed` (`pytest -q --cov=app --cov-report=term-missing --cov-fail-under=30`)
- [x] `ruff check apps/web/app apps/web/tests` — clean (ruff 0.15.20, matching CI's pin)
- [x] `python -m compileall apps/web/app apps/web/tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
