### PR TITLE
Fix mobile overflow hiding XP spend Review/Approve controls

### DIFF
--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -2663,6 +2663,14 @@ body.login-page {
   display: flex; align-items: center; flex-wrap: wrap; row-gap: 6px; gap: 14px; padding: 9px 18px; border-bottom: 1px solid var(--border);
   font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: var(--text-faint);
 }
+/* Column headers assume fixed-width children matching each row's layout —
+   on narrow viewports rows wrap onto multiple lines (see .dp-row above) so
+   a single-line header row no longer lines up with anything and is more
+   confusing than useful. Hiding it is simpler and more robust than trying
+   to keep two independently-maintained fixed-width layouts in sync. */
+@media (max-width: 600px) {
+  .dp-table-head { display: none; }
+}
 .dp-row {
   display: flex; align-items: center; flex-wrap: wrap; row-gap: 8px; gap: 14px; padding: 12px 18px; border-bottom: 1px solid var(--border);
   text-decoration: none; color: inherit;

--- a/apps/web/app/static/css/style.css
+++ b/apps/web/app/static/css/style.css
@@ -2660,11 +2660,11 @@ body.login-page {
 /* Boxed data table (flex rows, not <table>) */
 .dp-table { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-card); overflow: hidden; margin-bottom: 26px; }
 .dp-table-head {
-  display: flex; align-items: center; gap: 14px; padding: 9px 18px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; flex-wrap: wrap; row-gap: 6px; gap: 14px; padding: 9px 18px; border-bottom: 1px solid var(--border);
   font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: var(--text-faint);
 }
 .dp-row {
-  display: flex; align-items: center; gap: 14px; padding: 12px 18px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; flex-wrap: wrap; row-gap: 8px; gap: 14px; padding: 12px 18px; border-bottom: 1px solid var(--border);
   text-decoration: none; color: inherit;
 }
 .dp-row:last-child { border-bottom: none; }

--- a/apps/web/app/templates/audit/errors.html
+++ b/apps/web/app/templates/audit/errors.html
@@ -93,13 +93,13 @@
   </div>
   {% for entry in entries %}
   <div id="log-row-{{ entry.id }}">
-    <div style="display:flex;align-items:center;gap:14px;padding:11px 18px;border-bottom:1px solid var(--border);">
+    <div style="display:flex;align-items:center;flex-wrap:wrap;row-gap:8px;gap:14px;padding:11px 18px;border-bottom:1px solid var(--border);">
       <input type="checkbox" class="dp-checkbox error-select" value="{{ entry.id }}" style="accent-color:var(--accent);">
-      <div style="width:135px;flex-shrink:0;font-size:11.5px;color:var(--text-muted);font-family:monospace;">{{ entry.timestamp | to_eastern }}</div>
-      <div style="width:55px;flex-shrink:0;"><span class="dp-pill dp-pill--neutral">{{ entry.source }}</span></div>
-      <div style="width:65px;flex-shrink:0;"><span class="dp-pill {{ 'dp-pill--red' if entry.level == 'error' else 'dp-pill--amber' }}">{{ entry.level }}</span></div>
-      <div style="width:170px;flex-shrink:0;font-size:11.5px;color:#7cb8f0;font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ entry.event }}</div>
-      <div style="flex:1;min-width:0;font-size:12px;color:var(--text-body);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="{{ entry.message }}">{{ entry.message }}</div>
+      <div style="flex:0 1 135px;min-width:100px;font-size:11.5px;color:var(--text-muted);font-family:monospace;">{{ entry.timestamp | to_eastern }}</div>
+      <div style="flex-shrink:0;"><span class="dp-pill dp-pill--neutral">{{ entry.source }}</span></div>
+      <div style="flex-shrink:0;"><span class="dp-pill {{ 'dp-pill--red' if entry.level == 'error' else 'dp-pill--amber' }}">{{ entry.level }}</span></div>
+      <div style="flex:0 1 170px;min-width:100px;font-size:11.5px;color:#7cb8f0;font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ entry.event }}</div>
+      <div style="flex:1 1 160px;min-width:120px;font-size:12px;color:var(--text-body);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="{{ entry.message }}">{{ entry.message }}</div>
       {% if entry.occurrence_count > 1 %}
       <span class="dp-pill dp-pill--amber">×{{ entry.occurrence_count }}</span>
       {% endif %}

--- a/apps/web/app/templates/spends/pending.html
+++ b/apps/web/app/templates/spends/pending.html
@@ -42,14 +42,14 @@
     {% set valid = r.validation.matches %}
     {% set blocked = r.depends_on_spend and r.depends_on_spend.status|lower == 'pending' %}
     <div>
-      <div style="display:flex;align-items:center;gap:14px;padding:13px 18px;border-bottom:1px solid var(--border);">
+      <div style="display:flex;align-items:center;flex-wrap:wrap;row-gap:8px;gap:14px;padding:13px 18px;border-bottom:1px solid var(--border);">
         <input type="checkbox" name="spend_ids" value="{{ spend.row_index }}" form="bulk-spend-form" class="dp-checkbox spend-checkbox" {% if blocked %}disabled{% endif %}>
         <div class="dp-urgency-bar {% if r.days >= 5 %}dp-urgency-bar--high{% elif r.days >= 3 %}dp-urgency-bar--med{% else %}dp-urgency-bar--low{% endif %}"></div>
-        <div style="width:150px;flex-shrink:0;font-size:13.5px;font-weight:600;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ spend.character_name }}</div>
-        <div style="width:170px;flex-shrink:0;font-size:12.5px;color:var(--text-body);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
+        <div style="flex:0 1 150px;min-width:90px;font-size:13.5px;font-weight:600;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ spend.character_name }}</div>
+        <div style="flex:0 1 170px;min-width:110px;font-size:12.5px;color:var(--text-body);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
           {{ spend.trait_name }} <span style="color:var(--text-faint);">({{ spend.current_dots }}→{{ spend.new_dots }})</span>
         </div>
-        <div style="width:85px;flex-shrink:0;">
+        <div style="flex-shrink:0;">
           <span class="dp-pill {{ 'dp-pill--green' if valid else 'dp-pill--amber' }}">{{ '✓ Valid' if valid else '⚠ Mismatch' }}</span>
         </div>
         {% if r.depends_on_spend %}


### PR DESCRIPTION
## Summary
Reported: on mobile, the XP spend Pending page is cut off, making it impossible to act on a spend request.

Root cause: the pending-spend row is a non-wrapping flexbox with several fixed-width columns (character name 150px, trait 170px, etc.). On a narrow phone viewport the total row width exceeds the screen, so the "Review ▼" button — the only way to open Approve/Deny — gets pushed off-screen to the right with no visible scroll indicator. Same underlying issue exists in the shared `.dp-row`/`.dp-table-head` classes used by History, dashboard, roster, periods, and audit-log pages.

## Fix
- `spends/pending.html`: row now wraps (`flex-wrap:wrap`), and the name/trait columns shrink (`flex: 0 1 …px`) instead of staying rigid — content flows to a new line on narrow screens instead of being clipped.
- `style.css`: added `flex-wrap`/`row-gap` to the shared `.dp-row` and `.dp-table-head` classes, fixing the same class of bug everywhere they're used, not just the one reported page.

## Test plan
- [x] Full web suite: 346/346 (pre-existing, no logic touched)
- [x] ruff clean
- [ ] Manual mobile check recommended before merge — no visual regression testing in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)