### PR TITLE
Hotfix: cubby category matching tolerates decorative emoji

### DIFF
--- a/apps/bot/src/__tests__/cubbyChannels.test.ts
+++ b/apps/bot/src/__tests__/cubbyChannels.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { findClosestChannelName, normalizeChannelName } from '../services/cubbyChannels';
+import { findClosestChannelName, isCubbyCategoryName, normalizeChannelName } from '../services/cubbyChannels';
+
+describe('isCubbyCategoryName', () => {
+  it('matches the plain category names', () => {
+    expect(isCubbyCategoryName('Ancilla Character Cubbies')).toBe(true);
+    expect(isCubbyCategoryName('neonate character cubbies')).toBe(true);
+  });
+
+  it('matches even when staff add decorative emoji/symbols', () => {
+    // Regression: staff added a trailing folder emoji to all four cubby
+    // categories, which broke an exact-string match and caused
+    // cubbySyncWorker to see zero active cubby categories and mass-retire
+    // the entire roster (57 of 65 characters in one pass).
+    expect(isCubbyCategoryName('Ancilla Character Cubbies 📁')).toBe(true);
+    expect(isCubbyCategoryName('Fledgeling Character Cubbies 📁')).toBe(true);
+    expect(isCubbyCategoryName('  Mortal Character Cubbies 📁  ')).toBe(true);
+  });
+
+  it('does not match unrelated categories', () => {
+    expect(isCubbyCategoryName('Retired Characters')).toBe(false);
+    expect(isCubbyCategoryName('Coterie Cubbies')).toBe(false);
+  });
+});
 
 describe('normalizeChannelName', () => {
   it('lowercases, hyphenates, and trims', () => {

--- a/apps/bot/src/services/cubbyChannels.ts
+++ b/apps/bot/src/services/cubbyChannels.ts
@@ -7,6 +7,18 @@ export const CUBBY_CATEGORY_NAMES = [
   'mortal character cubbies',
 ] as const;
 
+/**
+ * Staff decorate category names with trailing emoji/symbols from time to
+ * time (e.g. "Ancilla Character Cubbies 📁"), which breaks an exact-string
+ * match against CUBBY_CATEGORY_NAMES — a mismatch here reads as "every
+ * character's cubby is gone" to cubbySyncWorker, which auto-retires the
+ * whole roster. Match by substring instead, so decoration doesn't matter.
+ */
+export function isCubbyCategoryName(name: string): boolean {
+  const normalized = name.toLowerCase().trim();
+  return CUBBY_CATEGORY_NAMES.some((n) => normalized.includes(n));
+}
+
 export type NotificationChannel = GuildBasedChannel & {
   send: (payload: { content: string; components?: unknown[]; allowedMentions?: { parse?: string[] } }) => Promise<unknown>;
 };
@@ -80,7 +92,7 @@ export async function findCubbyChannel(guild: Guild, characterName: string): Pro
   const cubbyParentIds = new Set<string>();
   for (const channel of channels.values()) {
     if (channel && channel.type === ChannelType.GuildCategory) {
-      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+      if (isCubbyCategoryName(channel.name)) {
         cubbyParentIds.add(channel.id);
       }
     }
@@ -125,7 +137,7 @@ export async function buildCubbyChannelMap(guild: Guild): Promise<Map<string, No
   const cubbyParentIds = new Set<string>();
   for (const channel of channels.values()) {
     if (channel && channel.type === ChannelType.GuildCategory) {
-      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+      if (isCubbyCategoryName(channel.name)) {
         cubbyParentIds.add(channel.id);
       }
     }
@@ -162,7 +174,7 @@ export async function getChannelsInCubbyCategories(guild: Guild): Promise<Array<
   const cubbyParentIds = new Set<string>();
   for (const channel of channels.values()) {
     if (channel && channel.type === ChannelType.GuildCategory) {
-      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+      if (isCubbyCategoryName(channel.name)) {
         cubbyParentIds.add(channel.id);
       }
     }

--- a/apps/bot/src/services/cubbySyncWorker.ts
+++ b/apps/bot/src/services/cubbySyncWorker.ts
@@ -11,7 +11,7 @@
 import { ChannelType, type Client } from 'discord.js';
 import { errorToMessage, logEvent } from '../logger';
 import type { TrackerAdapter } from './adapter';
-import { CUBBY_CATEGORY_NAMES, normalizeChannelName } from './cubbyChannels';
+import { isCubbyCategoryName, normalizeChannelName } from './cubbyChannels';
 
 type CubbySyncConfig = {
   enabled: boolean;
@@ -87,7 +87,7 @@ export class CubbySyncWorker {
     const activeCubbyParentIds = new Set<string>();
     for (const channel of allChannels.values()) {
       if (!channel || channel.type !== ChannelType.GuildCategory) continue;
-      if ((CUBBY_CATEGORY_NAMES as readonly string[]).includes(channel.name.toLowerCase().trim())) {
+      if (isCubbyCategoryName(channel.name)) {
         activeCubbyParentIds.add(channel.id);
       }
     }

--- a/apps/bot/src/services/retirementAutomationWorker.ts
+++ b/apps/bot/src/services/retirementAutomationWorker.ts
@@ -10,7 +10,7 @@ import {
 import { config } from '../config';
 import { errorToMessage, logEvent } from '../logger';
 import type { TrackerAdapter } from './adapter';
-import { CUBBY_CATEGORY_NAMES, normalizeChannelName } from './cubbyChannels';
+import { isCubbyCategoryName, normalizeChannelName } from './cubbyChannels';
 import { messagesToMarkdown, type DiscordMessageForWiki } from '../scripts/notionSync/wikiSyncHelpers';
 
 export type RetirementAutomationConfig = {
@@ -280,7 +280,7 @@ export class RetirementAutomationWorker {
       const activeParentIds = new Set<string>();
       for (const candidate of allChannels.values()) {
         if (candidate?.type === ChannelType.GuildCategory &&
-            (CUBBY_CATEGORY_NAMES as readonly string[]).includes(candidate.name.toLowerCase().trim())) {
+            isCubbyCategoryName(candidate.name)) {
           activeParentIds.add(candidate.id);
         }
       }


### PR DESCRIPTION
## Summary
Production incident: staff added a trailing folder emoji to all four cubby category names during a channel reorg. The exact-string category-name match in `cubbyChannels.ts`/`cubbySyncWorker.ts`/`retirementAutomationWorker.ts` broke instantly, and `cubbySyncWorker`'s startup scan saw zero matching active-cubby categories — so it mass-retired 57 of 65 characters (`"cubby channel no longer exists"`) in ~50 seconds. `retirementAutomationWorker` then tried to physically move each one into the Retired Characters category; most failed (that category is at Discord's 50-channel cap) and rolled back cleanly, but one character's channel was actually moved before the cap hit.

## Fix
New `isCubbyCategoryName()` helper does a substring match instead of an exact match — the same approach `activityBackfillScanner.ts` already used (which is why activity tracking wasn't affected by the same rename). All exact-match call sites now go through it.

## Test plan
- [x] New regression test reproducing the exact failure (emoji-decorated category names) plus the plain/unrelated cases
- [x] Full `npm run check` (lint, format, typecheck, 348 tests, build) passes

This is a hotfix for an active incident — DB status for the 57 affected characters and the one physically-moved channel are being remediated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)