### PR TITLE
Make IC/OOC/Rolls activity category IDs editable in Settings

### DIFF
--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -140,6 +140,15 @@ CC_CREATION_RULES_URL=
 CC_TICKET_CATEGORY_IDS=
 # Set to false on dev bots to prevent posting welcome messages in prod ticket channels.
 CC_TICKET_MONITOR_ENABLED=true
+
+# IC/OOC/Rolls activity-tracking category IDs (comma-separated, optional).
+# Normally managed via the web Settings page (Activity Tracking group), which
+# live-syncs to the bot every ~60s with no restart needed. These env vars are
+# only a fallback default for when no DB override is set — if left unset they
+# default to the historical hardcoded category ID set baked into the app.
+ACTIVITY_IC_CATEGORY_IDS=
+ACTIVITY_OOC_CATEGORY_IDS=
+ACTIVITY_ROLLS_CATEGORY_IDS=
 # Character submission notifier: posts an embed in the player's ticket channel when
 # they hit "Submit for Review" in the character creator.
 # Enabled by default — set to false to disable.

--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { BotConfigResponse, TrackerAdapter } from '../services/adapter';
 import { ConfigSyncWorker } from '../services/configSyncWorker';
+import { liveConfig } from '../liveConfig';
 import { currentWikiSyncOwner, tryAcquireWikiSync } from '../services/wikiSyncLock';
 import { runWikiSync } from '../scripts/discord-wiki-sync';
 
