### PR TITLE
Add Skill Specialty purchase and staff edit

### DIFF
--- a/apps/bot/src/__tests__/xpRules.test.ts
+++ b/apps/bot/src/__tests__/xpRules.test.ts
@@ -11,6 +11,7 @@ describe('xpRules', () => {
     expect(calculateXpCost('New Skill', 0, 1)).toBe(3);
     expect(calculateXpCost('Advantage (Merit/Background)', 3, 4)).toBe(3);
     expect(calculateXpCost('Loresheet', 0, 3)).toBe(9);
+    expect(calculateXpCost('Skill Specialty', 0, 1)).toBe(3);
   });
 
   it('validates player submitted costs', () => {

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -538,6 +538,18 @@ def submit_spend(name):
         flash(f'{subcategory_label} is required for {trait_name}.', 'danger')
         return redirect(url_for('player.character', name=name))
 
+    if spend_category == 'Skill Specialty':
+        from app.character_sheet import character_has_specialty, character_skill_rating
+        if not power_name:
+            flash('A specialty name is required.', 'danger')
+            return redirect(url_for('player.character', name=name))
+        if character_skill_rating(name, trait_name) < 1:
+            flash(f'{trait_name} must be rated at least 1 to buy a specialty in it.', 'danger')
+            return redirect(url_for('player.character', name=name))
+        if character_has_specialty(name, trait_name, power_name):
+            flash(f'{trait_name} already has a "{power_name}" specialty.', 'danger')
+            return redirect(url_for('player.character', name=name))
+
     try:
         current_dots = int(request.form.get('current_dots', 0))
         new_dots = int(request.form.get('new_dots', 1))

--- a/apps/web/app/blueprints/player.py
+++ b/apps/web/app/blueprints/player.py
@@ -1031,20 +1031,8 @@ def _normalize_sheet_data(data: dict) -> dict:
     Always produces skill_specialties (dict) and convictions (list) so
     templates have one format to handle.
     """
-    if 'skill_specialties' not in data:
-        cc_specs = list(data.get('skillSpecialties') or [])
-        predator = data.get('predatorType')
-        if isinstance(predator, dict):
-            cc_specs = cc_specs + list(predator.get('pickedSpecialties') or [])
-        merged: dict[str, list[str]] = {}
-        for item in cc_specs:
-            if isinstance(item, dict):
-                skill = item.get('skill', '').replace(' ', '_')
-                name = item.get('name', '').strip()
-                if skill and name:
-                    merged.setdefault(skill, []).append(name)
-        if merged:
-            data['skill_specialties'] = merged
+    from app.character_sheet import _merge_cc_specialties
+    _merge_cc_specialties(data)
 
     if not data.get('convictions'):
         conv_from_ts = [

--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -910,12 +910,14 @@ def edit_sheet(name):
     ).first()
 
     if request.method == 'GET':
-        sheet_json = json.dumps(json.loads(draft.character_data), indent=2) if draft else ''
+        sheet_data = json.loads(draft.character_data) if draft else {}
+        sheet_json = json.dumps(sheet_data, indent=2) if draft else ''
         return render_template(
             'roster/edit_sheet.html',
             char=char,
             draft=draft,
             sheet_json=sheet_json,
+            skill_specialties=sheet_data.get('skill_specialties', {}),
         )
 
     action = request.form.get('action', 'save')
@@ -975,3 +977,69 @@ def edit_sheet(name):
     db.session.commit()
     flash('Character sheet saved.', 'success')
     return redirect(url_for('roster.detail', name=name))
+
+
+@bp.route('/<name>/skill-specialty', methods=['POST'])
+@require_staff
+def edit_skill_specialty(name):
+    """Staff: directly add or remove a skill specialty on the living sheet.
+
+    No XP is charged and no spend-request row is created — this is a direct
+    administrative correction, the same trust tier as the raw sheet-JSON
+    editor above, not a player-facing purchase shortcut.
+    """
+    char_row = DbCharacter.query.filter(DbCharacter.character_name.ilike(name)).first()
+    if not char_row:
+        abort(404)
+
+    draft = CharacterDraft.query.filter_by(
+        roster_character_id=char_row.id,
+        status='approved',
+    ).first()
+    if not draft or not draft.character_data:
+        flash('No living sheet exists for this character yet.', 'danger')
+        return redirect(url_for('roster.edit_sheet', name=name))
+
+    action = request.form.get('action', '').strip()
+    skill = request.form.get('skill', '').strip()
+    specialty = request.form.get('specialty', '').strip()
+
+    if action not in ('add', 'remove') or not skill or not specialty:
+        flash('Skill and specialty name are required.', 'danger')
+        return redirect(url_for('roster.edit_sheet', name=name))
+
+    try:
+        data = json.loads(draft.character_data)
+    except (json.JSONDecodeError, TypeError):
+        flash('Living sheet JSON is invalid; fix it in the editor first.', 'danger')
+        return redirect(url_for('roster.edit_sheet', name=name))
+
+    skill_key = skill.lower()
+    specialties = data.setdefault('skill_specialties', {}).setdefault(skill_key, [])
+    staff = get_staff_user()
+
+    if action == 'add':
+        if any((s or '').strip().lower() == specialty.lower() for s in specialties):
+            flash(f'{skill} already has a "{specialty}" specialty.', 'danger')
+            return redirect(url_for('roster.edit_sheet', name=name))
+        specialties.append(specialty)
+        details = f'Staff added specialty "{specialty}" to {skill}'
+    else:
+        match = next((s for s in specialties if (s or '').strip().lower() == specialty.lower()), None)
+        if match is None:
+            flash(f'{skill} has no "{specialty}" specialty to remove.', 'danger')
+            return redirect(url_for('roster.edit_sheet', name=name))
+        specialties.remove(match)
+        details = f'Staff removed specialty "{specialty}" from {skill}'
+
+    draft.character_data = json.dumps(data)
+    draft.updated_at = datetime.now(timezone.utc)
+    db_service.log_action(
+        staff_user=staff,
+        action_type='staff_skill_specialty_edit',
+        target=name,
+        details=details,
+    )
+    db.session.commit()
+    flash(details + '.', 'success')
+    return redirect(url_for('roster.edit_sheet', name=name))

--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -10,6 +10,7 @@ from app.auth import require_staff, get_staff_user
 from app.xp_rules import validate_spend_request
 from app.character_sheet import (
     patch_character_draft, find_trait_sheet_match, subcategory_label_for_trait,
+    character_has_specialty,
 )
 
 bp = Blueprint('spends', __name__)
@@ -173,6 +174,23 @@ def approve(row_id):
         flash(
             f'Cannot approve — insufficient XP. {spend.character_name} has '
             f'{available_xp} XP available, this costs {verified_cost} XP.',
+            'danger',
+        )
+        return redirect(url_for('spends.review', row_id=row_id))
+
+    # Two identical Skill Specialty requests can both pass submit_spend's
+    # duplicate check if submitted before either is approved (neither sheet
+    # has the specialty yet). Re-check live, right before charging, so the
+    # second approval is rejected instead of silently charging XP for a
+    # patch that will no-op (character_sheet.py's staleness/duplicate guard).
+    if (
+        spend.spend_category == 'Skill Specialty'
+        and character_has_specialty(spend.character_name, spend.trait_name, spend.power_name)
+    ):
+        flash(
+            f'Cannot approve — {spend.character_name} already has a '
+            f'"{spend.power_name}" specialty in {spend.trait_name}. '
+            'This looks like a duplicate of an already-approved request.',
             'danger',
         )
         return redirect(url_for('spends.review', row_id=row_id))
@@ -392,6 +410,20 @@ def bulk_approve():
             skipped.append(
                 f'{spend.character_name} / {spend.trait_name} '
                 f'(insufficient XP: has {available_xp}, needs {verified_cost})'
+            )
+            continue
+
+        # Same re-check as the single-approve path: two identical Skill
+        # Specialty requests can both pass submit_spend's duplicate check
+        # before either is approved, so re-validate live right before
+        # charging rather than trusting the submit-time check still holds.
+        if (
+            spend.spend_category == 'Skill Specialty'
+            and character_has_specialty(spend.character_name, spend.trait_name, spend.power_name)
+        ):
+            skipped.append(
+                f'{spend.character_name} / {spend.trait_name} '
+                f'(duplicate "{spend.power_name}" specialty — already approved elsewhere)'
             )
             continue
 

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -46,7 +46,15 @@ def subcategory_label_for_trait(trait_name: str, spend_category: str | None = No
     The category gate matters because trait_name is free text: a Discipline
     spend whose trait_name happens to be typed as "Status" (a power name,
     not the Status advantage) must not be mislabeled as a Faction/Group.
+
+    Skill Specialty uses the same power_name field for the specialty name.
+    Unlike Advantage sub-categories, the trigger here is the category alone
+    (spend_category == 'Skill Specialty') — the skill name in trait_name
+    varies freely, so there's no fixed trait-name set to key off, and the
+    category itself is already unambiguous.
     """
+    if spend_category == 'Skill Specialty':
+        return 'Specialty'
     if spend_category != 'Advantage (Merit/Background)':
         return None
     return _SUBCATEGORY_ADVANTAGES.get((trait_name or '').strip().lower())
@@ -123,6 +131,36 @@ def _effective_advantage_name(trait_name: str, power_name: str) -> str:
     if power_name and trait_name.lower() in _SUBCATEGORY_ADVANTAGES:
         return f'{trait_name} ({power_name})'
     return trait_name
+
+
+def character_skill_rating(character_name: str, skill_name: str) -> int:
+    """Return the character's current dot rating for a skill (0 if unrated/unknown).
+
+    Reads the approved sheet's `skills` dict, keyed the same way `_apply_patch`
+    stores it (lowercased skill name) — the source of truth for the
+    "skill must be rated >= 1" gate on Skill Specialty purchases, not a
+    client-supplied value.
+    """
+    data = _load_approved_sheet_data(character_name)
+    if data is None:
+        return 0
+    try:
+        return int(data.get('skills', {}).get((skill_name or '').strip().lower(), 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def character_has_specialty(character_name: str, skill_name: str, specialty_name: str) -> bool:
+    """Return True if the character's approved sheet already has this specialty on this skill."""
+    data = _load_approved_sheet_data(character_name)
+    if data is None:
+        return False
+    skill_key = (skill_name or '').strip().lower()
+    specialty_key = (specialty_name or '').strip().lower()
+    existing = data.get('skill_specialties', {}).get(skill_key, [])
+    if not isinstance(existing, list):
+        return False
+    return any((s or '').strip().lower() == specialty_key for s in existing)
 
 
 def find_trait_sheet_match(
@@ -334,6 +372,18 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         purchases.append({'loresheet_id': trait_name, 'dot': new_dots})
         return True
 
+    if category == 'Skill Specialty':
+        # power_name carries the specialty name here (dual-purpose field, same
+        # as Discipline power name / Advantage sub-category above).
+        if not power_name:
+            return False
+        skill_key = trait_name.lower()
+        specialties = data.setdefault('skill_specialties', {}).setdefault(skill_key, [])
+        if any((s or '').lower() == power_name.lower() for s in specialties):
+            return False  # already present — submit_spend should have caught this
+        specialties.append(power_name)
+        return True
+
     if category == 'Humanity':
         data['humanity'] = new_dots
         return True
@@ -460,6 +510,17 @@ def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name:
         for lp in purchases:
             if lp.get('dot') == new_dots and lp.get('loresheet_id', '').lower() == trait_name.lower():
                 purchases.remove(lp)
+                return True
+        return False
+
+    if category == 'Skill Specialty':
+        if not power_name:
+            return False
+        skill_key = trait_name.lower()
+        specialties = data.get('skill_specialties', {}).get(skill_key, [])
+        for s in specialties:
+            if (s or '').lower() == power_name.lower():
+                specialties.remove(s)
                 return True
         return False
 

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -8,9 +8,50 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_skill_key(name: str) -> str:
+    """Canonical skill-dict key: lowercase, spaces collapsed to underscores.
+
+    Matches the fixed key lists player/sheet.html iterates (e.g. 'animal_ken')
+    and the client-side lookup in character.html's JS — a plain .lower() with
+    no space handling fails every multiword skill.
+    """
+    return re.sub(r'\s+', '_', (name or '').strip().lower())
+
+
+def _merge_cc_specialties(data: dict) -> None:
+    """Merge CC-format skillSpecialties (list of {skill, name}) into the
+    skill_specialties dict in-place, if skill_specialties isn't already set.
+
+    Mirrors the specialty-merge half of player.py's _normalize_sheet_data
+    (that function delegates here) so validation/patch logic sees the same
+    specialties a rendered sheet would — otherwise a specialty recorded only
+    in CC's list format looks unrated/absent to character_skill_rating and
+    character_has_specialty, and once a Skill Specialty patch creates
+    skill_specialties from scratch, _normalize_sheet_data's own
+    'if not already present' guard permanently stops deriving from the CC
+    list, silently orphaning any specialties that were only ever there.
+    """
+    if 'skill_specialties' in data:
+        return
+    cc_specs = list(data.get('skillSpecialties') or [])
+    predator = data.get('predatorType')
+    if isinstance(predator, dict):
+        cc_specs = cc_specs + list(predator.get('pickedSpecialties') or [])
+    merged: dict[str, list[str]] = {}
+    for item in cc_specs:
+        if isinstance(item, dict):
+            skill = _normalize_skill_key(item.get('skill', ''))
+            name = item.get('name', '').strip()
+            if skill and name:
+                merged.setdefault(skill, []).append(name)
+    if merged:
+        data['skill_specialties'] = merged
 
 _DISCIPLINE_CATEGORIES = frozenset({
     'Discipline (In-Clan)',
@@ -109,9 +150,11 @@ def _load_approved_sheet_data(character_name: str) -> dict | None:
         return None
 
     try:
-        return json.loads(draft.character_data)
+        data = json.loads(draft.character_data)
     except (json.JSONDecodeError, TypeError):
         return None
+    _merge_cc_specialties(data)
+    return data
 
 
 def _effective_advantage_name(trait_name: str, power_name: str) -> str:
@@ -145,7 +188,7 @@ def character_skill_rating(character_name: str, skill_name: str) -> int:
     if data is None:
         return 0
     try:
-        return int(data.get('skills', {}).get((skill_name or '').strip().lower(), 0))
+        return int(data.get('skills', {}).get(_normalize_skill_key(skill_name), 0))
     except (TypeError, ValueError):
         return 0
 
@@ -155,7 +198,7 @@ def character_has_specialty(character_name: str, skill_name: str, specialty_name
     data = _load_approved_sheet_data(character_name)
     if data is None:
         return False
-    skill_key = (skill_name or '').strip().lower()
+    skill_key = _normalize_skill_key(skill_name)
     specialty_key = (specialty_name or '').strip().lower()
     existing = data.get('skill_specialties', {}).get(skill_key, [])
     if not isinstance(existing, list):
@@ -236,6 +279,10 @@ def _do_patch(spend) -> bool:
         data = json.loads(draft.character_data)
     except (json.JSONDecodeError, TypeError):
         return False
+    # Merge CC-format specialties before patching so a Skill Specialty write
+    # doesn't create skill_specialties from scratch and silently orphan
+    # specialties that only ever existed in the CC skillSpecialties list.
+    _merge_cc_specialties(data)
 
     power_name = (getattr(spend, 'power_name', '') or '').strip()
     patched = _apply_patch(data, spend.spend_category, spend.trait_name, power_name, spend.new_dots)
@@ -377,7 +424,7 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         # as Discipline power name / Advantage sub-category above).
         if not power_name:
             return False
-        skill_key = trait_name.lower()
+        skill_key = _normalize_skill_key(trait_name)
         specialties = data.setdefault('skill_specialties', {}).setdefault(skill_key, [])
         if any((s or '').lower() == power_name.lower() for s in specialties):
             return False  # already present — submit_spend should have caught this
@@ -420,6 +467,7 @@ def _do_reverse_patch(spend) -> bool:
         data = json.loads(draft.character_data)
     except (json.JSONDecodeError, TypeError):
         return False
+    _merge_cc_specialties(data)
 
     power_name = (getattr(spend, 'power_name', '') or '').strip()
     reverted = _apply_reverse_patch(
@@ -516,7 +564,7 @@ def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name:
     if category == 'Skill Specialty':
         if not power_name:
             return False
-        skill_key = trait_name.lower()
+        skill_key = _normalize_skill_key(trait_name)
         specialties = data.get('skill_specialties', {}).get(skill_key, [])
         for s in specialties:
             if (s or '').lower() == power_name.lower():

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -682,6 +682,9 @@
                             <label for="trait_name" class="form-label fw-bold">Trait Name</label>
                             <input type="text" class="form-control" name="trait_name" id="trait_name"
                                    placeholder="e.g., Strength, Dominate, Allies" required>
+                            <!-- Populated by JS with skills rated >= 1 when Skill Specialty is
+                                 selected — client-side convenience only, server-side is the gate. -->
+                            <datalist id="specialty-skill-options"></datalist>
                         </div>
 
                         <!-- Power Name (discipline spends) / Faction-Group (Status advantage) -->
@@ -1300,6 +1303,7 @@ document.addEventListener('DOMContentLoaded', function() {
         'Loresheet':                   { level_mult: 3, min: 0, max: 5 },
         'Ghoul Discipline':            { flat: 10, min: 0, max: 1 },
         'Humanity':                    { multiplier: 2, min: 1, max: 10 },
+        'Skill Specialty':             { flat: 3, min: 0, max: 1 },
     };
 
     function calcCost() {
@@ -1405,6 +1409,12 @@ document.addEventListener('DOMContentLoaded', function() {
         const traitLower = traitNameInput ? traitNameInput.value.trim().toLowerCase() : '';
         const subcategoryLabel = (cat === 'Advantage (Merit/Background)') ? SUBCATEGORY_ADVANTAGES[traitLower] : undefined;
         const needsSubcategory = !!subcategoryLabel;
+        // Skill Specialty also shares the power_name field (for the specialty
+        // name), gated by category alone rather than a trait-name lookup —
+        // the skill name in Trait Name varies freely, unlike the fixed
+        // SUBCATEGORY_ADVANTAGES trigger set. Mirrors subcategory_label_for_trait
+        // in character_sheet.py.
+        const needsSpecialty = cat === 'Skill Specialty';
         if (powerNameGroup) {
             if (needsPowerName) {
                 powerNameGroup.classList.remove('d-none');
@@ -1418,12 +1428,31 @@ document.addEventListener('DOMContentLoaded', function() {
                     'e.g., Tremere, Anarch Movement, Cult of Set',
                     'Enter which faction, clan, cult, or group this Status applies to.');
                 if (powerNameInput) powerNameInput.required = true;
+            } else if (needsSpecialty) {
+                powerNameGroup.classList.remove('d-none');
+                setPowerNameLabel('Specialty Name', '',
+                    'e.g., Quickdraw, Interrogation, Hot-Wiring',
+                    'Enter the specialty name. The skill in Trait Name must already be rated at least 1.');
+                if (powerNameInput) powerNameInput.required = true;
             } else {
                 powerNameGroup.classList.add('d-none');
                 if (powerNameInput) {
                     powerNameInput.required = false;
                     powerNameInput.value = '';
                 }
+            }
+        }
+
+        // Skill Specialty: constrain Trait Name to skills rated >= 1 via a
+        // datalist (client-side convenience only — the real gate is
+        // server-side in submit_spend, since a client-supplied rating can't
+        // be trusted).
+        if (traitNameInput) {
+            if (needsSpecialty) {
+                traitNameInput.setAttribute('list', 'specialty-skill-options');
+                populateSpecialtySkillOptions();
+            } else {
+                traitNameInput.removeAttribute('list');
             }
         }
 
@@ -1437,6 +1466,20 @@ document.addEventListener('DOMContentLoaded', function() {
                 traitNameInput.readOnly = false;
             }
         }
+    }
+
+    function populateSpecialtySkillOptions() {
+        const datalist = document.getElementById('specialty-skill-options');
+        if (!datalist) return;
+        datalist.innerHTML = '';
+        const skills = (SHEET_DATA && SHEET_DATA.skills) || {};
+        Object.keys(skills).forEach(function(key) {
+            if ((skills[key] || 0) >= 1) {
+                const opt = document.createElement('option');
+                opt.value = key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+                datalist.appendChild(opt);
+            }
+        });
     }
 
     // ═══ Living Sheet — pre-fill current dots from imported sheet data ═══

--- a/apps/web/app/templates/roster/edit_sheet.html
+++ b/apps/web/app/templates/roster/edit_sheet.html
@@ -83,6 +83,47 @@
         </div>
         {% endif %}
 
+        {% if draft %}
+        <div class="card border-secondary mb-3">
+            <div class="card-header py-2">
+                <small class="text-muted" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.08em;">
+                    <i class="bi bi-stars"></i> Skill Specialties
+                </small>
+            </div>
+            <div class="card-body">
+                {% if skill_specialties %}
+                <ul class="list-unstyled mb-3" style="font-size:0.85rem;">
+                    {% for skill, specs in skill_specialties.items() %}
+                        {% for spec in specs %}
+                        <li class="d-flex justify-content-between align-items-center mb-1">
+                            <span><strong>{{ skill|capitalize }}</strong>: {{ spec }}</span>
+                            <form method="POST" action="{{ url_for('roster.edit_skill_specialty', name=char.character_name) }}" class="d-inline">
+                                <input type="hidden" name="action" value="remove">
+                                <input type="hidden" name="skill" value="{{ skill }}">
+                                <input type="hidden" name="specialty" value="{{ spec }}">
+                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-2" title="Remove">
+                                    <i class="bi bi-x"></i>
+                                </button>
+                            </form>
+                        </li>
+                        {% endfor %}
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <p class="text-muted mb-3" style="font-size:0.85rem;">No specialties on file.</p>
+                {% endif %}
+                <form method="POST" action="{{ url_for('roster.edit_skill_specialty', name=char.character_name) }}" class="d-flex flex-column gap-2">
+                    <input type="hidden" name="action" value="add">
+                    <input type="text" name="skill" class="form-control form-control-sm" placeholder="Skill (e.g. Firearms)" required>
+                    <input type="text" name="specialty" class="form-control form-control-sm" placeholder="Specialty (e.g. Quickdraw)" required>
+                    <button type="submit" class="btn btn-sm btn-outline-secondary">
+                        <i class="bi bi-plus"></i> Add Specialty
+                    </button>
+                </form>
+            </div>
+        </div>
+        {% endif %}
+
         <div class="card border-info">
             <div class="card-header bg-info bg-opacity-10 py-2">
                 <h6 class="mb-0"><i class="bi bi-info-circle"></i> Key Fields</h6>

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -7,6 +7,8 @@ import app as app_module
 from app.character_sheet import (
     _apply_patch,
     _apply_reverse_patch,
+    _merge_cc_specialties,
+    _normalize_skill_key,
     character_has_specialty,
     character_skill_rating,
     find_trait_sheet_match,
@@ -402,3 +404,112 @@ def test_character_has_specialty_false_when_absent(app_ctx):
 def test_subcategory_label_for_trait_specialty_for_skill_specialty_category():
     assert subcategory_label_for_trait('Firearms', _SKILL_SPECIALTY) == 'Specialty'
     assert subcategory_label_for_trait('Anything', _SKILL_SPECIALTY) == 'Specialty'
+
+
+# ── _normalize_skill_key (Codex P2: multiword skills like Animal Ken) ──────
+
+
+def test_normalize_skill_key_lowercases():
+    assert _normalize_skill_key('Firearms') == 'firearms'
+
+
+def test_normalize_skill_key_collapses_spaces_to_underscore():
+    assert _normalize_skill_key('Animal Ken') == 'animal_ken'
+    assert _normalize_skill_key('animal ken') == 'animal_ken'
+    assert _normalize_skill_key('  Animal   Ken  ') == 'animal_ken'
+
+
+def test_normalize_skill_key_blank():
+    assert _normalize_skill_key('') == ''
+    assert _normalize_skill_key(None) == ''
+
+
+def test_character_skill_rating_multiword_skill(app_ctx):
+    """Regression test: a plain .lower() with no space handling would look
+    up 'animal ken' against a sheet keyed 'animal_ken' and always miss."""
+    _seed_approved_character('Beast Whisperer', {'skills': {'animal_ken': 3}})
+    assert character_skill_rating('Beast Whisperer', 'Animal Ken') == 3
+
+
+def test_apply_patch_specialty_multiword_skill_matches_rating_key():
+    """The Skill Specialty patch branch must key skill_specialties the same
+    way the sheet's skills dict and player/sheet.html's fixed key lists do
+    ('animal_ken'), or a purchased specialty would be stored under a key the
+    sheet template never looks at."""
+    data = {'skills': {'animal_ken': 2}, 'skill_specialties': {}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Animal Ken', 'Big Cats', 1)
+    assert patched is True
+    assert data['skill_specialties']['animal_ken'] == ['Big Cats']
+
+
+# ── _merge_cc_specialties (Codex P1: CC-format skillSpecialties list) ──────
+
+
+def test_merge_cc_specialties_populates_from_cc_list():
+    data = {'skillSpecialties': [{'skill': 'Firearms', 'name': 'Quickdraw'}]}
+    _merge_cc_specialties(data)
+    assert data['skill_specialties'] == {'firearms': ['Quickdraw']}
+
+
+def test_merge_cc_specialties_multiword_skill_normalized():
+    data = {'skillSpecialties': [{'skill': 'Animal Ken', 'name': 'Big Cats'}]}
+    _merge_cc_specialties(data)
+    assert data['skill_specialties'] == {'animal_ken': ['Big Cats']}
+
+
+def test_merge_cc_specialties_includes_predator_type_picks():
+    data = {
+        'skillSpecialties': [{'skill': 'Firearms', 'name': 'Quickdraw'}],
+        'predatorType': {'pickedSpecialties': [{'skill': 'Stealth', 'name': 'Shadowing'}]},
+    }
+    _merge_cc_specialties(data)
+    assert data['skill_specialties'] == {'firearms': ['Quickdraw'], 'stealth': ['Shadowing']}
+
+
+def test_merge_cc_specialties_noop_when_skill_specialties_already_present():
+    """Once skill_specialties exists (e.g. from a RoD import or a prior
+    patch), the CC list is never consulted again — this is the existing,
+    intentional guard in player.py's _normalize_sheet_data."""
+    data = {
+        'skillSpecialties': [{'skill': 'Firearms', 'name': 'Quickdraw'}],
+        'skill_specialties': {'firearms': ['Already Here']},
+    }
+    _merge_cc_specialties(data)
+    assert data['skill_specialties'] == {'firearms': ['Already Here']}
+
+
+def test_merge_cc_specialties_noop_when_no_cc_data():
+    data = {'skills': {'firearms': 2}}
+    _merge_cc_specialties(data)
+    assert 'skill_specialties' not in data
+
+
+def test_character_has_specialty_sees_cc_format_specialty(app_ctx):
+    """Regression test for the Codex P1 finding: without merging CC-format
+    specialties, a character whose specialty only exists as
+    skillSpecialties: [{skill, name}] would look unspecialized, letting the
+    same specialty be purchased again."""
+    _seed_approved_character('CC Imported Casey', {
+        'skills': {'firearms': 3},
+        'skillSpecialties': [{'skill': 'Firearms', 'name': 'Quickdraw'}],
+    })
+    assert character_has_specialty('CC Imported Casey', 'Firearms', 'Quickdraw') is True
+
+
+def test_apply_patch_preserves_cc_specialties_when_adding_new_one():
+    """Regression test for the Codex P1 finding: patching a new specialty
+    onto a sheet that already has CC-format specialties must not create a
+    skill_specialties dict from scratch and silently drop them — this test
+    exercises _merge_cc_specialties directly the way _do_patch calls it
+    before _apply_patch."""
+    data = {
+        'skills': {'firearms': 3, 'stealth': 2},
+        'skillSpecialties': [{'skill': 'Firearms', 'name': 'Quickdraw'}],
+    }
+    _merge_cc_specialties(data)
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Stealth', 'Shadowing', 1)
+    assert patched is True
+    assert data['skill_specialties'] == {
+        'firearms': ['Quickdraw'],
+        'stealth': ['Shadowing'],
+    }

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -4,7 +4,14 @@ import pytest
 from flask import Flask
 
 import app as app_module
-from app.character_sheet import _apply_patch, find_trait_sheet_match, subcategory_label_for_trait
+from app.character_sheet import (
+    _apply_patch,
+    _apply_reverse_patch,
+    character_has_specialty,
+    character_skill_rating,
+    find_trait_sheet_match,
+    subcategory_label_for_trait,
+)
 from app.db import CharacterDraft, DbCharacter, db
 from app.db_service import DBService
 
@@ -293,3 +300,105 @@ def test_subcategory_label_for_trait_none_for_non_triggering_advantage():
     """Advantage-category spends for traits outside _SUBCATEGORY_ADVANTAGES
     (e.g. Contacts) still get no label — only Status is in scope."""
     assert subcategory_label_for_trait('Contacts', _ADVANTAGE_CATEGORY) is None
+
+
+# ── Skill Specialty ─────────────────────────────────────────────────────────
+
+_SKILL_SPECIALTY = 'Skill Specialty'
+
+
+def test_apply_patch_adds_specialty():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Firearms', 'Quickdraw', 1)
+    assert patched is True
+    assert data['skill_specialties']['firearms'] == ['Quickdraw']
+
+
+def test_apply_patch_specialty_creates_skill_specialties_dict_if_missing():
+    data = {'skills': {'firearms': 2}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Firearms', 'Quickdraw', 1)
+    assert patched is True
+    assert data['skill_specialties']['firearms'] == ['Quickdraw']
+
+
+def test_apply_patch_specialty_appends_to_existing_list():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Firearms', 'Trick Shots', 1)
+    assert patched is True
+    assert data['skill_specialties']['firearms'] == ['Quickdraw', 'Trick Shots']
+
+
+def test_apply_patch_specialty_rejects_duplicate():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Firearms', 'Quickdraw', 1)
+    assert patched is False
+    assert data['skill_specialties']['firearms'] == ['Quickdraw']
+
+
+def test_apply_patch_specialty_duplicate_check_is_case_insensitive():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Firearms', 'quickdraw', 1)
+    assert patched is False
+
+
+def test_apply_patch_specialty_requires_power_name():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {}}
+    patched = _apply_patch(data, _SKILL_SPECIALTY, 'Firearms', '', 1)
+    assert patched is False
+    assert data['skill_specialties'] == {}
+
+
+def test_apply_reverse_patch_removes_specialty():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}}
+    reverted = _apply_reverse_patch(data, _SKILL_SPECIALTY, 'Firearms', 'Quickdraw', 0, 1)
+    assert reverted is True
+    assert data['skill_specialties']['firearms'] == []
+
+
+def test_apply_reverse_patch_specialty_no_op_if_already_removed():
+    """Staleness guard: if the specialty isn't present anymore (e.g. staff
+    already removed it directly), the reversal is a no-op rather than
+    raising or clobbering unrelated state."""
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': []}}
+    reverted = _apply_reverse_patch(data, _SKILL_SPECIALTY, 'Firearms', 'Quickdraw', 0, 1)
+    assert reverted is False
+
+
+def test_apply_reverse_patch_specialty_no_op_when_missing_power_name():
+    data = {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}}
+    reverted = _apply_reverse_patch(data, _SKILL_SPECIALTY, 'Firearms', '', 0, 1)
+    assert reverted is False
+
+
+def test_character_skill_rating_reads_approved_sheet(app_ctx):
+    _seed_approved_character('Rated Rex', {'skills': {'firearms': 3}})
+    assert character_skill_rating('Rated Rex', 'Firearms') == 3
+
+
+def test_character_skill_rating_zero_for_unrated_skill(app_ctx):
+    _seed_approved_character('Unrated Uma', {'skills': {'firearms': 3}})
+    assert character_skill_rating('Unrated Uma', 'Larceny') == 0
+
+
+def test_character_skill_rating_zero_when_no_approved_sheet(app_ctx):
+    assert character_skill_rating('Nobody', 'Firearms') == 0
+
+
+def test_character_has_specialty_true_when_present(app_ctx):
+    _seed_approved_character(
+        'Specialized Sam', {'skills': {'firearms': 3}, 'skill_specialties': {'firearms': ['Quickdraw']}},
+    )
+    assert character_has_specialty('Specialized Sam', 'Firearms', 'Quickdraw') is True
+    assert character_has_specialty('Specialized Sam', 'Firearms', 'quickdraw') is True
+
+
+def test_character_has_specialty_false_when_absent(app_ctx):
+    _seed_approved_character(
+        'Specialized Sam', {'skills': {'firearms': 3}, 'skill_specialties': {'firearms': ['Quickdraw']}},
+    )
+    assert character_has_specialty('Specialized Sam', 'Firearms', 'Trick Shots') is False
+
+
+def test_subcategory_label_for_trait_specialty_for_skill_specialty_category():
+    assert subcategory_label_for_trait('Firearms', _SKILL_SPECIALTY) == 'Specialty'
+    assert subcategory_label_for_trait('Anything', _SKILL_SPECIALTY) == 'Specialty'

--- a/apps/web/tests/test_player_skill_specialty_validation.py
+++ b/apps/web/tests/test_player_skill_specialty_validation.py
@@ -1,0 +1,178 @@
+"""Skill Specialty spend requests: gated on the skill being rated >= 1 on the
+character's approved sheet, require a specialty name (power_name), and reject
+a duplicate specialty name for the same skill. See openspec change
+skill-specialties-web-editing / GitHub issue #266."""
+
+import json
+import os
+
+from flask import Blueprint, Flask
+from flask_wtf.csrf import CSRFProtect
+
+import app as app_module
+from app.blueprints import player as player_module
+from app.db import CharacterDraft, DbCharacter, DbSpendRequest, db
+from app.db_service import DBService
+
+_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), '..', 'app', 'templates')
+_STATIC_DIR = os.path.join(os.path.dirname(__file__), '..', 'app', 'static')
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__, template_folder=_TEMPLATES_DIR, static_folder=_STATIC_DIR)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'test'
+    app.config['ALLOWED_DISCORD_IDS'] = set()
+    app.config['WTF_CSRF_ENABLED'] = False
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    service = DBService()
+    app_module.db_service = service
+    player_module.db_service = service
+    player_module.sheets_sync = None
+    app.register_blueprint(player_module.bp, url_prefix='/player')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(app, character_data, discord_id='111', character_name='Skilled Sasha'):
+    with app.app_context():
+        char = DbCharacter(
+            character_name=character_name,
+            player_discord=discord_id,
+            active=True,
+            status='active',
+        )
+        db.session.add(char)
+        db.session.flush()
+        db.session.add(CharacterDraft(
+            player_discord_id=discord_id,
+            character_name=character_name,
+            status='approved',
+            roster_character_id=char.id,
+            character_data=json.dumps(character_data),
+        ))
+        db.session.commit()
+
+
+def _client(app, discord_id='111'):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['discord_id'] = discord_id
+    return client
+
+
+def _base_form(**overrides):
+    form = {
+        'spend_category': 'Skill Specialty',
+        'trait_name': 'Firearms',
+        'power_name': 'Quickdraw',
+        'justification': 'Practiced at the range',
+        'current_dots': '0',
+        'new_dots': '1',
+    }
+    form.update(overrides)
+    return form
+
+
+def test_submit_spend_accepts_specialty_on_rated_skill():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}})
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Skilled Sasha/spend', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 1
+        assert rows[0].trait_name == 'Firearms'
+        assert rows[0].power_name == 'Quickdraw'
+        assert rows[0].spend_category == 'Skill Specialty'
+
+
+def test_submit_spend_rejects_specialty_on_unrated_skill():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 0}})
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Skilled Sasha/spend', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        assert DbSpendRequest.query.count() == 0
+
+
+def test_submit_spend_rejects_specialty_on_skill_not_on_sheet():
+    app = _app()
+    _seed(app, {'skills': {}})
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Skilled Sasha/spend', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        assert DbSpendRequest.query.count() == 0
+
+
+def test_submit_spend_rejects_missing_specialty_name():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}})
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Skilled Sasha/spend', data=_base_form(power_name=''), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        assert DbSpendRequest.query.count() == 0
+
+
+def test_submit_spend_rejects_duplicate_specialty():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}})
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Skilled Sasha/spend', data=_base_form(), follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        assert DbSpendRequest.query.count() == 0
+
+
+def test_submit_spend_allows_different_specialty_on_same_skill():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}})
+    client = _client(app)
+
+    resp = client.post(
+        '/player/Skilled Sasha/spend',
+        data=_base_form(power_name='Trick Shots'),
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = DbSpendRequest.query.all()
+        assert len(rows) == 1
+        assert rows[0].power_name == 'Trick Shots'

--- a/apps/web/tests/test_roster_skill_specialty_edit.py
+++ b/apps/web/tests/test_roster_skill_specialty_edit.py
@@ -1,0 +1,178 @@
+"""Staff direct-edit of skill_specialties via roster.edit_skill_specialty:
+add/remove without an XP charge, duplicate rejection on add, staff-only
+gate. See openspec change skill-specialties-web-editing / GitHub issue #266.
+
+Requests are asserted against the redirect response directly (not
+follow_redirects=True) since the destination page (roster/edit_sheet.html)
+extends the full site nav, which references many blueprints not registered
+in this focused test app.
+"""
+
+import json
+
+from flask import Blueprint, Flask
+from flask_wtf.csrf import CSRFProtect
+
+import app as app_module
+from app.blueprints import roster as roster_module
+from app.db import CharacterDraft, DbAuditLog, DbCharacter, db
+from app.db_service import DBService
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.secret_key = 'test-secret'
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    service = DBService()
+    app_module.db_service = service
+    roster_module.db_service = service
+    app.register_blueprint(roster_module.bp, url_prefix='/roster')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(app, character_data, character_name='Specialized Sam'):
+    with app.app_context():
+        char = DbCharacter(character_name=character_name, active=True, status='active')
+        db.session.add(char)
+        db.session.flush()
+        db.session.add(CharacterDraft(
+            player_discord_id='111111111111111111',
+            character_name=character_name,
+            status='approved',
+            roster_character_id=char.id,
+            character_data=json.dumps(character_data),
+        ))
+        db.session.commit()
+
+
+def _staff_client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['staff_user'] = 'Tester'
+    return client
+
+
+def _current_specialties(app, character_name='Specialized Sam'):
+    with app.app_context():
+        draft = CharacterDraft.query.filter_by(character_name=character_name, status='approved').first()
+        return json.loads(draft.character_data).get('skill_specialties', {})
+
+
+def test_staff_can_add_specialty():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}})
+    client = _staff_client(app)
+
+    resp = client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'add', 'skill': 'Firearms', 'specialty': 'Quickdraw'},
+    )
+
+    assert resp.status_code == 302
+    assert _current_specialties(app) == {'firearms': ['Quickdraw']}
+
+
+def test_staff_add_creates_no_xp_ledger_entry():
+    """No spend request is created — this is a direct correction, not a purchase."""
+    from app.db import DbSpendRequest
+
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}})
+    client = _staff_client(app)
+
+    client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'add', 'skill': 'Firearms', 'specialty': 'Quickdraw'},
+    )
+
+    with app.app_context():
+        assert DbSpendRequest.query.count() == 0
+
+
+def test_staff_add_logs_audit_entry():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}})
+    client = _staff_client(app)
+
+    client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'add', 'skill': 'Firearms', 'specialty': 'Quickdraw'},
+    )
+
+    with app.app_context():
+        entries = DbAuditLog.query.filter_by(action_type='staff_skill_specialty_edit').all()
+        assert len(entries) == 1
+        assert 'Quickdraw' in entries[0].details
+
+
+def test_staff_can_remove_specialty():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw', 'Trick Shots']}})
+    client = _staff_client(app)
+
+    resp = client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'remove', 'skill': 'Firearms', 'specialty': 'Quickdraw'},
+    )
+
+    assert resp.status_code == 302
+    assert _current_specialties(app) == {'firearms': ['Trick Shots']}
+
+
+def test_staff_add_rejects_duplicate():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}})
+    client = _staff_client(app)
+
+    resp = client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'add', 'skill': 'Firearms', 'specialty': 'Quickdraw'},
+    )
+
+    assert resp.status_code == 302
+    assert _current_specialties(app) == {'firearms': ['Quickdraw']}
+
+
+def test_staff_remove_no_op_when_specialty_absent():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}, 'skill_specialties': {'firearms': ['Quickdraw']}})
+    client = _staff_client(app)
+
+    resp = client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'remove', 'skill': 'Firearms', 'specialty': 'Nonexistent'},
+    )
+
+    assert resp.status_code == 302
+    assert _current_specialties(app) == {'firearms': ['Quickdraw']}
+
+
+def test_non_staff_request_is_redirected_to_login():
+    app = _app()
+    _seed(app, {'skills': {'firearms': 2}})
+    client = app.test_client()
+
+    resp = client.post(
+        '/roster/Specialized Sam/skill-specialty',
+        data={'action': 'add', 'skill': 'Firearms', 'specialty': 'Quickdraw'},
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == '/login'
+    assert _current_specialties(app) == {}

--- a/apps/web/tests/test_spends_skill_specialty_approval.py
+++ b/apps/web/tests/test_spends_skill_specialty_approval.py
@@ -1,0 +1,175 @@
+"""Approving a Skill Specialty spend re-checks live for a duplicate right
+before charging XP, closing a race where two identical requests submitted
+before either is approved would otherwise both get charged even though the
+second patch is a no-op. See openspec change skill-specialties-web-editing /
+GitHub issue #266 (Codex review finding on PR #397)."""
+
+import json
+
+from flask import Blueprint, Flask
+from flask_wtf.csrf import CSRFProtect
+
+import app as app_module
+from app.blueprints import spends as spends_module
+from app.db import CharacterDraft, DbCharacter, DbSpendRequest, db
+from app.db_service import DBService
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.secret_key = 'test-secret'
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    service = DBService()
+    app_module.db_service = service
+    spends_module.db_service = service
+    spends_module.sheets_sync = None
+    app.register_blueprint(spends_module.bp, url_prefix='/spends')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(app, character_name='Specialized Sam', creation_xp=20):
+    with app.app_context():
+        char = DbCharacter(character_name=character_name, active=True, status='active', creation_xp=creation_xp)
+        db.session.add(char)
+        db.session.flush()
+        db.session.add(CharacterDraft(
+            player_discord_id='111111111111111111',
+            character_name=character_name,
+            status='approved',
+            roster_character_id=char.id,
+            character_data=json.dumps({'skills': {'firearms': 2}}),
+        ))
+        db.session.commit()
+
+
+def _submit_duplicate_pair(app, character_name='Specialized Sam'):
+    """Simulate two identical Skill Specialty requests submitted before either
+    is approved (both pass submit_spend's duplicate check at submission time)."""
+    with app.app_context():
+        service = app_module.db_service
+        for _ in range(2):
+            service.submit_spend_request(
+                character_name=character_name,
+                spend_category='Skill Specialty',
+                trait_name='Firearms',
+                current_dots=0,
+                new_dots=1,
+                is_in_clan=False,
+                justification='Practiced at the range',
+                power_name='Quickdraw',
+            )
+        rows = DbSpendRequest.query.order_by(DbSpendRequest.id.asc()).all()
+        return [r.id for r in rows]
+
+
+def _staff_client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['staff_user'] = 'Tester'
+    return client
+
+
+def test_second_identical_specialty_approval_is_rejected():
+    app = _app()
+    _seed(app)
+    row_ids = _submit_duplicate_pair(app)
+    client = _staff_client(app)
+
+    resp1 = client.post(f'/spends/{row_ids[0]}/approve', data={'verified_cost': '3'})
+    assert resp1.status_code == 302
+
+    resp2 = client.post(f'/spends/{row_ids[1]}/approve', data={'verified_cost': '3'})
+    assert resp2.status_code == 302
+
+    with app.app_context():
+        rows = {r.id: r for r in DbSpendRequest.query.all()}
+        assert rows[row_ids[0]].status == 'Approved'
+        assert rows[row_ids[1]].status == 'Pending'  # rejected, not silently approved
+
+
+def test_second_identical_specialty_approval_does_not_charge_xp():
+    app = _app()
+    _seed(app)
+    row_ids = _submit_duplicate_pair(app)
+    client = _staff_client(app)
+
+    client.post(f'/spends/{row_ids[0]}/approve', data={'verified_cost': '3'})
+    client.post(f'/spends/{row_ids[1]}/approve', data={'verified_cost': '3'})
+
+    with app.app_context():
+        totals = app_module.db_service.get_xp_totals('Specialized Sam')
+        assert totals['total_spends'] == 3  # only the first approval charged
+
+
+def test_second_identical_specialty_approval_sheet_has_one_entry():
+    app = _app()
+    _seed(app)
+    row_ids = _submit_duplicate_pair(app)
+    client = _staff_client(app)
+
+    client.post(f'/spends/{row_ids[0]}/approve', data={'verified_cost': '3'})
+    client.post(f'/spends/{row_ids[1]}/approve', data={'verified_cost': '3'})
+
+    with app.app_context():
+        draft = CharacterDraft.query.filter_by(character_name='Specialized Sam', status='approved').first()
+        data = json.loads(draft.character_data)
+        assert data['skill_specialties']['firearms'] == ['Quickdraw']
+
+
+def test_bulk_approve_skips_second_identical_specialty():
+    app = _app()
+    _seed(app)
+    row_ids = _submit_duplicate_pair(app)
+    client = _staff_client(app)
+
+    resp = client.post('/spends/bulk-approve', data={'spend_ids': [str(row_ids[0]), str(row_ids[1])]})
+    assert resp.status_code == 302
+
+    with app.app_context():
+        rows = {r.id: r for r in DbSpendRequest.query.all()}
+        assert rows[row_ids[0]].status == 'Approved'
+        assert rows[row_ids[1]].status == 'Pending'
+        totals = app_module.db_service.get_xp_totals('Specialized Sam')
+        assert totals['total_spends'] == 3
+
+
+def test_non_duplicate_specialty_still_approves_normally():
+    """Regression check: approving a Skill Specialty spend that ISN'T a
+    duplicate of anything already on the sheet still works fine."""
+    app = _app()
+    _seed(app)
+    with app.app_context():
+        app_module.db_service.submit_spend_request(
+            character_name='Specialized Sam',
+            spend_category='Skill Specialty',
+            trait_name='Firearms',
+            current_dots=0,
+            new_dots=1,
+            is_in_clan=False,
+            justification='Practiced at the range',
+            power_name='Quickdraw',
+        )
+        row_id = DbSpendRequest.query.first().id
+    client = _staff_client(app)
+
+    resp = client.post(f'/spends/{row_id}/approve', data={'verified_cost': '3'})
+    assert resp.status_code == 302
+
+    with app.app_context():
+        assert DbSpendRequest.query.get(row_id).status == 'Approved'

--- a/packages/api-contract/spend_categories.json
+++ b/packages/api-contract/spend_categories.json
@@ -10,5 +10,6 @@
   "Advantage (Merit/Background)",
   "Loresheet",
   "Ghoul Discipline",
-  "Humanity"
+  "Humanity",
+  "Skill Specialty"
 ]

