### PR TITLE
Include Error.cause in errorToMessage, fixing opaque fetch-failure logs

### DIFF
--- a/apps/bot/src/__tests__/configSyncWorker.test.ts
+++ b/apps/bot/src/__tests__/configSyncWorker.test.ts
@@ -35,6 +35,7 @@ vi.mock('../config', () => ({
 
 vi.mock('../logger', () => ({
   logEvent: vi.fn(),
+  errorToMessage: (err: unknown) => String(err),
 }));
 
 vi.mock('../scripts/discord-wiki-sync', () => ({

--- a/apps/bot/src/__tests__/logger.test.ts
+++ b/apps/bot/src/__tests__/logger.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { errorToMessage } from '../logger';
+
+describe('errorToMessage', () => {
+  it('returns the plain message for an Error with no cause', () => {
+    expect(errorToMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('appends the cause when the Error has one', () => {
+    // Node's fetch (undici) always throws a generic "TypeError: fetch failed"
+    // for any connection-level failure — the real reason (DNS, ECONNREFUSED,
+    // TLS, connect timeout) lives in .cause. This is the exact shape that
+    // made every config_sync_failed/heartbeat_failed log indistinguishable.
+    const cause = new Error('getaddrinfo ENOTFOUND mcbn.jkomg.us');
+    const err = new Error('fetch failed', { cause });
+    expect(errorToMessage(err)).toBe('fetch failed (getaddrinfo ENOTFOUND mcbn.jkomg.us)');
+  });
+
+  it('stringifies a non-Error cause', () => {
+    const err = new Error('fetch failed');
+    (err as { cause?: unknown }).cause = 'connect ECONNREFUSED';
+    expect(errorToMessage(err)).toBe('fetch failed (connect ECONNREFUSED)');
+  });
+
+  it('does not append anything when cause is undefined', () => {
+    const err = new Error('plain failure');
+    expect(errorToMessage(err)).toBe('plain failure');
+  });
+
+  it('stringifies non-Error values unchanged', () => {
+    expect(errorToMessage('a plain string')).toBe('a plain string');
+    expect(errorToMessage(null)).toBe('null');
+    expect(errorToMessage(undefined)).toBe('undefined');
+  });
+});

--- a/apps/bot/src/__tests__/logger.test.ts
+++ b/apps/bot/src/__tests__/logger.test.ts
@@ -32,4 +32,32 @@ describe('errorToMessage', () => {
     expect(errorToMessage(null)).toBe('null');
     expect(errorToMessage(undefined)).toBe('undefined');
   });
+
+  it('formats an AggregateError cause by its sub-errors, not its own empty message', () => {
+    // When a hostname resolves to multiple addresses (IPv4 + IPv6) and every
+    // connection attempt fails, Node sets fetch's TypeError.cause to an
+    // AggregateError whose own .message is empty — the real per-attempt
+    // reasons (e.g. ECONNREFUSED) live in .errors. Codex review finding on
+    // PR #400.
+    const aggregate = new AggregateError(
+      [new Error('connect ECONNREFUSED 127.0.0.1:443'), new Error('connect ECONNREFUSED ::1:443')],
+      '',
+    );
+    const err = new Error('fetch failed', { cause: aggregate });
+    expect(errorToMessage(err)).toBe(
+      'fetch failed (AggregateError: connect ECONNREFUSED 127.0.0.1:443; connect ECONNREFUSED ::1:443)',
+    );
+  });
+
+  it('formats an AggregateError with a non-empty message too', () => {
+    const aggregate = new AggregateError([new Error('ECONNREFUSED')], 'all promises rejected');
+    const err = new Error('fetch failed', { cause: aggregate });
+    expect(errorToMessage(err)).toBe('fetch failed (all promises rejected: ECONNREFUSED)');
+  });
+
+  it('formats an AggregateError with no sub-errors using just its own message', () => {
+    const aggregate = new AggregateError([], 'nothing to report');
+    const err = new Error('fetch failed', { cause: aggregate });
+    expect(errorToMessage(err)).toBe('fetch failed (nothing to report)');
+  });
 });

--- a/apps/bot/src/logger.ts
+++ b/apps/bot/src/logger.ts
@@ -35,17 +35,33 @@ export function logEvent(level: LogLevel, event: string, context: Record<string,
   console.log(line);
 }
 
+/**
+ * Format an Error's own message — except AggregateError, whose .message is
+ * typically empty (e.g. Node's fetch trying both IPv4 and IPv6 and every
+ * attempt failing): the real per-attempt details live in .errors instead.
+ */
+function formatErrorValue(value: unknown): string {
+  if (value instanceof AggregateError) {
+    const sub = value.errors.map(formatErrorValue).join('; ');
+    return sub ? `${value.message || 'AggregateError'}: ${sub}` : (value.message || 'AggregateError');
+  }
+  if (value instanceof Error) {
+    return value.message;
+  }
+  return String(value);
+}
+
 export function errorToMessage(error: unknown): string {
   if (error instanceof Error) {
     // Node's fetch (undici) always throws a generic "TypeError: fetch
     // failed" for any connection-level failure (DNS, connection refused,
     // TLS, connect timeout) — the actual reason lives in .cause and was
     // previously dropped, making every network error indistinguishable in
-    // logs. cause can itself be an Error or an arbitrary value.
+    // logs. cause can itself be an Error (including AggregateError) or an
+    // arbitrary value.
     const cause = (error as { cause?: unknown }).cause;
     if (cause !== undefined) {
-      const causeMessage = cause instanceof Error ? cause.message : String(cause);
-      return `${error.message} (${causeMessage})`;
+      return `${error.message} (${formatErrorValue(cause)})`;
     }
     return error.message;
   }

--- a/apps/bot/src/logger.ts
+++ b/apps/bot/src/logger.ts
@@ -37,6 +37,16 @@ export function logEvent(level: LogLevel, event: string, context: Record<string,
 
 export function errorToMessage(error: unknown): string {
   if (error instanceof Error) {
+    // Node's fetch (undici) always throws a generic "TypeError: fetch
+    // failed" for any connection-level failure (DNS, connection refused,
+    // TLS, connect timeout) — the actual reason lives in .cause and was
+    // previously dropped, making every network error indistinguishable in
+    // logs. cause can itself be an Error or an arbitrary value.
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause !== undefined) {
+      const causeMessage = cause instanceof Error ? cause.message : String(cause);
+      return `${error.message} (${causeMessage})`;
+    }
     return error.message;
   }
   return String(error);

--- a/apps/bot/src/scripts/discord-wiki-sync.ts
+++ b/apps/bot/src/scripts/discord-wiki-sync.ts
@@ -50,6 +50,7 @@ import {
   wikiSlug,
 } from './notionSync/wikiSyncHelpers';
 import { WebWikiClient } from './notionSync/webWikiClient';
+import { errorToMessage } from '../logger';
 
 // ---------------------------------------------------------------------------
 // Public API — call this from the bot process or from the CLI
@@ -73,7 +74,7 @@ export async function runWikiSync(opts: WikiSyncOptions): Promise<{ success: boo
     await main(opts);
     return { success: true };
   } catch (err) {
-    return { success: false, error: String(err) };
+    return { success: false, error: errorToMessage(err) };
   }
 }
 

--- a/apps/bot/src/services/botHeartbeatService.ts
+++ b/apps/bot/src/services/botHeartbeatService.ts
@@ -1,4 +1,4 @@
-import { logEvent } from '../logger';
+import { errorToMessage, logEvent } from '../logger';
 import { liveConfig } from '../liveConfig';
 import type { TrackerAdapter } from './adapter';
 
@@ -27,7 +27,7 @@ export class BotHeartbeatService {
         ...this.staticState,
       });
     } catch (err) {
-      logEvent('warn', 'heartbeat_failed', { error: String(err) });
+      logEvent('warn', 'heartbeat_failed', { error: errorToMessage(err) });
     }
   }
 

--- a/apps/bot/src/services/configSyncWorker.ts
+++ b/apps/bot/src/services/configSyncWorker.ts
@@ -1,5 +1,5 @@
 import { liveConfig } from '../liveConfig';
-import { logEvent } from '../logger';
+import { errorToMessage, logEvent } from '../logger';
 import { config } from '../config';
 import { randomUUID } from 'node:crypto';
 import type { TrackerAdapter } from './adapter';
@@ -97,7 +97,7 @@ export class ConfigSyncWorker {
           await this.adapter.ackBotRestart();
           process.exit(0);
         } catch (ackErr) {
-          logEvent('warn', 'config_sync_restart_ack_failed_skipping_exit', { error: String(ackErr) });
+          logEvent('warn', 'config_sync_restart_ack_failed_skipping_exit', { error: errorToMessage(ackErr) });
         }
       }
 
@@ -105,7 +105,7 @@ export class ConfigSyncWorker {
         void this.runWikiSyncBackground();
       }
     } catch (err) {
-      logEvent('warn', 'config_sync_failed', { error: String(err) });
+      logEvent('warn', 'config_sync_failed', { error: errorToMessage(err) });
     }
   }
 
@@ -126,7 +126,7 @@ export class ConfigSyncWorker {
     try {
       await this.adapter.ackWikiSync('running', undefined, 'manual', runId);
     } catch (err) {
-      logEvent('warn', 'wiki_sync_ack_running_failed', { error: String(err) });
+      logEvent('warn', 'wiki_sync_ack_running_failed', { error: errorToMessage(err) });
       lease.release();
       this.wikiSyncRunning = false;
       return;
@@ -147,8 +147,8 @@ export class ConfigSyncWorker {
         await this.adapter.ackWikiSync('error', result.error, 'manual', runId);
       }
     } catch (err) {
-      logEvent('warn', 'wiki_sync_error', { error: String(err) });
-      try { await this.adapter.ackWikiSync('error', String(err), 'manual', runId); } catch { /* ignore */ }
+      logEvent('warn', 'wiki_sync_error', { error: errorToMessage(err) });
+      try { await this.adapter.ackWikiSync('error', errorToMessage(err), 'manual', runId); } catch { /* ignore */ }
     } finally {
       lease.release();
       this.wikiSyncRunning = false;

--- a/apps/bot/src/services/wikiSyncScheduler.ts
+++ b/apps/bot/src/services/wikiSyncScheduler.ts
@@ -161,7 +161,7 @@ export class WikiSyncScheduler {
       }
     } catch (error) {
       logEvent('warn', 'wiki_sync_scheduler_error', { error: errorToMessage(error) });
-      try { await this.adapter.ackWikiSync('error', String(error), 'scheduled', runId); } catch { /* ignore */ }
+      try { await this.adapter.ackWikiSync('error', errorToMessage(error), 'scheduled', runId); } catch { /* ignore */ }
     } finally {
       lease?.release();
       this.running = false;


### PR DESCRIPTION
## Summary
Recurring \`bot:config_sync_failed\` alert (5x/24h) — every occurrence logged the exact same unhelpful \`TypeError: fetch failed\`. Node's \`fetch\` (undici) always throws that generic message for any connection-level failure (DNS resolution, connection refused, TLS handshake, connect timeout) — the actual reason lives in \`Error.cause\`, which \`errorToMessage()\` silently dropped, making every possible network failure indistinguishable in logs.

## Fix
- \`errorToMessage()\` now appends the cause's message when present, e.g. \`fetch failed (getaddrinfo ENOTFOUND mcbn.jkomg.us)\` instead of just \`fetch failed\`.
- Swept sibling call sites still logging raw \`String(err)\` (same blind spot — \`String()\` on an Error is just \`.message\`, no cause) over to \`errorToMessage()\`: 4 in \`configSyncWorker.ts\` and 1 in \`botHeartbeatService.ts\` — both do the same \`fetch\`-based \`getBotConfig()\`/\`postHeartbeat()\` calls that produced the original alert — plus the wiki-sync error path in \`discord-wiki-sync.ts\`/\`wikiSyncScheduler.ts\`.

The next \`config_sync_failed\` occurrence will show the real underlying network error instead of a message that's identical no matter what actually went wrong.

## Test plan
- [x] New \`logger.test.ts\` covering cause-inclusion, non-Error cause, no-cause, and non-Error-value cases
- [x] \`npm run check\` (lint, format, typecheck, 357 tests, build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)