### PR TITLE
Let staff fix a spend's trait name at approval time

### DIFF
--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -131,6 +131,19 @@ def approve(row_id):
         flash('This spend request has already been approved.', 'warning')
         return redirect(url_for('spends.pending'))
 
+    # Staff can correct the trait name at approval time — e.g. resolving a
+    # "close match" warning (submitted as "Retainer" when the sheet already
+    # has "Retainer (Mortal Steve)") without needing to hand-edit the
+    # character's JSON afterward. Applied immediately so every downstream
+    # check/log/sync below (duplicate-specialty check, patch, audit log,
+    # Sheets mirror, flash message) sees the corrected name consistently.
+    original_trait_name = spend.trait_name
+    corrected_trait_name = request.form.get('trait_name', '').strip()[:100]
+    if corrected_trait_name and corrected_trait_name != spend.trait_name:
+        spend.trait_name = corrected_trait_name
+    else:
+        corrected_trait_name = None  # signal to approve_spend: no rename needed
+
     # Same queue-order and cost-validity guards bulk_approve() already
     # enforces — the single-spend path (both the classic review page and
     # the inline pending-queue expand panel) posted straight through
@@ -198,14 +211,15 @@ def approve(row_id):
     notes = request.form.get('notes', '')[:1000]
     staff = get_staff_user()
 
-    db_service.approve_spend(row_id, verified_cost, staff, notes)
+    db_service.approve_spend(row_id, verified_cost, staff, notes, trait_name=corrected_trait_name)
     patch_character_draft(spend)
+    rename_note = f' (renamed from "{original_trait_name}" to resolve a close-match warning)' if corrected_trait_name else ''
     db_service.log_action(
         staff_user=staff,
         action_type='approve_spend',
         target=spend.character_name,
         details=(
-            f'Approved spend: {spend.trait_name} '
+            f'Approved spend: {spend.trait_name}{rename_note} '
             f'({spend.current_dots}→{spend.new_dots}) '
             f'for {verified_cost} XP. {notes}'
         ).strip(),

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -741,10 +741,20 @@ class DBService:
         return _row_to_spend(row) if row else None
 
     def approve_spend(self, row_index: int, verified_cost: int,
-                      reviewer: str, notes: str = '') -> None:
+                      reviewer: str, notes: str = '', trait_name: str | None = None) -> None:
+        """Approve a spend request.
+
+        trait_name, when provided, corrects the stored trait name before the
+        sheet patch is applied — lets staff resolve a "close match" warning
+        (e.g. submitted as "Retainer" when the sheet already has "Retainer
+        (Mortal Steve)") by fixing the name at approval time instead of
+        needing to hand-edit the character's JSON afterward.
+        """
         row = db.session.get(DbSpendRequest, row_index)
         if not row:
             raise ValueError(f'Spend request not found: {row_index}')
+        if trait_name is not None:
+            row.trait_name = trait_name.strip()[:100]
         row.status = 'Approved'
         row.verified_cost = verified_cost
         row.reviewed_by = reviewer

--- a/apps/web/app/templates/spends/pending.html
+++ b/apps/web/app/templates/spends/pending.html
@@ -94,6 +94,18 @@
         <div style="display:flex;gap:20px;flex-wrap:wrap;">
           {% if not (blocked or not r.validation.valid) %}
           <form method="POST" action="{{ url_for('spends.approve', row_id=spend.row_index) }}" style="min-width:220px;flex:1;">
+            {% if r.sheet_match and not r.sheet_match.exact and r.sheet_match.close_matches %}
+            <div style="margin-bottom:8px;">
+              <label for="trait_name-{{ spend.row_index }}" class="dp-detail-label" style="display:block;margin-bottom:4px;">Sheet Name <span style="text-transform:none;font-weight:400;">(fixes the close-match warning above)</span></label>
+              <input type="text" class="form-control form-control-sm" id="trait_name-{{ spend.row_index }}"
+                     name="trait_name" value="{{ spend.trait_name }}" maxlength="100">
+              <div style="margin-top:4px;display:flex;gap:6px;flex-wrap:wrap;">
+                {% for m in r.sheet_match.close_matches %}
+                <button type="button" class="dp-btn use-match-name-btn" data-target="trait_name-{{ spend.row_index }}" data-name="{{ m.name }}" style="font-size:11px;padding:2px 8px;">Use "{{ m.name }}"</button>
+                {% endfor %}
+              </div>
+            </div>
+            {% endif %}
             <div style="display:flex;gap:8px;align-items:end;margin-bottom:8px;">
               <div style="flex:1;">
                 <label for="verified_cost-{{ spend.row_index }}" class="dp-detail-label" style="display:block;margin-bottom:4px;">Verified Cost (XP)</label>
@@ -157,6 +169,13 @@ document.addEventListener('DOMContentLoaded', function () {
     bulkClear.addEventListener('click', function () {
         checkboxes.forEach(function (cb) { cb.checked = false; });
         updateBulkBar();
+    });
+
+    document.querySelectorAll('.use-match-name-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const input = document.getElementById(btn.dataset.target);
+            if (input) input.value = btn.dataset.name;
+        });
     });
 });
 </script>