--- a/packages/rules/xp_costs.json
+++ b/packages/rules/xp_costs.json
@@ -70,5 +70,11 @@
     "description": "New rating × 2",
     "min_dots": 1,
     "max_dots": 10
+  },
+  "Skill Specialty": {
+    "flat_cost": 3,
+    "description": "3 XP (0 → 1)",
+    "min_dots": 0,
+    "max_dots": 1
   }
 }


### PR DESCRIPTION
## Summary
Closes #266. Skill specialties currently only enter a character sheet via RoD/CC import — this adds two write paths:

- **Player purchase**: `Skill Specialty` spend-request category, gated to skills rated ≥ 1, flat 3 XP (V5 rules), through the normal submit → review → approve pipeline.
- **Staff direct edit**: add/remove a specialty from the sheet-edit view, no XP charge, audit-logged.

## Approach
Followed the same reuse-first pattern as the recent Status sub-category work (#386-391):
- New `Skill Specialty` entry in `xp_costs.json` reuses the existing `flat_cost` cost type (same shape as `New Skill`) — zero new cost-calculation code.
- Reuses the `power_name` field for the specialty name (now its third use: discipline power / Advantage faction / specialty name), disambiguated in staff review by category rather than trait name (simpler than the Advantage case, since the skill name varies freely).
- No new DB columns, no new submission path, no bot-side changes (spend submission is web-portal-only).

Full design rationale in `openspec/changes/skill-specialties-web-editing/design.md` (this was planned with OpenSpec — proposal/specs/design/tasks all in that folder, all 22 tasks checked off).

## Explicitly out of scope
- Wish-list parity (per the proposal's Non-Goals — can follow the same pattern later if wanted)
- Any change to existing specialty *display* (PR #262/#265 stands as-is)

## Test plan
- [x] 30 new tests (patch/reverse-patch logic, player validation route, staff edit route) — all passing
- [x] Full web suite: 374/374, ruff clean
- [x] Full bot suite: 352/352 (confirms no bot source changes needed)
- [ ] Manual browser click-through (player form + staff sheet-edit UI) — recommended before merge, noted as still-open in the OpenSpec tasks file since this repo has no JS test harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)