### PR TITLE
Show Faction/Group distinctly in staff review UI (Status sub-category)

### DIFF
--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -8,7 +8,9 @@ from flask import (
 from app import db_service, sheets_sync
 from app.auth import require_staff, get_staff_user
 from app.xp_rules import validate_spend_request
-from app.character_sheet import patch_character_draft, find_trait_sheet_match
+from app.character_sheet import (
+    patch_character_draft, find_trait_sheet_match, subcategory_label_for_trait,
+)
 
 bp = Blueprint('spends', __name__)
 
@@ -52,6 +54,10 @@ def pending():
             'depends_on_spend': depends_on_spend,
             'sheet_match': sheet_match,
             'days': days,
+            # Distinguishes a Discipline power_name (e.g. "Auspex 3") from a
+            # structured Advantage sub-category value (e.g. "Tremere") stored
+            # in the same power_name field — see _SUBCATEGORY_ADVANTAGES.
+            'power_name_label': subcategory_label_for_trait(spend.trait_name),
         })
 
     # Oldest-first, matching the design's "sorted oldest-first" note.
@@ -95,6 +101,11 @@ def review(row_id):
         spend.character_name, spend.spend_category, spend.trait_name, spend.power_name,
     )
 
+    # Distinguishes a Discipline power_name (e.g. "Auspex 3") from a
+    # structured Advantage sub-category value (e.g. "Tremere") stored in the
+    # same power_name field — see _SUBCATEGORY_ADVANTAGES.
+    power_name_label = subcategory_label_for_trait(spend.trait_name)
+
     return render_template(
         'spends/review.html',
         spend=spend,
@@ -103,6 +114,7 @@ def review(row_id):
         depends_on_spend=depends_on_spend,
         dependents=dependents,
         sheet_match=sheet_match,
+        power_name_label=power_name_label,
     )
 
 

--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -57,7 +57,7 @@ def pending():
             # Distinguishes a Discipline power_name (e.g. "Auspex 3") from a
             # structured Advantage sub-category value (e.g. "Tremere") stored
             # in the same power_name field — see _SUBCATEGORY_ADVANTAGES.
-            'power_name_label': subcategory_label_for_trait(spend.trait_name),
+            'power_name_label': subcategory_label_for_trait(spend.trait_name, spend.spend_category),
         })
 
     # Oldest-first, matching the design's "sorted oldest-first" note.
@@ -104,7 +104,7 @@ def review(row_id):
     # Distinguishes a Discipline power_name (e.g. "Auspex 3") from a
     # structured Advantage sub-category value (e.g. "Tremere") stored in the
     # same power_name field — see _SUBCATEGORY_ADVANTAGES.