--- a/apps/web/app/templates/spends/review.html
+++ b/apps/web/app/templates/spends/review.html
@@ -180,7 +180,13 @@
                     </p>
                     <ul class="mb-0 small">
                         {% for m in sheet_match.close_matches %}
-                        <li><strong>{{ m.name }}</strong> (currently {{ m.level }})</li>
+                        <li>
+                            <strong>{{ m.name }}</strong> (currently {{ m.level }})
+                            <button type="button" class="btn btn-sm btn-outline-secondary use-match-name-btn ms-1"
+                                    data-target="trait_name" data-name="{{ m.name }}" style="font-size:11px;padding:1px 6px;">
+                                Use this name
+                            </button>
+                        </li>
                         {% endfor %}
                     </ul>
                 </div>
@@ -194,6 +200,13 @@
                 </div>
                 <div class="card-body">
                     <form method="POST" action="{{ url_for('spends.approve', row_id=spend.row_index) }}">
+                        {% if sheet_match and not sheet_match.exact and sheet_match.close_matches %}
+                        <div class="mb-3">
+                            <label for="trait_name" class="form-label small">Sheet Name <span class="text-muted">(fixes the close-match warning above)</span></label>
+                            <input type="text" class="form-control" id="trait_name" name="trait_name"
+                                   value="{{ spend.trait_name }}" maxlength="100">
+                        </div>
+                        {% endif %}
                         <div class="mb-3">
                             <label for="verified_cost" class="form-label small">Verified Cost (XP)</label>
                             <input type="number" class="form-control" id="verified_cost"
@@ -233,4 +246,17 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.use-match-name-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const input = document.getElementById(btn.dataset.target);
+            if (input) input.value = btn.dataset.name;
+        });
+    });
+});
+</script>
 {% endblock %}