@@ -14,6 +15,9 @@ vi.mock('../config', () => ({
     webAppApiWriteToken: 'write-token',
     ccTicketMonitorEnabled: false,
     ccTicketCategoryIds: new Set<string>(),
+    activityIcCategoryIds: new Set(['default-ic']),
+    activityOocCategoryIds: new Set(['default-ooc']),
+    activityRollsCategoryIds: new Set(['default-rolls']),
     honeypotMaxAccountAgeDays: 30,
     honeypotChannelId: '',
     honeypotModLogChannelId: '',
@@ -55,6 +59,9 @@ function baseBotConfig(overrides: Partial<BotConfigResponse> = {}): BotConfigRes
     claimReminderIntervalMs: null,
     announcementsChannelId: null,
     ccTicketCategoryIds: null,
+    activityIcCategoryIds: null,
+    activityOocCategoryIds: null,
+    activityRollsCategoryIds: null,
     honeypotEnabled: null,
     honeypotRequireYoungAccount: null,
     honeypotMaxAccountAgeDays: null,
@@ -142,6 +149,30 @@ describe('ConfigSyncWorker sync orchestration', () => {
     expect(firstRunId).toEqual(expect.any(String));
     expect(adapter.ackWikiSync).toHaveBeenCalledWith('running', undefined, 'manual', firstRunId);
     expect(runWikiSync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to config.activity*CategoryIds defaults when no DB override is set', async () => {
+    const adapter = makeAdapter(baseBotConfig());
+    const worker = new ConfigSyncWorker(adapter);
+    await worker.sync();
+
+    expect(liveConfig.activityIcCategoryIds).toEqual(new Set(['default-ic']));
+    expect(liveConfig.activityOocCategoryIds).toEqual(new Set(['default-ooc']));
+    expect(liveConfig.activityRollsCategoryIds).toEqual(new Set(['default-rolls']));
+  });
+
+  it('uses the DB override for activity*CategoryIds when present, ignoring the .env-derived default', async () => {
+    const adapter = makeAdapter(baseBotConfig({
+      activityIcCategoryIds: 'ic-1, ic-2',
+      activityOocCategoryIds: 'ooc-1',
+      activityRollsCategoryIds: '',
+    }));
+    const worker = new ConfigSyncWorker(adapter);
+    await worker.sync();
+
+    expect(liveConfig.activityIcCategoryIds).toEqual(new Set(['ic-1', 'ic-2']));
+    expect(liveConfig.activityOocCategoryIds).toEqual(new Set(['ooc-1']));
+    expect(liveConfig.activityRollsCategoryIds).toEqual(new Set());
   });
 
   it('start uses provided interval and unrefs timer', () => {

--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -172,7 +172,9 @@ describe('ConfigSyncWorker sync orchestration', () => {
 
     expect(liveConfig.activityIcCategoryIds).toEqual(new Set(['ic-1', 'ic-2']));
     expect(liveConfig.activityOocCategoryIds).toEqual(new Set(['ooc-1']));
-    expect(liveConfig.activityRollsCategoryIds).toEqual(new Set());
+    // A blank override means "restore the default" (per that Settings field's
+    // own help text), not "track nothing" — falls back to the .env default.
+    expect(liveConfig.activityRollsCategoryIds).toEqual(new Set(['default-rolls']));
   });
 
   it('start uses provided interval and unrefs timer', () => {

--- a/apps/bot/src/__tests__/discordActivityCategories.test.ts
+++ b/apps/bot/src/__tests__/discordActivityCategories.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { liveConfig } from '../liveConfig';
+import {
+  categoryFromId,
+  DEFAULT_IC_CATEGORY_IDS,
+  DEFAULT_OOC_CATEGORY_IDS,
+  DEFAULT_ROLLS_CATEGORY_IDS,
+} from '../services/discordActivityCategories';
+
+describe('categoryFromId', () => {
+  afterEach(() => {
+    liveConfig.activityIcCategoryIds = new Set();
+    liveConfig.activityOocCategoryIds = new Set();
+    liveConfig.activityRollsCategoryIds = new Set();
+  });
+
+  it('reads from liveConfig rather than any hardcoded set', () => {
+    liveConfig.activityIcCategoryIds = new Set(['ic-cat']);
+    liveConfig.activityOocCategoryIds = new Set(['ooc-cat']);
+    liveConfig.activityRollsCategoryIds = new Set(['rolls-cat']);
+
+    expect(categoryFromId('ic-cat')).toBe('ic');
+    expect(categoryFromId('ooc-cat')).toBe('ooc');
+    expect(categoryFromId('rolls-cat')).toBe('rolls');
+    expect(categoryFromId('unknown-cat')).toBeNull();
+  });
+
+  it('returns null for all categories when liveConfig sets are empty', () => {
+    expect(categoryFromId('anything')).toBeNull();
+  });
+
+  it('reflects live updates without re-import (no restart needed)', () => {
+    expect(categoryFromId('late-cat')).toBeNull();
+    liveConfig.activityIcCategoryIds = new Set(['late-cat']);
+    expect(categoryFromId('late-cat')).toBe('ic');
+  });
+
+  // Regression safety net: prove the migration from hardcoded module constants
+  // to DB-editable/liveConfig-backed values didn't drop or alter any of the
+  // previously-hardcoded IDs. config.ts defaults ACTIVITY_*_CATEGORY_IDS to
+  // these exact sets when no env var / DB override is present, and
+  // configSyncWorker seeds liveConfig from config.ts on first sync.
+  it('classifies every historically-hardcoded ID exactly as before, once liveConfig is seeded from defaults', () => {
+    liveConfig.activityIcCategoryIds = new Set(DEFAULT_IC_CATEGORY_IDS);
+    liveConfig.activityOocCategoryIds = new Set(DEFAULT_OOC_CATEGORY_IDS);
+    liveConfig.activityRollsCategoryIds = new Set(DEFAULT_ROLLS_CATEGORY_IDS);
+
+    for (const id of DEFAULT_IC_CATEGORY_IDS) {
+      expect(categoryFromId(id)).toBe('ic');
+    }
+    for (const id of DEFAULT_OOC_CATEGORY_IDS) {
+      expect(categoryFromId(id)).toBe('ooc');
+    }
+    for (const id of DEFAULT_ROLLS_CATEGORY_IDS) {
+      expect(categoryFromId(id)).toBe('rolls');
+    }
+  });
+});

--- a/apps/bot/src/config.ts
+++ b/apps/bot/src/config.ts
@@ -1,4 +1,9 @@
 import { z } from 'zod';
+import {
+  DEFAULT_IC_CATEGORY_IDS,
+  DEFAULT_OOC_CATEGORY_IDS,
+  DEFAULT_ROLLS_CATEGORY_IDS,
+} from './services/discordActivityCategories';
 
 function parsePositiveInt(input: string | undefined, fallback: number, key: string): number {
   const raw = input ?? String(fallback);
@@ -159,6 +164,9 @@ const envSchema = z.object({
   APPROVE_SHEET_IN_PROGRESS_ROLE_ID: z.string().optional(),
   CC_CREATION_RULES_URL: z.string().transform(v => v || undefined).pipe(z.string().url().optional()),
   CC_TICKET_CATEGORY_IDS: z.string().optional(),
+  ACTIVITY_IC_CATEGORY_IDS: z.string().optional(),
+  ACTIVITY_OOC_CATEGORY_IDS: z.string().optional(),
+  ACTIVITY_ROLLS_CATEGORY_IDS: z.string().optional(),
   CC_TICKET_MONITOR_ENABLED: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_ENABLED: z.string().optional(),
   CC_SUBMISSION_NOTIFIER_INTERVAL_MS: z.string().optional(),
@@ -231,6 +239,14 @@ function parseCsvIds(input: string | undefined): Set<string> {
       .map((v) => v.trim())
       .filter((v) => v.length > 0),
   );
+}
+
+/** Like parseCsvIds, but falls back to *defaultSet* when the env var is unset (rather than an empty set). */
+function parseCsvIdsWithDefault(input: string | undefined, defaultSet: Set<string>): Set<string> {
+  if (!input) {
+    return new Set(defaultSet);
+  }
+  return parseCsvIds(input);
 }
 
 export const config = {
@@ -435,6 +451,10 @@ export const config = {
   approveSheetInProgressRoleId: env.APPROVE_SHEET_IN_PROGRESS_ROLE_ID ?? '',
   ccCreationRulesUrl: env.CC_CREATION_RULES_URL,
   ccTicketCategoryIds: parseCsvIds(env.CC_TICKET_CATEGORY_IDS),
+  /** IC/OOC/Rolls activity-tracking category IDs. Default to the historical hardcoded set; overridable via env or web Settings (DB override wins, see configSyncWorker.ts). */
+  activityIcCategoryIds: parseCsvIdsWithDefault(env.ACTIVITY_IC_CATEGORY_IDS, DEFAULT_IC_CATEGORY_IDS),
+  activityOocCategoryIds: parseCsvIdsWithDefault(env.ACTIVITY_OOC_CATEGORY_IDS, DEFAULT_OOC_CATEGORY_IDS),
+  activityRollsCategoryIds: parseCsvIdsWithDefault(env.ACTIVITY_ROLLS_CATEGORY_IDS, DEFAULT_ROLLS_CATEGORY_IDS),
   ccTicketMonitorEnabled: (env.CC_TICKET_MONITOR_ENABLED ?? 'true').toLowerCase() === 'true',
   ccSubmissionNotifierEnabled: (env.CC_SUBMISSION_NOTIFIER_ENABLED ?? 'false').toLowerCase() === 'true',
   ccSubmissionNotifierIntervalMs: parsePositiveInt(

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -172,9 +172,15 @@ initClientCommandCollection(client);
 // Fetch DB-backed config overrides before constructing services so interval
 // overrides set in the web UI take effect immediately on this startup.
 async function applyStartupConfigOverrides(): Promise<void> {
-  // Seed CC ticket monitor from .env defaults so it works before first DB sync.
+  // Seed CC ticket monitor and activity-category tracking from .env defaults
+  // so they work before the first DB sync (ConfigSyncWorker starts after this
+  // and isn't awaited, so any message handled in that window needs a
+  // non-empty set here rather than the liveConfig module's empty-Set default).
   liveConfig.ccTicketMonitorEnabled = config.ccTicketMonitorEnabled;
   liveConfig.ccTicketCategoryIds = new Set(config.ccTicketCategoryIds);
+  liveConfig.activityIcCategoryIds = new Set(config.activityIcCategoryIds);
+  liveConfig.activityOocCategoryIds = new Set(config.activityOocCategoryIds);
+  liveConfig.activityRollsCategoryIds = new Set(config.activityRollsCategoryIds);
   try {
     const cfg = await adapter.getBotConfig();
     if (cfg.passageOfTimeIntervalMs !== null) liveConfig.passageOfTimeIntervalMs = cfg.passageOfTimeIntervalMs;
@@ -186,6 +192,21 @@ async function applyStartupConfigOverrides(): Promise<void> {
     if (cfg.ccTicketCategoryIds !== null) {
       liveConfig.ccTicketCategoryIds = new Set(
         cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
+      );
+    }
+    if (cfg.activityIcCategoryIds && cfg.activityIcCategoryIds.trim()) {
+      liveConfig.activityIcCategoryIds = new Set(
+        cfg.activityIcCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
+      );
+    }
+    if (cfg.activityOocCategoryIds && cfg.activityOocCategoryIds.trim()) {
+      liveConfig.activityOocCategoryIds = new Set(
+        cfg.activityOocCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
+      );
+    }
+    if (cfg.activityRollsCategoryIds && cfg.activityRollsCategoryIds.trim()) {
+      liveConfig.activityRollsCategoryIds = new Set(
+        cfg.activityRollsCategoryIds.split(',').map(s => s.trim()).filter(Boolean),
       );
     }
     logEvent('info', 'startup_config_loaded', { liveConfig });

--- a/apps/bot/src/liveConfig.ts
+++ b/apps/bot/src/liveConfig.ts
@@ -23,6 +23,10 @@ export const liveConfig = {
   ccTicketMonitorEnabled: true,
   /** Category IDs to restrict the CC ticket monitor to. Seeded from .env in index.ts, then updated by ConfigSyncWorker. */
   ccTicketCategoryIds: new Set<string>(),
+  /** IC/OOC/Rolls activity-tracking category IDs. Seeded from .env in index.ts, then updated by ConfigSyncWorker. */
+  activityIcCategoryIds: new Set<string>(),
+  activityOocCategoryIds: new Set<string>(),
+  activityRollsCategoryIds: new Set<string>(),
   /** Honeypot + mention-spam breaker — fully live (checked per-message, no restart needed). */
   honeypotEnabled: false,
   honeypotRequireYoungAccount: false,

--- a/apps/bot/src/services/activityBackfillScanner.ts
+++ b/apps/bot/src/services/activityBackfillScanner.ts
@@ -11,8 +11,9 @@
 import { ChannelType, type Collection, type Guild, type Message, type Snowflake, type TextChannel, type AnyThreadChannel } from 'discord.js';
 import { errorToMessage, logEvent } from '../logger';
 import type { TrackerAdapter } from './adapter';
-import { IC_CATEGORY_IDS, OOC_CATEGORY_IDS, ROLLS_CATEGORY_IDS, type ActivityCategory } from './discordActivityCategories';
+import { categoryFromId, type ActivityCategory } from './discordActivityCategories';
 import { CUBBY_CATEGORY_NAMES } from './cubbyChannels';
+import { liveConfig } from '../liveConfig';
 
 const MESSAGES_PER_FETCH = 100;
 // Flush to API every this many accumulated entries
@@ -73,9 +74,8 @@ function utcDateOf(d: Date): string {
 function categoryForChannel(channel: TextChannel): ActivityCategory | null {
   const catId = channel.parentId;
   if (!catId) return null;
-  if (IC_CATEGORY_IDS.has(catId)) return 'ic';
-  if (OOC_CATEGORY_IDS.has(catId)) return 'ooc';
-  if (ROLLS_CATEGORY_IDS.has(catId)) return 'rolls';
+  const cat = categoryFromId(catId);
+  if (cat) return cat;
   const parent = channel.parent;
   if (parent && (CUBBY_CATEGORY_NAMES as readonly string[]).some(n => parent.name.toLowerCase().includes(n))) {
     return 'cubby';
@@ -217,7 +217,11 @@ async function _runActivityBackfillInner(
   const channels = await guild.channels.fetch();
 
   // Build set of category IDs to scan
-  const monitoredCatIds = new Set([...IC_CATEGORY_IDS, ...OOC_CATEGORY_IDS, ...ROLLS_CATEGORY_IDS]);
+  const monitoredCatIds = new Set([
+    ...liveConfig.activityIcCategoryIds,
+    ...liveConfig.activityOocCategoryIds,
+    ...liveConfig.activityRollsCategoryIds,
+  ]);
   const cubbyCatIds = new Set<string>();
   for (const ch of channels.values()) {
     if (ch?.type === ChannelType.GuildCategory) {
@@ -232,11 +236,8 @@ async function _runActivityBackfillInner(
   for (const ch of channels.values()) {
     if (!ch || ch.type !== ChannelType.GuildText) continue;
     const catId = ch.parentId ?? '';
-    let cat: ActivityCategory | null = null;
-    if (IC_CATEGORY_IDS.has(catId)) cat = 'ic';
-    else if (OOC_CATEGORY_IDS.has(catId)) cat = 'ooc';
-    else if (ROLLS_CATEGORY_IDS.has(catId)) cat = 'rolls';
-    else if (cubbyCatIds.has(catId)) cat = 'cubby';
+    let cat: ActivityCategory | null = categoryFromId(catId);
+    if (!cat && cubbyCatIds.has(catId)) cat = 'cubby';
     if (cat) toScan.push({ channel: ch as TextChannel, category: cat });
   }
 
@@ -248,11 +249,8 @@ async function _runActivityBackfillInner(
       const parent = channels.get(thread.parentId);
       if (!parent) continue;
       const catId = parent.parentId ?? '';
-      let cat: ActivityCategory | null = null;
-      if (IC_CATEGORY_IDS.has(catId)) cat = 'ic';
-      else if (OOC_CATEGORY_IDS.has(catId)) cat = 'ooc';
-      else if (ROLLS_CATEGORY_IDS.has(catId)) cat = 'rolls';
-      else if (cubbyCatIds.has(catId)) cat = 'cubby';
+      let cat: ActivityCategory | null = categoryFromId(catId);
+      if (!cat && cubbyCatIds.has(catId)) cat = 'cubby';
       if (cat) toScan.push({ channel: thread as unknown as TextChannel, category: cat });
     }
   }

--- a/apps/bot/src/services/adapter.ts
+++ b/apps/bot/src/services/adapter.ts
@@ -35,6 +35,9 @@ export interface BotConfigResponse {
   claimReminderIntervalMs: number | null;
   announcementsChannelId: string | null;
   ccTicketCategoryIds: string | null;
+  activityIcCategoryIds: string | null;
+  activityOocCategoryIds: string | null;
+  activityRollsCategoryIds: string | null;
   honeypotEnabled: boolean | null;
   honeypotRequireYoungAccount: boolean | null;
   honeypotMaxAccountAgeDays: number | null;

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -37,6 +37,15 @@ export class ConfigSyncWorker {
       liveConfig.ccTicketCategoryIds = cfg.ccTicketCategoryIds !== null
         ? new Set(cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.ccTicketCategoryIds);
+      liveConfig.activityIcCategoryIds = cfg.activityIcCategoryIds !== null
+        ? new Set(cfg.activityIcCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
+        : new Set(config.activityIcCategoryIds);
+      liveConfig.activityOocCategoryIds = cfg.activityOocCategoryIds !== null
+        ? new Set(cfg.activityOocCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
+        : new Set(config.activityOocCategoryIds);
+      liveConfig.activityRollsCategoryIds = cfg.activityRollsCategoryIds !== null
+        ? new Set(cfg.activityRollsCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
+        : new Set(config.activityRollsCategoryIds);
       if (cfg.honeypotEnabled !== null) liveConfig.honeypotEnabled = cfg.honeypotEnabled;
       if (cfg.honeypotRequireYoungAccount !== null) liveConfig.honeypotRequireYoungAccount = cfg.honeypotRequireYoungAccount;
       if (cfg.mentionBreakerEnabled !== null) liveConfig.mentionBreakerEnabled = cfg.mentionBreakerEnabled;

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -37,13 +37,17 @@ export class ConfigSyncWorker {
       liveConfig.ccTicketCategoryIds = cfg.ccTicketCategoryIds !== null
         ? new Set(cfg.ccTicketCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.ccTicketCategoryIds);
-      liveConfig.activityIcCategoryIds = cfg.activityIcCategoryIds !== null
+      // A blank override (an admin clearing the Settings field to restore the
+      // built-in default, per that field's own help text) must fall back to
+      // the .env/default set, not resolve to an empty Set that silently
+      // stops counting that category.
+      liveConfig.activityIcCategoryIds = cfg.activityIcCategoryIds && cfg.activityIcCategoryIds.trim()
         ? new Set(cfg.activityIcCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.activityIcCategoryIds);
-      liveConfig.activityOocCategoryIds = cfg.activityOocCategoryIds !== null
+      liveConfig.activityOocCategoryIds = cfg.activityOocCategoryIds && cfg.activityOocCategoryIds.trim()
         ? new Set(cfg.activityOocCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.activityOocCategoryIds);
-      liveConfig.activityRollsCategoryIds = cfg.activityRollsCategoryIds !== null
+      liveConfig.activityRollsCategoryIds = cfg.activityRollsCategoryIds && cfg.activityRollsCategoryIds.trim()
         ? new Set(cfg.activityRollsCategoryIds.split(',').map(s => s.trim()).filter(Boolean))
         : new Set(config.activityRollsCategoryIds);
       if (cfg.honeypotEnabled !== null) liveConfig.honeypotEnabled = cfg.honeypotEnabled;

--- a/apps/bot/src/services/discordActivityCategories.ts
+++ b/apps/bot/src/services/discordActivityCategories.ts
@@ -2,11 +2,21 @@
  * Discord category IDs that the activity tracker monitors for post counts.
  * Cubbies are identified by category name (see cubbyChannels.ts) rather than
  * hardcoded IDs so they don't need updating if categories are renamed/recreated.
+ *
+ * IC/OOC/Rolls category IDs are DB-editable via the web Settings page and
+ * live-synced into `liveConfig` by ConfigSyncWorker (no restart needed) — see
+ * `liveConfig.activityIcCategoryIds` / `activityOocCategoryIds` / `activityRollsCategoryIds`.
+ * When no DB override exists, ConfigSyncWorker falls back to the .env-derived
+ * `config.activityIcCategoryIds` etc. (see config.ts), which themselves default
+ * to the historical hardcoded ID set below.
  */
+
+import { liveConfig } from '../liveConfig';
 
 export type ActivityCategory = 'ic' | 'ooc' | 'rolls' | 'cubby';
 
-export const IC_CATEGORY_IDS = new Set([
+/** Historical hardcoded defaults — now the fallback default for the ACTIVITY_*_CATEGORY_IDS env vars (see config.ts). */
+export const DEFAULT_IC_CATEGORY_IDS = new Set([
   '1170106727966986381',
   '1168840134347726849',
   '1170109891747270746',
@@ -15,7 +25,7 @@ export const IC_CATEGORY_IDS = new Set([
   '1170109341051916432',
 ]);
 
-export const OOC_CATEGORY_IDS = new Set([
+export const DEFAULT_OOC_CATEGORY_IDS = new Set([
   '1168638982540759132',
   '1168643826693460089',
   '1168655400787255416',
@@ -23,14 +33,14 @@ export const OOC_CATEGORY_IDS = new Set([
   '1168643282843222086',
 ]);
 
-export const ROLLS_CATEGORY_IDS = new Set([
+export const DEFAULT_ROLLS_CATEGORY_IDS = new Set([
   '1170103481479213141',
 ]);
 
 /** Returns the activity category for a given parent category ID, or null. */
 export function categoryFromId(categoryId: string): ActivityCategory | null {
-  if (IC_CATEGORY_IDS.has(categoryId)) return 'ic';
-  if (OOC_CATEGORY_IDS.has(categoryId)) return 'ooc';
-  if (ROLLS_CATEGORY_IDS.has(categoryId)) return 'rolls';
+  if (liveConfig.activityIcCategoryIds.has(categoryId)) return 'ic';
+  if (liveConfig.activityOocCategoryIds.has(categoryId)) return 'ooc';
+  if (liveConfig.activityRollsCategoryIds.has(categoryId)) return 'rolls';
   return null;
 }

--- a/apps/web/app/app_settings.py
+++ b/apps/web/app/app_settings.py
@@ -38,6 +38,10 @@ EDITABLE_KEYS = {
     # CC ticket monitor (polled by bot via /api/bot-config; applies within 1 minute)
     'BOT_CC_TICKET_MONITOR_ENABLED',
     'BOT_CC_TICKET_CATEGORY_IDS',
+    # Activity tracking category IDs (polled by bot via /api/bot-config; applies within 1 minute)
+    'BOT_ACTIVITY_IC_CATEGORY_IDS',
+    'BOT_ACTIVITY_OOC_CATEGORY_IDS',
+    'BOT_ACTIVITY_ROLLS_CATEGORY_IDS',
     # Bot channel IDs (polled by bot via /api/bot-config; take effect after restart)
     'BOT_ANNOUNCEMENTS_CHANNEL_ID',
     'BOT_HONEYPOT_CHANNEL_ID',

--- a/apps/web/app/blueprints/api.py
+++ b/apps/web/app/blueprints/api.py
@@ -816,6 +816,9 @@ def bot_config():
         'BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID': 'correspondenceCobwebChannelId',
         'BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID': 'correspondenceRumorChannelId',
         'BOT_CORRESPONDENCE_SCENE_REQUEST_CHANNEL_ID': 'correspondenceSceneRequestChannelId',
+        'BOT_ACTIVITY_IC_CATEGORY_IDS': 'activityIcCategoryIds',
+        'BOT_ACTIVITY_OOC_CATEGORY_IDS': 'activityOocCategoryIds',
+        'BOT_ACTIVITY_ROLLS_CATEGORY_IDS': 'activityRollsCategoryIds',
     }
     all_keys = list(BOOL_KEYS) + list(INT_KEYS) + list(STR_KEYS)
     from app.db import AppSetting

--- a/apps/web/app/blueprints/settings.py
+++ b/apps/web/app/blueprints/settings.py
@@ -106,6 +106,9 @@ CHANNEL_GROUPS = [
     ('Announcements & Events', [
         'BOT_ANNOUNCEMENTS_CHANNEL_ID', 'BOT_NEW_NIGHT_BROADCAST_MESSAGE',
     ]),
+    ('Activity Tracking', [
+        'BOT_ACTIVITY_IC_CATEGORY_IDS', 'BOT_ACTIVITY_OOC_CATEGORY_IDS', 'BOT_ACTIVITY_ROLLS_CATEGORY_IDS',
+    ]),
 ]
 USED_BY = {
     'BOT_ANNOUNCEMENTS_CHANNEL_ID': '/lasombra broadcast',
@@ -127,6 +130,9 @@ USED_BY = {
     'BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID': '/cobweb',
     'BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID': '/rumor',
     'BOT_CORRESPONDENCE_SCENE_REQUEST_CHANNEL_ID': '/scene request · claim/reject buttons',
+    'BOT_ACTIVITY_IC_CATEGORY_IDS': '/lasombra scan-activity · passive activity tracking',
+    'BOT_ACTIVITY_OOC_CATEGORY_IDS': '/lasombra scan-activity · passive activity tracking',
+    'BOT_ACTIVITY_ROLLS_CATEGORY_IDS': '/lasombra scan-activity · passive activity tracking',
 }
 
 
@@ -744,6 +750,42 @@ def index():
             'editable': True,
             'description': '/scene request posts the ST queue (with Claim/Reject buttons) here. Leave blank to disable the command.',
         },
+        {
+            'label': 'IC activity category IDs',
+            'key': 'BOT_ACTIVITY_IC_CATEGORY_IDS',
+            'used_by': '/lasombra scan-activity · passive activity tracking',
+            'env': 'ACTIVITY_IC_CATEGORY_IDS',
+            'value': _eff_str('BOT_ACTIVITY_IC_CATEGORY_IDS'),
+            'placeholder': 'e.g. 123456789012345678,987654321098765432',
+            'input_pattern': None,
+            'overridden': 'BOT_ACTIVITY_IC_CATEGORY_IDS' in overrides,
+            'editable': True,
+            'description': 'Discord category IDs treated as IC for post-count activity tracking and /lasombra scan-activity backfills (comma-separated). Leave blank to use the built-in default set.',
+        },
+        {
+            'label': 'OOC activity category IDs',
+            'key': 'BOT_ACTIVITY_OOC_CATEGORY_IDS',
+            'used_by': '/lasombra scan-activity · passive activity tracking',
+            'env': 'ACTIVITY_OOC_CATEGORY_IDS',
+            'value': _eff_str('BOT_ACTIVITY_OOC_CATEGORY_IDS'),
+            'placeholder': 'e.g. 123456789012345678,987654321098765432',
+            'input_pattern': None,
+            'overridden': 'BOT_ACTIVITY_OOC_CATEGORY_IDS' in overrides,
+            'editable': True,
+            'description': 'Discord category IDs treated as OOC for post-count activity tracking and /lasombra scan-activity backfills (comma-separated). Leave blank to use the built-in default set.',
+        },
+        {
+            'label': 'Rolls activity category IDs',
+            'key': 'BOT_ACTIVITY_ROLLS_CATEGORY_IDS',
+            'used_by': '/lasombra scan-activity · passive activity tracking',
+            'env': 'ACTIVITY_ROLLS_CATEGORY_IDS',
+            'value': _eff_str('BOT_ACTIVITY_ROLLS_CATEGORY_IDS'),
+            'placeholder': 'e.g. 123456789012345678,987654321098765432',
+            'input_pattern': None,
+            'overridden': 'BOT_ACTIVITY_ROLLS_CATEGORY_IDS' in overrides,
+            'editable': True,
+            'description': 'Discord category IDs treated as Rolls for post-count activity tracking and /lasombra scan-activity backfills (comma-separated). Leave blank to use the built-in default set.',
+        },
     ]
     _channels_by_key = {c['key']: c for c in bot_channels}
     bot_channel_groups = [
@@ -1200,6 +1242,9 @@ def update():
         'BOT_CORRESPONDENCE_COBWEB_CHANNEL_ID',
         'BOT_CORRESPONDENCE_RUMOR_CHANNEL_ID',
         'BOT_CORRESPONDENCE_SCENE_REQUEST_CHANNEL_ID',
+        'BOT_ACTIVITY_IC_CATEGORY_IDS',
+        'BOT_ACTIVITY_OOC_CATEGORY_IDS',
+        'BOT_ACTIVITY_ROLLS_CATEGORY_IDS',
     }
 
     # Keys that are always boolean regardless of whether they appear in app.config.

--- a/apps/web/tests/test_activity_category_settings.py
+++ b/apps/web/tests/test_activity_category_settings.py
@@ -1,0 +1,186 @@
+"""Tests for the IC/OOC/Rolls activity-tracking category ID settings.
+
+Mirrors the existing BOT_CC_TICKET_CATEGORY_IDS pattern: DB-editable via
+Settings, exposed to the bot through /api/bot-config, applied within ~1
+minute via the bot's ConfigSyncWorker (no restart needed).
+"""
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from flask import Blueprint, Flask
+
+import app as app_module
+from app.app_settings import EDITABLE_KEYS
+from app.blueprints.api import bp as api_bp
+import app.blueprints.api as api_module
+from app.blueprints.settings import bp as settings_bp
+from app.db import AppSetting, db
+from app.db_service import DBService
+
+_TEMPLATE_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'templates')
+_STATIC_DIR = str(Path(__file__).resolve().parents[1] / 'app' / 'static')
+
+_ACTIVITY_KEYS = (
+    'BOT_ACTIVITY_IC_CATEGORY_IDS',
+    'BOT_ACTIVITY_OOC_CATEGORY_IDS',
+    'BOT_ACTIVITY_ROLLS_CATEGORY_IDS',
+)
+
+
+# ── /api/bot-config ──────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def api_app_ctx():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WEB_APP_API_TOKEN'] = 'legacy-token'
+    app.config['WEB_APP_API_READ_TOKEN'] = 'read-token'
+    app.config['WEB_APP_API_WRITE_TOKEN'] = 'write-token'
+    app.config['BOT_API_REPLAY_PROTECTION_ENABLED'] = True
+    app.config['BOT_API_REPLAY_WINDOW_SECONDS'] = 300
+    app.config['BOT_API_NONCE_TTL_SECONDS'] = 600
+    app.config['BOT_API_NONCE_CACHE_SIZE'] = 1000
+    app.config['ALLOWED_DISCORD_IDS'] = {'999999999999999999'}
+    db.init_app(app)
+    app.register_blueprint(api_bp, url_prefix='/api')
+    with app.app_context():
+        db.create_all()
+        app_module.db_service = DBService()
+        api_module.db_service = app_module.db_service
+        yield app
+
+
+def _read_headers(token='read-token'):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def test_bot_config_activity_category_ids_default_to_null(api_app_ctx):
+    with api_app_ctx.test_client() as client:
+        res = client.get('/api/bot-config', headers=_read_headers())
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body['activityIcCategoryIds'] is None
+        assert body['activityOocCategoryIds'] is None
+        assert body['activityRollsCategoryIds'] is None
+
+
+def test_bot_config_returns_db_override_for_activity_category_ids(api_app_ctx):
+    with api_app_ctx.app_context():
+        db.session.add(AppSetting(key='BOT_ACTIVITY_IC_CATEGORY_IDS', value='111,222'))
+        db.session.add(AppSetting(key='BOT_ACTIVITY_OOC_CATEGORY_IDS', value='333'))
+        db.session.add(AppSetting(key='BOT_ACTIVITY_ROLLS_CATEGORY_IDS', value='444'))
+        db.session.commit()
+
+    with api_app_ctx.test_client() as client:
+        res = client.get('/api/bot-config', headers=_read_headers())
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body['activityIcCategoryIds'] == '111,222'
+        assert body['activityOocCategoryIds'] == '333'
+        assert body['activityRollsCategoryIds'] == '444'
+
+
+# ── EDITABLE_KEYS ─────────────────────────────────────────────────────────────
+
+def test_activity_category_keys_are_editable():
+    for key in _ACTIVITY_KEYS:
+        assert key in EDITABLE_KEYS
+
+
+# ── /settings/update ──────────────────────────────────────────────────────────
+
+def _stub_bp(name: str, prefix: str, routes: dict[str, str]) -> Blueprint:
+    bp = Blueprint(name, __name__, url_prefix=prefix)
+    for rule, fn_name in routes.items():
+        bp.add_url_rule(rule, fn_name, lambda **_: ('', 200))
+    return bp
+
+
+def _settings_app():
+    app = Flask(__name__, template_folder=_TEMPLATE_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.secret_key = 'test-secret'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SETTINGS_ADMIN_DISCORD_IDS'] = {'12345'}
+    app.config['CLOUD_SPEND_ADMIN_DISCORD_IDS'] = set()
+    app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(hours=12)
+    app.jinja_env.globals['csrf_token'] = lambda: 'test-csrf'
+    db.init_app(app)
+    app.register_blueprint(_stub_bp('dashboard', '/', {'/': 'index', '/login': 'login', '/logout': 'logout'}))
+    app.register_blueprint(_stub_bp('claims', '/claims', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('spends', '/spends', {'/pending': 'pending'}))
+    app.register_blueprint(_stub_bp('roster', '/roster', {'/': 'list_characters'}))
+    app.register_blueprint(_stub_bp('periods', '/periods', {'/': 'list_periods'}))
+    app.register_blueprint(_stub_bp('audit', '/audit', {'/': 'log', '/errors': 'errors'}))
+    app.register_blueprint(_stub_bp('player', '/player', {'/': 'my_characters'}))
+    app.register_blueprint(_stub_bp('wiki', '/wiki', {'/': 'index'}))
+    app.register_blueprint(_stub_bp('cc_admin', '/cc-admin', {'/loresheets': 'loresheet_list', '/drafts': 'draft_list', '/drafts/<int:draft_id>': 'draft_review'}))
+    app.register_blueprint(_stub_bp('coteries', '/coteries', {'/': 'index'}))
+    app.register_blueprint(settings_bp, url_prefix='/settings')
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _set_session(client, discord_id: str):
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['discord_id'] = discord_id
+        sess['discord_name'] = 'Tester'
+        sess['staff_user'] = 'Tester'
+
+
+@pytest.mark.parametrize('key', _ACTIVITY_KEYS)
+def test_settings_update_saves_activity_category_ids_as_raw_string(key):
+    app = _settings_app()
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post(
+            '/settings/update',
+            data={'key': key, 'value': '123456789012345678, 987654321098765432', 'action': 'update', 'section': 'bot-channels'},
+        )
+        assert res.status_code in (302, 303)
+
+    with app.app_context():
+        record = db.session.get(AppSetting, key)
+        assert record is not None
+        # Stored as a raw comma-separated string — not coerced to bool/int.
+        assert record.value == '123456789012345678, 987654321098765432'
+
+
+@pytest.mark.parametrize('key', _ACTIVITY_KEYS)
+def test_settings_update_reset_clears_activity_category_override(key):
+    app = _settings_app()
+    with app.app_context():
+        db.session.add(AppSetting(key=key, value='111,222'))
+        db.session.commit()
+
+    with app.test_client() as client:
+        _set_session(client, '12345')
+        res = client.post(
+            '/settings/update',
+            data={'key': key, 'action': 'reset', 'section': 'bot-channels'},
+        )
+        assert res.status_code in (302, 303)
+
+    with app.app_context():
+        assert db.session.get(AppSetting, key) is None
+
+
+def test_settings_update_denied_for_non_admin():
+    app = _settings_app()
+    with app.test_client() as client:
+        _set_session(client, 'not-an-admin')
+        res = client.post(
+            '/settings/update',
+            data={'key': 'BOT_ACTIVITY_IC_CATEGORY_IDS', 'value': '111', 'action': 'update', 'section': 'bot-channels'},
+        )
+        assert res.status_code in (302, 303, 403)
+
+    with app.app_context():
+        assert db.session.get(AppSetting, 'BOT_ACTIVITY_IC_CATEGORY_IDS') is None


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `IC_CATEGORY_IDS` / `OOC_CATEGORY_IDS` / `ROLLS_CATEGORY_IDS` module constants in `apps/bot/src/services/discordActivityCategories.ts` with DB-editable Settings values, following the existing `BOT_CC_TICKET_CATEGORY_IDS` pattern exactly.
- New DB/settings keys: `BOT_ACTIVITY_IC_CATEGORY_IDS`, `BOT_ACTIVITY_OOC_CATEGORY_IDS`, `BOT_ACTIVITY_ROLLS_CATEGORY_IDS`, editable on the web Settings page (new "Activity Tracking" group in the Bot · Channel IDs pane).
- Exposed to the bot via `GET /api/bot-config` (`activityIcCategoryIds` / `activityOocCategoryIds` / `activityRollsCategoryIds`), and live-synced into `liveConfig` by `ConfigSyncWorker` every ~60s — **no bot restart required**, same mechanism as CC ticket categories.
- `categoryFromId()` in `discordActivityCategories.ts` now reads from `liveConfig` instead of hardcoded sets; `discordActivityTracker.ts` needed no changes since the function signature/return type is unchanged. `activityBackfillScanner.ts`'s inline category-membership checks were consolidated to go through `categoryFromId()` / `liveConfig` as well.
- New `.env` fallbacks `ACTIVITY_IC_CATEGORY_IDS` / `ACTIVITY_OOC_CATEGORY_IDS` / `ACTIVITY_ROLLS_CATEGORY_IDS` in `apps/bot/src/config.ts`, parsed the same way as `CC_TICKET_CATEGORY_IDS`, **defaulting to the exact previously-hardcoded ID sets** when unset (moved to `DEFAULT_IC_CATEGORY_IDS` / `DEFAULT_OOC_CATEGORY_IDS` / `DEFAULT_ROLLS_CATEGORY_IDS` in `discordActivityCategories.ts`).

## Backward compatibility

Zero behavior change for any existing deployment that doesn't set the new env vars or Settings overrides — the defaults preserve every currently-hardcoded category ID exactly. A regression test (`discordActivityCategories.test.ts`) seeds `liveConfig` from the default constants and asserts every one of the 12 historical IDs still classifies the same way. `configSyncWorker.test.ts` also covers both the DB-override path and the .env-default fallback path for the three new fields.

## Out of scope

Cubby category names were deliberately left out of scope here — cubbies are matched by category *name* (not ID) for resilience to renames, a different mechanism from IC/OOC/Rolls. If cubby category matching ever needs to become DB-editable too, the same pattern used here would apply.

## Test plan

- [x] `apps/bot`: `npm run check` (lint, format:check, typecheck, vitest, build) — all pass, 346/346 tests
- [x] `apps/web`: full `pytest` suite — 334/334 pass; `ruff check app tests` — clean
- [x] New bot test: `src/__tests__/discordActivityCategories.test.ts` — liveConfig-driven classification + default-preservation regression test
- [x] Updated bot test: `src/__tests__/configSyncWorker.test.ts` — DB-override vs .env-default fallback for the three new fields
- [x] New web test: `tests/test_activity_category_settings.py` — `/api/bot-config` field exposure (default null + DB override), `EDITABLE_KEYS` membership, `/settings/update` save (raw string, no coercion) + reset, and non-admin denial

🤖 Generated with [Claude Code](https://claude.com/claude-code)