-    power_name_label = subcategory_label_for_trait(spend.trait_name)
+    power_name_label = subcategory_label_for_trait(spend.trait_name, spend.spend_category)
 
     return render_template(
         'spends/review.html',

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -33,14 +33,22 @@ _SUBCATEGORY_ADVANTAGES = {
 }
 
 
-def subcategory_label_for_trait(trait_name: str) -> str | None:
+def subcategory_label_for_trait(trait_name: str, spend_category: str | None = None) -> str | None:
     """Return the sub-category label (e.g. 'Faction / Group') for a trigger
 
     trait like 'Status', or None if trait_name isn't one of
-    _SUBCATEGORY_ADVANTAGES. Used by staff-facing templates to distinguish a
-    Discipline power_name (e.g. "Auspex 3") from a structured Advantage
-    sub-category value (e.g. "Tremere") stored in the same power_name field.
+    _SUBCATEGORY_ADVANTAGES, or spend_category isn't
+    'Advantage (Merit/Background)'. Used by staff-facing templates to
+    distinguish a Discipline power_name (e.g. "Auspex 3") from a structured
+    Advantage sub-category value (e.g. "Tremere") stored in the same
+    power_name field.
+
+    The category gate matters because trait_name is free text: a Discipline
+    spend whose trait_name happens to be typed as "Status" (a power name,
+    not the Status advantage) must not be mislabeled as a Faction/Group.
     """
+    if spend_category != 'Advantage (Merit/Background)':
+        return None
     return _SUBCATEGORY_ADVANTAGES.get((trait_name or '').strip().lower())
 
 _SHEET_MARKER_START = '<!-- CHARACTER_SHEET -->'

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -32,6 +32,17 @@ _SUBCATEGORY_ADVANTAGES = {
     'status': 'Faction / Group',
 }
 
+
+def subcategory_label_for_trait(trait_name: str) -> str | None:
+    """Return the sub-category label (e.g. 'Faction / Group') for a trigger
+
+    trait like 'Status', or None if trait_name isn't one of
+    _SUBCATEGORY_ADVANTAGES. Used by staff-facing templates to distinguish a
+    Discipline power_name (e.g. "Auspex 3") from a structured Advantage
+    sub-category value (e.g. "Tremere") stored in the same power_name field.
+    """
+    return _SUBCATEGORY_ADVANTAGES.get((trait_name or '').strip().lower())
+
 _SHEET_MARKER_START = '<!-- CHARACTER_SHEET -->'
 _SHEET_MARKER_END = '<!-- /CHARACTER_SHEET -->'
 

--- a/apps/web/app/templates/spends/pending.html
+++ b/apps/web/app/templates/spends/pending.html
@@ -68,6 +68,15 @@
           <div><div class="dp-detail-label">Validated Cost</div><div style="font-size:16px;font-weight:700;color:{{ '#3ecf7e' if valid else '#e2a53d' }};">{{ r.validation.correct_cost }} XP</div></div>
           <div><div class="dp-detail-label">Available</div><div style="font-size:16px;font-weight:700;color:var(--text);">{{ r.available_xp }} XP</div></div>
         </div>
+        {% if spend.power_name %}
+        <div style="font-size:12.5px;color:var(--text-muted);margin-bottom:10px;">
+          {% if r.power_name_label %}
+          <i class="bi bi-flag"></i> <strong>{{ r.power_name_label }}:</strong> {{ spend.power_name }}
+          {% else %}
+          <i class="bi bi-lightning"></i> {{ spend.power_name }}
+          {% endif %}
+        </div>
+        {% endif %}
         {% if spend.justification %}
         <div style="font-size:12.5px;color:var(--text-body);font-style:italic;margin-bottom:12px;">{{ spend.justification | urlize(target='_blank', rel='noopener noreferrer nofollow') }}</div>
         {% endif %}

--- a/apps/web/app/templates/spends/review.html
+++ b/apps/web/app/templates/spends/review.html
@@ -27,7 +27,13 @@
                             {% if spend.coterie_id %}<span class="badge bg-info ms-2" title="Coterie donation"><i class="bi bi-people"></i> {{ spend.coterie_name }}</span>{% endif %}
                         </h4>
                         {% if spend.power_name %}
-                        <div class="text-muted small mt-1"><i class="bi bi-lightning"></i> {{ spend.power_name }}</div>
+                        <div class="text-muted small mt-1">
+                            {% if power_name_label %}
+                            <i class="bi bi-flag"></i> <strong>{{ power_name_label }}:</strong> {{ spend.power_name }}
+                            {% else %}
+                            <i class="bi bi-lightning"></i> {{ spend.power_name }}
+                            {% endif %}
+                        </div>
                         {% endif %}
                     </div>
                     {% if spend.current_dots is not none and spend.new_dots %}

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -4,7 +4,7 @@ import pytest
 from flask import Flask
 
 import app as app_module
-from app.character_sheet import _apply_patch, find_trait_sheet_match
+from app.character_sheet import _apply_patch, find_trait_sheet_match, subcategory_label_for_trait
 from app.db import CharacterDraft, DbCharacter, db
 from app.db_service import DBService
 
@@ -241,3 +241,26 @@ def test_find_trait_sheet_match_legacy_bare_status_still_warns_against_structure
     assert sorted(m['name'] for m in result['close_matches']) == [
         'Status (Anarch Movement)', 'Status (Tremere)',
     ]
+
+
+# --- subcategory_label_for_trait -------------------------------------------
+# Used by the staff pending/review templates to distinguish a Discipline
+# power_name (e.g. "Auspex 3") from a structured Advantage sub-category value
+# (e.g. "Tremere") stored in the same power_name field, so staff see
+# "Faction / Group: Tremere" instead of mistaking it for a discipline power.
+
+def test_subcategory_label_for_trait_matches_status():
+    assert subcategory_label_for_trait('Status') == 'Faction / Group'
+
+
+def test_subcategory_label_for_trait_case_and_whitespace_insensitive():
+    assert subcategory_label_for_trait('  STATUS  ') == 'Faction / Group'
+
+
+def test_subcategory_label_for_trait_none_for_discipline():
+    assert subcategory_label_for_trait('Auspex') is None
+
+
+def test_subcategory_label_for_trait_none_for_blank():
+    assert subcategory_label_for_trait('') is None
+    assert subcategory_label_for_trait(None) is None

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -248,19 +248,48 @@ def test_find_trait_sheet_match_legacy_bare_status_still_warns_against_structure
 # power_name (e.g. "Auspex 3") from a structured Advantage sub-category value
 # (e.g. "Tremere") stored in the same power_name field, so staff see
 # "Faction / Group: Tremere" instead of mistaking it for a discipline power.
+#
+# The label is only meaningful for Advantage (Merit/Background) spends —
+# trait_name is free text, so a Discipline spend could coincidentally be
+# typed as "Status" and must not be mislabeled as a Faction/Group.
+
+_ADVANTAGE_CATEGORY = 'Advantage (Merit/Background)'
+
 
 def test_subcategory_label_for_trait_matches_status():
-    assert subcategory_label_for_trait('Status') == 'Faction / Group'
+    assert subcategory_label_for_trait('Status', _ADVANTAGE_CATEGORY) == 'Faction / Group'
 
 
 def test_subcategory_label_for_trait_case_and_whitespace_insensitive():
-    assert subcategory_label_for_trait('  STATUS  ') == 'Faction / Group'
+    assert subcategory_label_for_trait('  STATUS  ', _ADVANTAGE_CATEGORY) == 'Faction / Group'
 
 
 def test_subcategory_label_for_trait_none_for_discipline():
-    assert subcategory_label_for_trait('Auspex') is None
+    assert subcategory_label_for_trait('Auspex', _ADVANTAGE_CATEGORY) is None
 
 
 def test_subcategory_label_for_trait_none_for_blank():
-    assert subcategory_label_for_trait('') is None
-    assert subcategory_label_for_trait(None) is None
+    assert subcategory_label_for_trait('', _ADVANTAGE_CATEGORY) is None
+    assert subcategory_label_for_trait(None, _ADVANTAGE_CATEGORY) is None
+
+
+def test_subcategory_label_for_trait_none_for_non_advantage_category_even_if_status_named():
+    """Regression test for the Codex P2 finding: a Discipline spend whose
+    free-text trait_name happens to be "Status" (e.g. a player typed a
+    discipline power named "Status" with a real power_name set) must not be
+    labeled as a Faction/Group — the category gate must win over the name
+    match so staff see the Discipline power_name display instead."""
+    assert subcategory_label_for_trait('Status', 'Discipline (In-Clan)') is None
+    assert subcategory_label_for_trait('status', 'Caitiff Discipline') is None
+
+
+def test_subcategory_label_for_trait_none_when_category_omitted():
+    """Without a spend_category, the label must not be returned — callers
+    are required to pass the category through."""
+    assert subcategory_label_for_trait('Status') is None
+
+
+def test_subcategory_label_for_trait_none_for_non_triggering_advantage():
+    """Advantage-category spends for traits outside _SUBCATEGORY_ADVANTAGES
+    (e.g. Contacts) still get no label — only Status is in scope."""
+    assert subcategory_label_for_trait('Contacts', _ADVANTAGE_CATEGORY) is None


### PR DESCRIPTION
## Summary

PR 3 of 3 for #386 (structured per-faction Status tracking). Stacks on #388 (player-facing Faction/Group form input), which stacks on #387 (backend `_SUBCATEGORY_ADVANTAGES` support).

PR 1 and PR 2 made `power_name` a dual-purpose field: it now carries either a Discipline's power name (e.g. `"Auspex 3"`) or a Status advantage's faction/group (e.g. `"Tremere"`). The staff-facing pending/review templates hadn't caught up — `review.html` rendered `power_name` with a single lightning-bolt icon regardless of which kind of value it held, so a staff member reviewing a Status spend for "Tremere" would see the same presentation as a Discipline power name, with nothing to tell them it's actually a faction. `pending.html`'s expandable row detail didn't render `power_name` at all, so the faction wasn't visible there even by scrolling.

## Changes

- `apps/web/app/character_sheet.py`: added `subcategory_label_for_trait(trait_name, spend_category)`, a small public wrapper around the existing `_SUBCATEGORY_ADVANTAGES` trigger dict (e.g. returns `"Faction / Group"` for `"status"` when `spend_category == 'Advantage (Merit/Background)'`, `None` otherwise).
- `apps/web/app/blueprints/spends.py`: both `pending()` and `review()` now compute `power_name_label = subcategory_label_for_trait(spend.trait_name, spend.spend_category)` and pass it to their templates (`pending()` adds it per-row; `review()` passes it directly), following the same "compute in Python, pass a display hint to the template" pattern already used for `sheet_match`/`close_matches`.
- `apps/web/app/templates/spends/review.html` (~line 29-36): when `power_name_label` is set, shows a flag icon with `"Faction / Group: Tremere"` instead of the lightning icon; Discipline spends (no label) keep the original lightning icon with no extra text — unchanged.
- `apps/web/app/templates/spends/pending.html` (~line 71-79): the expandable row detail didn't render `power_name` at all before this change; added the same icon/label treatment so staff working from the list view (not just the full `/spends/<id>` review page) can see the faction without navigating away.
- `apps/web/tests/test_character_sheet_patch.py`: added unit tests for `subcategory_label_for_trait` (matches "status" case/whitespace-insensitively, `None` for a Discipline name, `None` for blank/`None` input, plus category-gate regression coverage — see fix below).

## Fix applied after Codex review (P2)

Codex flagged that `subcategory_label_for_trait` matched on `trait_name` alone, ignoring `spend_category`. Since `trait_name` is free text, a Discipline spend whose `trait_name` happened to be typed as `"Status"` (with a real `power_name` set) would be mislabeled `"Faction / Group"` in both `pending()` and `review()`, misrepresenting a Discipline power name as a Status faction to staff.

Fixed by requiring `spend_category == 'Advantage (Merit/Background)'` in addition to the trait_name match before returning a label. Both call sites in `blueprints/spends.py` now pass `spend.spend_category` through. Added regression tests: Advantage + "status" → label returned; Discipline category + trait_name literally "status" + power_name set → label NOT returned; Advantage + non-triggering trait ("Contacts") → label NOT returned.

## Close-match warning banner

Reviewed both the `review.html` "No exact sheet match" card and `pending.html`'s inline "closest sheet match" line against PR 1's structured-faction close-match logic. Both already surface the full existing entry name (e.g. `"Status (Tremere)"`), which is enough context for staff to see there's already a structured entry and ask the player which faction they meant — the original "Marcus bug" case. No wording change was needed; left as-is.

## Test plan

- [x] `pytest -q --cov=app --cov-report=term-missing --cov-fail-under=30` — 336 passed (full apps/web suite, post-fix)
- [x] `ruff check apps/web/app apps/web/tests` (ruff 0.15.20, matching CI's pin) — all checks passed
- [x] Manually traced both templates' rendering paths for a Discipline spend (label `None` → unchanged lightning icon) and a Status spend with `power_name="Tremere"` (label `"Faction / Group"` → new flag-icon display)

This is presentation-only for the flag/label display; there's no existing route-level (Flask test client) test coverage for `spends.pending()`/`spends.review()` template rendering in this repo to extend — coverage for this area follows the existing pattern of unit-testing the underlying pure functions (`find_trait_sheet_match`, now `subcategory_label_for_trait`) rather than asserting on rendered HTML.

Related to #386 — this is the last PR in the stack; #387 and #388 are both still open (not yet merged to main), so this doesn't close the issue on its own, but once all three merge, the full backend + form + staff-review-UI request from #386 should be delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)