--- a/apps/web/tests/test_spends_trait_name_correction.py
+++ b/apps/web/tests/test_spends_trait_name_correction.py
@@ -1,0 +1,195 @@
+"""Staff can correct a spend's trait_name at approval time, resolving a
+"close match" warning (e.g. submitted as "Retainer" when the character's
+sheet already has "Retainer (Mortal Steve)") without hand-editing the
+character's JSON afterward. See spends.approve's trait_name form field and
+db_service.approve_spend's trait_name kwarg."""
+
+import json
+
+from flask import Blueprint, Flask
+from flask_wtf.csrf import CSRFProtect
+
+import app as app_module
+from app.blueprints import spends as spends_module
+from app.db import CharacterDraft, DbAuditLog, DbCharacter, DbSpendRequest, db
+from app.db_service import DBService
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.secret_key = 'test-secret'
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    service = DBService()
+    app_module.db_service = service
+    spends_module.db_service = service
+    spends_module.sheets_sync = None
+    app.register_blueprint(spends_module.bp, url_prefix='/spends')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(app, character_data, character_name='Steve Player', creation_xp=20):
+    with app.app_context():
+        char = DbCharacter(character_name=character_name, active=True, status='active', creation_xp=creation_xp)
+        db.session.add(char)
+        db.session.flush()
+        db.session.add(CharacterDraft(
+            player_discord_id='111111111111111111',
+            character_name=character_name,
+            status='approved',
+            roster_character_id=char.id,
+            character_data=json.dumps(character_data),
+        ))
+        db.session.commit()
+
+
+def _submit(app, character_name='Steve Player', trait_name='Retainer', current_dots=0, new_dots=1):
+    with app.app_context():
+        app_module.db_service.submit_spend_request(
+            character_name=character_name,
+            spend_category='Advantage (Merit/Background)',
+            trait_name=trait_name,
+            current_dots=current_dots,
+            new_dots=new_dots,
+            is_in_clan=False,
+            justification='Retainer raise',
+        )
+        return DbSpendRequest.query.first().id
+
+
+def _staff_client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['staff_user'] = 'Tester'
+    return client
+
+
+def _sheet_data(app, character_name='Steve Player'):
+    with app.app_context():
+        draft = CharacterDraft.query.filter_by(character_name=character_name, status='approved').first()
+        return json.loads(draft.character_data)
+
+
+def test_approve_with_corrected_trait_name_raises_existing_entry_not_a_duplicate():
+    app = _app()
+    _seed(app, {
+        'merits': [{'name': 'Retainer (Mortal Steve)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+    row_id = _submit(app, trait_name='Retainer', current_dots=1, new_dots=2)
+    client = _staff_client(app)
+
+    resp = client.post(
+        f'/spends/{row_id}/approve',
+        data={'verified_cost': '3', 'trait_name': 'Retainer (Mortal Steve)'},
+    )
+    assert resp.status_code == 302
+
+    data = _sheet_data(app)
+    assert data['merits'] == [
+        {'name': 'Retainer (Mortal Steve)', 'level': 2, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
+def test_approve_with_corrected_trait_name_updates_the_stored_spend_row():
+    app = _app()
+    _seed(app, {
+        'merits': [{'name': 'Retainer (Mortal Steve)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+    row_id = _submit(app, trait_name='Retainer', current_dots=1, new_dots=2)
+    client = _staff_client(app)
+
+    client.post(
+        f'/spends/{row_id}/approve',
+        data={'verified_cost': '3', 'trait_name': 'Retainer (Mortal Steve)'},
+    )
+
+    with app.app_context():
+        row = DbSpendRequest.query.get(row_id)
+        assert row.trait_name == 'Retainer (Mortal Steve)'
+        assert row.status == 'Approved'
+
+
+def test_approve_with_corrected_trait_name_logs_the_rename():
+    app = _app()
+    _seed(app, {
+        'merits': [{'name': 'Retainer (Mortal Steve)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+    row_id = _submit(app, trait_name='Retainer', current_dots=1, new_dots=2)
+    client = _staff_client(app)
+
+    client.post(
+        f'/spends/{row_id}/approve',
+        data={'verified_cost': '3', 'trait_name': 'Retainer (Mortal Steve)'},
+    )
+
+    with app.app_context():
+        entry = DbAuditLog.query.filter_by(action_type='approve_spend').first()
+        assert 'renamed from "Retainer"' in entry.details
+        assert 'Retainer (Mortal Steve)' in entry.details
+
+
+def test_approve_without_trait_name_field_keeps_original_name():
+    """Regression check: omitting trait_name (the normal case, no warning
+    present) must not touch the stored name."""
+    app = _app()
+    _seed(app, {'merits': []})
+    row_id = _submit(app, trait_name='Iron Will', current_dots=0, new_dots=1)
+    client = _staff_client(app)
+
+    resp = client.post(f'/spends/{row_id}/approve', data={'verified_cost': '3'})
+    assert resp.status_code == 302
+
+    with app.app_context():
+        row = DbSpendRequest.query.get(row_id)
+        assert row.trait_name == 'Iron Will'
+
+    data = _sheet_data(app)
+    assert data['merits'] == [
+        {'name': 'Iron Will', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
+def test_approve_with_blank_trait_name_field_keeps_original_name():
+    """A submitted-but-empty trait_name field (e.g. the form input existed
+    but staff left it untouched and it happened to be cleared) must not
+    wipe out the trait name."""
+    app = _app()
+    _seed(app, {'merits': []})
+    row_id = _submit(app, trait_name='Iron Will', current_dots=0, new_dots=1)
+    client = _staff_client(app)
+
+    client.post(f'/spends/{row_id}/approve', data={'verified_cost': '3', 'trait_name': '   '})
+
+    with app.app_context():
+        row = DbSpendRequest.query.get(row_id)
+        assert row.trait_name == 'Iron Will'
+
+
+def test_approve_with_same_trait_name_is_a_no_op_rename():
+    """Submitting trait_name identical to the current value shouldn't log a
+    spurious rename note."""
+    app = _app()
+    _seed(app, {'merits': []})
+    row_id = _submit(app, trait_name='Iron Will', current_dots=0, new_dots=1)
+    client = _staff_client(app)
+
+    client.post(f'/spends/{row_id}/approve', data={'verified_cost': '3', 'trait_name': 'Iron Will'})
+
+    with app.app_context():
+        entry = DbAuditLog.query.filter_by(action_type='approve_spend').first()
+        assert 'renamed from' not in entry.details


### PR DESCRIPTION
## Summary
The "close match" warning on a pending spend (e.g. submitted as "Retainer" when the sheet already has "Retainer (Mortal Steve)") was informational only — no way to actually fix it besides approving as-is (creating a stray duplicate entry) and then hand-editing the character's living-sheet JSON.

## Fix
Both the pending-queue inline panel and the full review page now show a **Sheet Name** field on the Approve form — pre-filled with the submitted name, only shown when a close-match warning is present — plus a one-click **"Use this name"** button per suggested match. Submitting a corrected value renames the spend row before the sheet patch runs, so approval raises the existing entry instead of creating a duplicate.

- `db_service.approve_spend()` gains an optional `trait_name` kwarg
- `spends.approve()` applies the correction to the in-memory spend object immediately, before validation/patch/audit-log/Sheets-sync all run, so every downstream consumer sees the corrected name consistently — and logs a "renamed from X" note when a correction was actually applied
- Scoped to the single-approve path (both surfaces where the warning appears); bulk-approve is unaffected

## Test plan
- [x] 6 new tests covering: exact reproduction of the Retainer scenario (raises existing entry, doesn't duplicate), stored-row rename, audit-log note, no-op when field omitted/blank/unchanged
- [x] Manual Jinja render check for both templates (field presence, pre-filled value, button wiring)
- [x] Full web suite: 402/402, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)