### PR TITLE
Add Faction/Group input for Status spends (form UI)

### DIFF
--- a/apps/bot/src/types.ts
+++ b/apps/bot/src/types.ts
@@ -41,6 +41,7 @@ export type SpendPayload = {
   characterName: string;
   spendCategory: XpSpendCategory;
   traitName: string;
+  powerName?: string;
   currentDots: number;
   newDots: number;
   isInClan: boolean;

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -1104,6 +1104,15 @@ def submit_spend():
     if not character_name or not spend_category or not trait_name or not justification:
         return jsonify({'error': 'characterName, spendCategory, traitName, and justification are required'}), 400
 
+    from app.character_sheet import _SUBCATEGORY_ADVANTAGES
+    if (
+        spend_category == 'Advantage (Merit/Background)'
+        and trait_name.strip().lower() in _SUBCATEGORY_ADVANTAGES
+        and not power_name
+    ):
+        subcategory_label = _SUBCATEGORY_ADVANTAGES[trait_name.strip().lower()]
+        return jsonify({'error': f'powerName ({subcategory_label}) is required for {trait_name}'}), 400
+
     try:
         current_dots = int(payload.get('currentDots', 0))
         new_dots = int(payload.get('newDots', 0))

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -528,6 +528,16 @@ def submit_spend(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
+    from app.character_sheet import _SUBCATEGORY_ADVANTAGES
+    if (
+        spend_category == 'Advantage (Merit/Background)'
+        and trait_name.strip().lower() in _SUBCATEGORY_ADVANTAGES
+        and not power_name
+    ):
+        subcategory_label = _SUBCATEGORY_ADVANTAGES[trait_name.strip().lower()]
+        flash(f'{subcategory_label} is required for {trait_name}.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
     try:
         current_dots = int(request.form.get('current_dots', 0))
         new_dots = int(request.form.get('new_dots', 1))
@@ -648,9 +658,18 @@ def add_wish_list_item(name):
         flash('Invalid spend category.', 'danger')
         return redirect(url_for('player.character', name=name))
 
-    from app.character_sheet import _DISCIPLINE_CATEGORIES
+    from app.character_sheet import _DISCIPLINE_CATEGORIES, _SUBCATEGORY_ADVANTAGES
     if spend_category in _DISCIPLINE_CATEGORIES and not power_name:
         flash('Power name is required for discipline purchases.', 'danger')
+        return redirect(url_for('player.character', name=name))
+
+    if (
+        spend_category == 'Advantage (Merit/Background)'
+        and trait_name.strip().lower() in _SUBCATEGORY_ADVANTAGES
+        and not power_name
+    ):
+        subcategory_label = _SUBCATEGORY_ADVANTAGES[trait_name.strip().lower()]
+        flash(f'{subcategory_label} is required for {trait_name}.', 'danger')
         return redirect(url_for('player.character', name=name))
 
     try:

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -684,12 +684,15 @@
                                    placeholder="e.g., Strength, Dominate, Allies" required>
                         </div>
 
-                        <!-- Power Name (discipline spends only) -->
+                        <!-- Power Name (discipline spends) / Faction-Group (Status advantage) -->
+                        <!-- Shared input: only one of these two triggers is ever active for a
+                             given category+trait combo, so we relabel one field rather than
+                             maintain two separate name="power_name" inputs in the same form. -->
                         <div class="mb-3 d-none" id="power-name-group">
-                            <label for="power_name" class="form-label fw-bold">Power Name <span class="text-muted fw-normal">(specific power being purchased)</span></label>
+                            <label for="power_name" class="form-label fw-bold" id="power-name-label">Power Name <span class="text-muted fw-normal" id="power-name-sublabel">(specific power being purchased)</span></label>
                             <input type="text" class="form-control" name="power_name" id="power_name"
                                    placeholder="e.g., Mesmerize, Prowl, Sense the Unseen">
-                            <div class="form-text">Enter the exact name of the discipline power you are purchasing. This updates your character sheet.</div>
+                            <div class="form-text" id="power-name-help">Enter the exact name of the discipline power you are purchasing. This updates your character sheet.</div>
                         </div>
 
                         <!-- Dots Row -->
@@ -1002,12 +1005,14 @@
                         <input type="number" class="form-control form-control-sm" id="wl-to" name="new_dots" min="1" max="5" value="1">
                     </div>
                 </div>
+                <!-- Shared input: relabeled for Status advantage's Faction/Group, same
+                     rationale as the main spend-form's power-name-group above. -->
                 <div class="row g-2 mt-1 d-none" id="wl-power-name-group">
                     <div class="col-12">
-                        <label class="form-label small fw-bold mb-1">Power Name <span class="text-muted fw-normal">(specific power being purchased)</span></label>
+                        <label class="form-label small fw-bold mb-1" id="wl-power-name-label">Power Name <span class="text-muted fw-normal" id="wl-power-name-sublabel">(specific power being purchased)</span></label>
                         <input type="text" class="form-control form-control-sm" name="power_name" id="wl-power-name"
                                placeholder="e.g., Mesmerize, Prowl, Sense the Unseen">
-                        <div class="form-text">Required to update your character sheet when converted to a spend request.</div>
+                        <div class="form-text" id="wl-power-name-help">Required to update your character sheet when converted to a spend request.</div>
                     </div>
                 </div>
                 <div class="mt-1 d-none" id="wl-in-clan-group">
@@ -1256,11 +1261,28 @@ document.addEventListener('DOMContentLoaded', function() {
     const inClanGroup = document.getElementById('in-clan-group');
     const powerNameGroup = document.getElementById('power-name-group');
     const powerNameInput = document.getElementById('power_name');
+    const powerNameLabel = document.getElementById('power-name-label');
+    const powerNameSublabel = document.getElementById('power-name-sublabel');
+    const powerNameHelp = document.getElementById('power-name-help');
     const costValue = document.getElementById('spend-cost-value');
     const costFormula = document.getElementById('spend-cost-formula');
     const xpWarning = document.getElementById('spend-xp-warning');
     const xpWarningText = document.getElementById('spend-xp-warning-text');
     const availableXpEl = document.getElementById('available-xp');
+
+    // Advantages (Merit/Background) that require a sub-category/faction value
+    // in the shared power_name field. Mirrors _SUBCATEGORY_ADVANTAGES in
+    // apps/web/app/character_sheet.py — keep both in sync when adding triggers.
+    const SUBCATEGORY_ADVANTAGES = {
+        'status': 'Faction / Group',
+    };
+
+    function setPowerNameLabel(label, sublabelText, placeholder, helpText) {
+        if (powerNameLabel) powerNameLabel.firstChild.textContent = label + ' ';
+        if (powerNameSublabel) powerNameSublabel.textContent = sublabelText;
+        if (powerNameInput) powerNameInput.placeholder = placeholder;
+        if (powerNameHelp) powerNameHelp.textContent = helpText;
+    }
 
     if (!spendCategory) return;
 
@@ -1372,11 +1394,29 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
 
-        // Show Power Name field for all discipline categories (including Ghoul)
+        // Show Power Name field for all discipline categories (including Ghoul).
+        // Separately, some Advantages (see SUBCATEGORY_ADVANTAGES below, mirrors
+        // _SUBCATEGORY_ADVANTAGES in character_sheet.py) require a sub-category/
+        // faction field instead — e.g. "Status" needs "Faction / Group". A
+        // category is never both a Discipline and an Advantage at once, so these
+        // two triggers are mutually exclusive; we relabel the single shared
+        // power_name input rather than keep two separate inputs of the same name.
         const needsPowerName = isDiscipline || cat === 'Ghoul Discipline';
+        const traitLower = traitNameInput ? traitNameInput.value.trim().toLowerCase() : '';
+        const subcategoryLabel = (cat === 'Advantage (Merit/Background)') ? SUBCATEGORY_ADVANTAGES[traitLower] : undefined;
+        const needsSubcategory = !!subcategoryLabel;
         if (powerNameGroup) {
             if (needsPowerName) {
                 powerNameGroup.classList.remove('d-none');
+                setPowerNameLabel('Power Name', '(specific power being purchased)',
+                    'e.g., Mesmerize, Prowl, Sense the Unseen',
+                    'Enter the exact name of the discipline power you are purchasing. This updates your character sheet.');
+                if (powerNameInput) powerNameInput.required = true;
+            } else if (needsSubcategory) {
+                powerNameGroup.classList.remove('d-none');
+                setPowerNameLabel(subcategoryLabel, '',
+                    'e.g., Tremere, Anarch Movement, Cult of Set',
+                    'Enter which faction, clan, cult, or group this Status applies to.');
                 if (powerNameInput) powerNameInput.required = true;
             } else {
                 powerNameGroup.classList.add('d-none');
@@ -1442,6 +1482,11 @@ document.addEventListener('DOMContentLoaded', function() {
     if (traitNameInput) {
         traitNameInput.addEventListener('change', autofillCurrentDots);
         traitNameInput.addEventListener('blur', autofillCurrentDots);
+        // Status (and future SUBCATEGORY_ADVANTAGES triggers) depend on what's
+        // typed into Trait Name, not just spend_category — re-run the
+        // power-name-group toggle on every keystroke so it appears/disappears
+        // live as the player types "status", not only on blur.
+        traitNameInput.addEventListener('input', updateDotConstraints);
     }
 
     spendCategory.addEventListener('change', function() {
@@ -1494,7 +1539,57 @@ document.addEventListener('DOMContentLoaded', function() {
     const wlAddBtn  = document.getElementById('wl-add-btn');
     const wlPowerNameGroup = document.getElementById('wl-power-name-group');
     const wlPowerNameInput = document.getElementById('wl-power-name');
+    const wlPowerNameLabel = document.getElementById('wl-power-name-label');
+    const wlPowerNameSublabel = document.getElementById('wl-power-name-sublabel');
+    const wlPowerNameHelp = document.getElementById('wl-power-name-help');
     const wlInClanGroup = document.getElementById('wl-in-clan-group');
+
+    // Advantages (Merit/Background) that require a sub-category/faction value
+    // in the shared power_name field. Mirrors _SUBCATEGORY_ADVANTAGES in
+    // apps/web/app/character_sheet.py (and the same-named const in the spend
+    // form's script block above) — keep all three in sync when adding triggers.
+    const WL_SUBCATEGORY_ADVANTAGES = {
+        'status': 'Faction / Group',
+    };
+
+    function setWlPowerNameLabel(label, sublabelText, placeholder, helpText) {
+        if (wlPowerNameLabel) wlPowerNameLabel.firstChild.textContent = label + ' ';
+        if (wlPowerNameSublabel) wlPowerNameSublabel.textContent = sublabelText;
+        if (wlPowerNameInput) wlPowerNameInput.placeholder = placeholder;
+        if (wlPowerNameHelp) wlPowerNameHelp.textContent = helpText;
+    }
+
+    // Show/relabel the shared power_name group for Discipline power purchases
+    // or a triggering Advantage sub-category (e.g. Status). A category is
+    // never both at once, so these two triggers are mutually exclusive.
+    function updateWlPowerNameGroup() {
+        const isDiscipline = wlCat.value === 'Discipline (In-Clan)' || wlCat.value === 'Discipline (Out-of-Clan)' || wlCat.value === 'Caitiff Discipline';
+        const needsPowerName = isDiscipline || wlCat.value === 'Ghoul Discipline';
+        const traitLower = wlTrait ? wlTrait.value.trim().toLowerCase() : '';
+        const subcategoryLabel = (wlCat.value === 'Advantage (Merit/Background)') ? WL_SUBCATEGORY_ADVANTAGES[traitLower] : undefined;
+        const needsSubcategory = !!subcategoryLabel;
+        if (wlPowerNameGroup) {
+            if (needsPowerName) {
+                wlPowerNameGroup.classList.remove('d-none');
+                setWlPowerNameLabel('Power Name', '(specific power being purchased)',
+                    'e.g., Mesmerize, Prowl, Sense the Unseen',
+                    'Required to update your character sheet when converted to a spend request.');
+                if (wlPowerNameInput) wlPowerNameInput.required = true;
+            } else if (needsSubcategory) {
+                wlPowerNameGroup.classList.remove('d-none');
+                setWlPowerNameLabel(subcategoryLabel, '',
+                    'e.g., Tremere, Anarch Movement, Cult of Set',
+                    'Enter which faction, clan, cult, or group this Status applies to.');
+                if (wlPowerNameInput) wlPowerNameInput.required = true;
+            } else {
+                wlPowerNameGroup.classList.add('d-none');
+                if (wlPowerNameInput) {
+                    wlPowerNameInput.required = false;
+                    wlPowerNameInput.value = '';
+                }
+            }
+        }
+    }
 
     function updatePreview() {
         const cost = wlCost(wlCat.value, parseInt(wlFrom.value)||0, parseInt(wlTo.value)||0);
@@ -1508,17 +1603,16 @@ document.addEventListener('DOMContentLoaded', function() {
         el?.addEventListener('change', updatePreview);
     });
 
+    // Status (and future WL_SUBCATEGORY_ADVANTAGES triggers) depend on what's
+    // typed into Trait, not just the category — re-run the power-name-group
+    // toggle on every keystroke so it appears/disappears live, matching the
+    // main spend form's trait_name 'input' listener.
+    wlTrait?.addEventListener('input', updateWlPowerNameGroup);
+
     wlCat?.addEventListener('change', function() {
         const isDiscipline = wlCat.value === 'Discipline (In-Clan)' || wlCat.value === 'Discipline (Out-of-Clan)' || wlCat.value === 'Caitiff Discipline';
-        const needsPowerName = isDiscipline || wlCat.value === 'Ghoul Discipline';
         if (wlInClanGroup) wlInClanGroup.classList.toggle('d-none', !isDiscipline);
-        if (wlPowerNameGroup) {
-            wlPowerNameGroup.classList.toggle('d-none', !needsPowerName);
-            if (wlPowerNameInput) {
-                wlPowerNameInput.required = needsPowerName;
-                if (!needsPowerName) wlPowerNameInput.value = '';
-            }
-        }
+        updateWlPowerNameGroup();
         if (wlCat.value === 'Humanity') {
             wlTrait.value = 'Humanity';
             wlTrait.readOnly = true;

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -1442,7 +1442,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // ═══ Living Sheet — pre-fill current dots from imported sheet data ═══
     const SHEET_DATA = {{ sheet_data | tojson if sheet_data else 'null' }};
 
-    function lookupCurrentDots(cat, traitName) {
+    function lookupCurrentDots(cat, traitName, powerName) {
         if (!SHEET_DATA || !traitName) return null;
         const key = traitName.trim().toLowerCase().replace(/\s+/g, '_');
         if (cat === 'Attribute') {
@@ -1463,7 +1463,17 @@ document.addEventListener('DOMContentLoaded', function() {
         if (cat === 'Advantage (Merit/Background)') {
             // Schema v7+ keeps Backgrounds in a separate array from Merits.
             const merits = (SHEET_DATA.backgrounds || []).concat(SHEET_DATA.merits || []);
-            const m = merits.find(m => m.name && m.name.toLowerCase() === traitName.trim().toLowerCase());
+            const trimmedTrait = traitName.trim();
+            const trimmedPower = (powerName || '').trim();
+            // Mirrors _effective_advantage_name in character_sheet.py: when the
+            // trait is a SUBCATEGORY_ADVANTAGES trigger (e.g. "Status") and a
+            // sub-category/faction is given, look up the folded sheet name
+            // (e.g. "Status (Tremere)") instead of the bare trait name — the
+            // bare name is a different sheet entry (or none at all).
+            const lookupName = (trimmedPower && SUBCATEGORY_ADVANTAGES[trimmedTrait.toLowerCase()])
+                ? `${trimmedTrait} (${trimmedPower})`
+                : trimmedTrait;
+            const m = merits.find(m => m.name && m.name.toLowerCase() === lookupName.toLowerCase());
             return m ? (m.level || 0) : null;
         }
         return null;
@@ -1473,7 +1483,8 @@ document.addEventListener('DOMContentLoaded', function() {
     function autofillCurrentDots() {
         const cat = spendCategory.value;
         const trait = traitNameInput ? traitNameInput.value : '';
-        const dots = lookupCurrentDots(cat, trait);
+        const power = powerNameInput ? powerNameInput.value : '';
+        const dots = lookupCurrentDots(cat, trait, power);
         if (dots != null) {
             currentDots.value = dots;
             calcCost();
@@ -1487,6 +1498,16 @@ document.addEventListener('DOMContentLoaded', function() {
         // power-name-group toggle on every keystroke so it appears/disappears
         // live as the player types "status", not only on blur.
         traitNameInput.addEventListener('input', updateDotConstraints);
+    }
+    if (powerNameInput) {
+        // The current-dots autofill for triggering Advantages (e.g. Status)
+        // depends on BOTH trait_name and power_name (faction/group) — re-run
+        // it whenever the faction input changes so a character who already
+        // has "Status (Tremere)" at N dots doesn't get silently proposed as
+        // a fresh 0-dot purchase once a faction is typed.
+        powerNameInput.addEventListener('input', autofillCurrentDots);
+        powerNameInput.addEventListener('change', autofillCurrentDots);
+        powerNameInput.addEventListener('blur', autofillCurrentDots);
     }
 
     spendCategory.addEventListener('change', function() {

--- a/apps/web/tests/test_api_requester_authz.py
+++ b/apps/web/tests/test_api_requester_authz.py
@@ -293,6 +293,61 @@ def test_claim_and_spend_include_requester_and_enforce_ownership():
         assert fake.audit[-1]['staff_user'] == 'bot-api:111111111111111111'
 
 
+def test_spend_rejects_status_advantage_without_power_name():
+    """API-path counterpart of the player-form validation: a bot/service-token
+    caller posting Status under 'Advantage (Merit/Background)' with no
+    powerName must be rejected too — this is the gap Codex flagged in #387's
+    investigation (powerName was parsed but never required, and the bot
+    couldn't even send it since SpendPayload lacked the field)."""
+    fake = FakeSheets()
+    app = _app(fake)
+    with app.test_client() as client:
+        res = client.post(
+            '/api/spends',
+            headers=_auth(),
+            json={
+                'characterName': 'Alice',
+                'spendCategory': 'Advantage (Merit/Background)',
+                'traitName': 'Status',
+                'currentDots': 0,
+                'newDots': 1,
+                'justification': 'Bot flow',
+                'isInClan': False,
+                'requesterDiscordId': '111111111111111111',
+                'requesterDiscordName': 'alice-user',
+            },
+        )
+        assert res.status_code == 400
+        assert 'powerName' in res.get_json()['error']
+        assert not fake.spends
+
+
+def test_spend_accepts_status_advantage_with_power_name():
+    """Same as above, but with powerName supplied — must be accepted."""
+    fake = FakeSheets()
+    app = _app(fake)
+    with app.test_client() as client:
+        res = client.post(
+            '/api/spends',
+            headers=_auth(),
+            json={
+                'characterName': 'Alice',
+                'spendCategory': 'Advantage (Merit/Background)',
+                'traitName': 'Status',
+                'powerName': 'Tremere',
+                'currentDots': 0,
+                'newDots': 1,
+                'justification': 'Bot flow',
+                'isInClan': False,
+                'requesterDiscordId': '111111111111111111',
+                'requesterDiscordName': 'alice-user',
+            },
+        )
+        assert res.status_code == 201
+        assert fake.spends
+        assert fake.spends[-1]['power_name'] == 'Tremere'
+
+
 def test_review_events_returns_only_reviewed_claims_and_spends():
     app = _app(FakeSheets())
     with app.test_client() as client:

--- a/apps/web/tests/test_player_status_subcategory_validation.py
+++ b/apps/web/tests/test_player_status_subcategory_validation.py
@@ -1,9 +1,19 @@
-"""Status spends with a faction/sub-category (power_name) still work fine at
-this layer. Note: power_name is NOT hard-required here yet — that requirement
-ships in a later PR (#388) bundled with the player-facing form UI that lets
-players actually supply a faction value. See GitHub issue #386 / PR #387
-discussion for why the requirement was deliberately deferred rather than
-added in this PR standalone."""
+"""Status spends with a faction/sub-category (power_name) work fine, and a
+bare "Status" submitted under the Advantage (Merit/Background) category
+without a faction is now rejected.
+
+This requirement was deliberately deferred out of PR #387 (which shipped only
+the additive/optional folded-name matching logic) into PR #388 (this one,
+which ships the player-facing form UI that lets players actually supply a
+faction value) — see GitHub issue #386.
+
+Codex flagged the version originally proposed in #387 as over-broad: it
+matched on trait_name alone, which would have forced ANY trait literally
+named "Status" — even a custom Loresheet or skill under a different spend
+category — to supply a faction. The check here is correctly scoped: it only
+fires when spend_category == 'Advantage (Merit/Background)' AND the
+lowercased trait_name is a key in _SUBCATEGORY_ADVANTAGES. See the
+non-Advantage-category regression test below."""
 
 import os
 
@@ -136,10 +146,10 @@ def test_submit_spend_unaffected_for_non_triggering_trait():
         assert rows[0].trait_name == 'Contacts'
 
 
-def test_submit_spend_accepts_status_without_faction():
-    """Confirms the hard requirement is NOT enforced at this layer yet (that
-    lands in PR #388, together with the form UI that supplies power_name for
-    Status). A bare Status spend must still be accepted here."""
+def test_submit_spend_rejects_status_without_faction():
+    """A bare Status spend under Advantage (Merit/Background) with no
+    power_name/faction is now rejected — this is the hard requirement
+    deferred from PR #387 into #388."""
     app = _app()
     _seed(app)
     client = _client(app)
@@ -151,12 +161,10 @@ def test_submit_spend_accepts_status_without_faction():
     assert resp.status_code == 200
     with app.app_context():
         rows = DbSpendRequest.query.all()
-        assert len(rows) == 1
-        assert rows[0].trait_name == 'Status'
-        assert not rows[0].power_name
+        assert len(rows) == 0
 
 
-def test_wishlist_add_accepts_status_without_faction():
+def test_wishlist_add_rejects_status_without_faction():
     """Same as above, for the wishlist-add route."""
     app = _app()
     _seed(app)
@@ -164,6 +172,67 @@ def test_wishlist_add_accepts_status_without_faction():
 
     resp = client.post(
         '/player/Faction Fred/wishlist/add', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbWishListItem.query.all()
+        assert len(rows) == 0
+
+
+def test_submit_spend_rejects_status_without_faction_case_insensitive():
+    """The trait-name match is case-insensitive, mirroring the backend fold."""
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/spend',
+        data=_base_form(trait_name='StAtUs'),
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 0
+
+
+def test_submit_spend_status_under_non_advantage_category_not_rejected():
+    """Regression test proving the category gate works: Codex correctly
+    flagged that a trait literally named "Status" under a DIFFERENT spend
+    category (e.g. a custom Loresheet or skill someone named "Status") must
+    NOT be forced to supply a faction — the folded-name matching this
+    requirement protects only ever applies to
+    'Advantage (Merit/Background)'."""
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/spend',
+        data=_base_form(spend_category='Loresheet', trait_name='Status', new_dots='1'),
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Status'
+        assert not rows[0].power_name
+
+
+def test_wishlist_add_status_under_non_advantage_category_not_rejected():
+    """Same category-gate regression check, for the wishlist-add route."""
+    app = _app()
+    _seed(app)
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Faction Fred/wishlist/add',
+        data=_base_form(spend_category='Loresheet', trait_name='Status', new_dots='1'),
+        follow_redirects=True,
     )
 
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

PR 2 of 3 for #386 (structured per-faction Status tracking). Stacks on #387 (PR 1, backend) — **requires #387 to be merged first**, since the server-side `power_name`-required validation this depends on lives there.

Adds the player-facing form input so players actually see and fill in the sub-category/faction field for triggering Advantages (currently just Status), mirroring the existing Discipline "Power Name" conditional-input pattern as closely as possible rather than inventing a new UI pattern.

## UI approach: shared input, not a second field

Both the main spend-request form and the wish-list mini-form already had a single `power_name` input/group used for Discipline power names. Rather than adding a *second* `name="power_name"` input for Status (which would mean two same-named inputs coexisting in one `<form>` — fragile, since a category is never both a Discipline and an Advantage at once, but keeping both in the DOM risks both being visible/required or both submitting values if the mutual-exclusivity logic ever has a gap), I relabel the **same** input/group at runtime:

- Label, placeholder, and help text are swapped between "Power Name" (Discipline) and "Faction / Group" (Status) depending on which trigger is active.
- `spend_category === 'Advantage (Merit/Background)' && trait_name.trim().toLowerCase() === 'status'` now also opens the group and marks the input `required`, matching how the Discipline trigger already worked.
- A small `SUBCATEGORY_ADVANTAGES` JS map (`{'status': 'Faction / Group'}`) mirrors `_SUBCATEGORY_ADVANTAGES` in `apps/web/app/character_sheet.py` from PR 1 — adding a future trigger trait is a one-line change in three places (backend dict + two JS copies, one per form), called out in comments at each site.

## Trait-name-driven toggle

The existing toggle logic only listened for `spend_category` `change` events. Since the Status trigger also depends on typed text in Trait Name (not selectable from a fixed list), I added `input` listeners on `trait_name` (main form) and `wl-trait` (wish-list form) that re-run the same group-toggle function, so the Faction/Group field appears/disappears live as the player types "status".

## Files changed (original scope)

`apps/web/app/templates/player/character.html`:
- Main spend form (`power-name-group` / `power_name`, ~L687-696): added `id`s to label/sublabel/help text nodes so JS can swap them; `updateDotConstraints()` (~L1394-1421) now also computes `needsSubcategory` and relabels via a new `setPowerNameLabel()` helper; `trait_name` gets an `input` listener (~L1482-1488).
- Wish-list mini-form (`wl-power-name-group` / `wl-power-name`, ~L1005-1016): same pattern via `updateWlPowerNameGroup()` / `setWlPowerNameLabel()`, `wl-trait` gets an `input` listener.

---

## Update: three follow-up fixes (Codex review + deferred #387 findings)

Since the original scope above, PR #387 was rebased down to *only* its additive/optional folded-name matching logic (no hard-required validation — deliberately deferred here to avoid a deploy-order hazard). This PR now also includes:

### 1. Fix Codex P1: current-dots autofill ignored faction/power_name

`autofillCurrentDots()` only ever looked up the plain trait name (e.g. "Status"), never the folded "Status (Tremere)" sheet entry #387's backend matching resolves to, and never re-ran when the faction input changed. Concrete failure: a character with an existing "Status (Tremere)" at 3 dots would autofill 0→1 instead of 3→4 — and since the backend folds "Status"+"Tremere" to the same sheet entry, approval would overwrite the existing 3-dot entry down to 1 while charging XP for only a 1-dot purchase.

Fix: `lookupCurrentDots()` now folds trait_name + power_name into "Trait (Power)" (mirroring `_effective_advantage_name` in `character_sheet.py`) for `SUBCATEGORY_ADVANTAGES` triggers, and `autofillCurrentDots()` re-runs on `power_name` input/change/blur, not just `trait_name`. The wish-list mini-form has no equivalent sheet-driven autofill (manual from/to numeric input), so nothing to change there.

### 2. Re-add required-field validation, correctly scoped this time

Restores the hard requirement deferred out of #387, in both `submit_spend` and `add_wish_list_item` (`apps/web/app/blueprints/player.py`): reject if `spend_category == 'Advantage (Merit/Background)'` AND `trait_name` is a `_SUBCATEGORY_ADVANTAGES` key AND `power_name` is blank.

Unlike the version originally removed from #387, this also gates on **category**, not just trait name — Codex correctly flagged that a trait literally named "Status" under a *different* category (e.g. a custom Loresheet) shouldn't be forced to supply a faction, since the folding logic itself only applies to Advantage (Merit/Background). Recreated/extended `apps/web/tests/test_player_status_subcategory_validation.py` (which #387 had gutted to non-rejection tests only) with rejection-path tests plus a regression test proving the category gate works.

### 3. Fix Codex P1: bot/API path could never require or send powerName

`apps/web/app/blueprints/api.py`'s `submit_spend` handler parsed `powerName` but never required it, even for Status/Advantage. `apps/bot/src/types.ts`'s `SpendPayload` had no `powerName` field at all, so the bot literally couldn't send one. Fixed:
- `api.py`: same category+trigger-gated required-field check as player.py, reusing `_SUBCATEGORY_ADVANTAGES`, returning 400 matching this handler's existing error style.
- `apps/bot/src/types.ts`: added `powerName?: string` to `SpendPayload` so a future bot command can send it (`adapter.ts`'s `submitSpend` already posts the payload as-is — no change needed there).
- Added tests to `apps/web/tests/test_api_requester_authz.py` covering both rejection (no powerName) and acceptance (with powerName).
- Confirmed `packages/api-contract` has no per-field payload schema needing an update (only `spend_categories.json`, a category enum).

## Test plan

- [x] Full `pytest` suite for `apps/web` (329 tests) passes.
- [x] `ruff check apps/web/app apps/web/tests` clean.
- [x] `python -m compileall apps/web/app apps/web/tests` clean.
- [x] Bot: `npm run check` (lint, format, typecheck, vitest, build) all pass (49 files / 340 tests).
- [x] Manual diff review of the JS changes: brace/paren balance, no duplicate `id`s, listeners correctly wired.
- [ ] Manual click-through in a running app once merged (can't run a browser as a headless agent): type "status" + a faction into the main spend form, confirm current-dots autofills to the existing sheet value; try submitting Status with no faction, confirm it's rejected with a clear message.

Related to #386. Addresses Codex findings on this PR plus the two findings deferred from #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
