### PR TITLE
Fix cubby-category matching in approve/edit wizards + Ghoul/Mortal role names

### DIFF
--- a/apps/bot/src/approveWizard.ts
+++ b/apps/bot/src/approveWizard.ts
@@ -18,6 +18,7 @@ import {
 import type { CommandContext } from './discord';
 import { config } from './config';
 import { errorToMessage, logEvent } from './logger';
+import { isCubbyCategoryName } from './services/cubbyChannels';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -39,10 +40,8 @@ const AGE_TO_CUBBY: Record<string, string> = {
   ancilla: 'ancilla character cubbies',
 };
 
-const CUBBY_CATEGORY_NAMES = new Set(Object.values(AGE_TO_CUBBY));
-
 const APPROVAL_ROLE_NAMES = [
-  'Kindred', 'Ghoul', 'Mortal', 'Camarilla', 'Anarch', 'Family', 'Autarkis',
+  'Kindred', 'Ghouls', 'Mortals', 'Camarilla', 'Anarch', 'Family', 'Autarkis',
   'Banu Haqim', 'Brujah', 'Clanless', 'Gangrel', 'Lasombra', 'Malkavian',
   'Ministry', 'Nosferatu', 'Ravnos', 'Salubri', 'Toreador', 'Tremere',
   'Tzimisce', 'Ventrue',
@@ -298,8 +297,7 @@ export async function startApproveWizard(
   }
 
   // Guard: don't run if already inside a cubby category
-  const parentName = channel.parent?.name.toLowerCase().trim() ?? '';
-  if (CUBBY_CATEGORY_NAMES.has(parentName)) {
+  if (channel.parent?.name && isCubbyCategoryName(channel.parent.name)) {
     await interaction.reply({
       content: `⚠️ This channel is already in **${channel.parent?.name}**. Run \`/lasombra approve\` from a Character Tickets channel.`,
       ephemeral: true,
@@ -448,7 +446,7 @@ export async function handleApproveWizardButton(
     const targetCategory = allChannels.find(
       (ch) =>
         ch?.type === ChannelType.GuildCategory &&
-        ch.name.toLowerCase().trim() === targetCubbyName,
+        ch.name.toLowerCase().includes(targetCubbyName),
     );
     if (!targetCategory) {
       results.push(`⚠️ Category **${targetCubbyName}** not found — channel not moved.`);

--- a/apps/bot/src/editWizard.ts
+++ b/apps/bot/src/editWizard.ts
@@ -343,7 +343,7 @@ export async function handleEditWizardButton(
         const targetCategory = allChannels.find(
           (ch) =>
             ch?.type === ChannelType.GuildCategory &&
-            ch.name.toLowerCase().trim() === targetCubbyName,
+            ch.name.toLowerCase().includes(targetCubbyName),
         );
         if (!targetCategory) {
           results.push(`⚠️ Category **${targetCubbyName}** not found — channel not moved.`);


### PR DESCRIPTION
## Summary
Follow-up to `hotfix/cubby-category-emoji-match` (#392). During a full audit of bot automation against the reorganized server structure, found two more call sites with the same exact-string category-name match that broke when a folder emoji was added to the four cubby category names:

- `approveWizard.ts` — `/lasombra approve`'s channel-move step, and the guard against re-running `/approve` from inside an already-placed cubby channel.
- `editWizard.ts` — `/lasombra edit`'s age-category-change channel move.

Both now match by substring, consistent with `activityBackfillScanner.ts`/`xp.ts`'s existing (working) approach.

Also fixed `APPROVAL_ROLE_NAMES` listing `'Ghoul'`/`'Mortal'` (singular) against live roles named `'Ghouls'`/`'Mortals'` (plural) — an exact-match lookup meant these two roles were never offered in the approve/edit role picker. Unrelated to the reorg, found during the same audit.

## Test plan
- [x] `npm run check` (lint, format, typecheck, 352 tests, build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)