### PR TITLE
Fix Sheets-sync rename mismatch and level check in spend approval

### DIFF
--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -140,6 +140,29 @@ def approve(row_id):
     original_trait_name = spend.trait_name
     corrected_trait_name = request.form.get('trait_name', '').strip()[:100]
     if corrected_trait_name and corrected_trait_name != spend.trait_name:
+        # The corrected name must refer to a trait currently at
+        # spend.current_dots — otherwise this spend's submitted dot range
+        # (and the XP cost derived from it) no longer describes the entry
+        # being patched. e.g. selecting a level-3 "Retainer (Bob)" for a
+        # submitted 1→2 spend would charge for 1→2 while patch_character_draft
+        # unconditionally sets that entry to new_dots, silently lowering it.
+        sheet_match = find_trait_sheet_match(
+            spend.character_name, spend.spend_category, original_trait_name, spend.power_name,
+        )
+        matched_entry = next(
+            (m for m in (sheet_match or {}).get('close_matches', [])
+             if m.get('name') == corrected_trait_name),
+            None,
+        )
+        if matched_entry and matched_entry.get('level') != spend.current_dots:
+            flash(
+                f'Cannot approve — "{corrected_trait_name}" is currently at '
+                f'{matched_entry.get("level")} dots on the sheet, not '
+                f'{spend.current_dots}. Correct the submitted dot range or '
+                'choose the right match.',
+                'danger',
+            )
+            return redirect(url_for('spends.review', row_id=row_id))
         spend.trait_name = corrected_trait_name
     else:
         corrected_trait_name = None  # signal to approve_spend: no rename needed
@@ -234,6 +257,7 @@ def approve(row_id):
             verified_cost=verified_cost,
             reviewer=staff,
             notes=notes,
+            original_trait_name=original_trait_name,
         )
         sheets_sync.sync_log_action(
             staff_user=staff,

--- a/apps/web/app/blueprints/spends.py
+++ b/apps/web/app/blueprints/spends.py
@@ -10,7 +10,7 @@ from app.auth import require_staff, get_staff_user
 from app.xp_rules import validate_spend_request
 from app.character_sheet import (
     patch_character_draft, find_trait_sheet_match, subcategory_label_for_trait,
-    character_has_specialty,
+    character_has_specialty, advantage_sheet_level,
 )
 
 bp = Blueprint('spends', __name__)
@@ -146,18 +146,21 @@ def approve(row_id):
         # being patched. e.g. selecting a level-3 "Retainer (Bob)" for a
         # submitted 1→2 spend would charge for 1→2 while patch_character_draft
         # unconditionally sets that entry to new_dots, silently lowering it.
-        sheet_match = find_trait_sheet_match(
-            spend.character_name, spend.spend_category, original_trait_name, spend.power_name,
+        # Looked up the same way _apply_patch itself resolves the name
+        # (case-insensitive, against both backgrounds and merits) — not
+        # find_trait_sheet_match's close_matches, which is prefix-filtered
+        # against the *original* submitted name and can miss a casing
+        # variant or an entry outside that prefix that the patch would still
+        # find and silently overwrite.
+        matched_level = (
+            advantage_sheet_level(spend.character_name, corrected_trait_name)
+            if spend.spend_category == 'Advantage (Merit/Background)'
+            else None
         )
-        matched_entry = next(
-            (m for m in (sheet_match or {}).get('close_matches', [])
-             if m.get('name') == corrected_trait_name),
-            None,
-        )
-        if matched_entry and matched_entry.get('level') != spend.current_dots:
+        if matched_level is not None and matched_level != spend.current_dots:
             flash(
                 f'Cannot approve — "{corrected_trait_name}" is currently at '
-                f'{matched_entry.get("level")} dots on the sheet, not '
+                f'{matched_level} dots on the sheet, not '
                 f'{spend.current_dots}. Correct the submitted dot range or '
                 'choose the right match.',
                 'danger',

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -206,6 +206,31 @@ def character_has_specialty(character_name: str, skill_name: str, specialty_name
     return any((s or '').strip().lower() == specialty_key for s in existing)
 
 
+def advantage_sheet_level(character_name: str, trait_name: str, power_name: str = '') -> int | None:
+    """Return the current dot level of an existing Advantage (Merit/Background)
+    entry matching trait_name/power_name, or None if there's no such entry.
+
+    Mirrors _apply_patch's own lookup exactly (same effective_name folding,
+    same case-insensitive match against both the backgrounds and merits
+    arrays) so a caller validating a name *before* patching sees precisely
+    the entry the patch would find and overwrite — a prefix-filtered check
+    like find_trait_sheet_match's close_matches can miss a casing variant or
+    an existing entry outside the submitted name's prefix.
+    """
+    data = _load_approved_sheet_data(character_name)
+    if data is None:
+        return None
+    key = _effective_advantage_name(trait_name, power_name).lower()
+    for array_name in ('backgrounds', 'merits'):
+        items = data.get(array_name)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if (item.get('name') or '').lower() == key:
+                return item.get('level')
+    return None
+
+
 def find_trait_sheet_match(
     character_name: str, category: str, trait_name: str, power_name: str = '',
 ) -> dict | None:

--- a/apps/web/app/sheets.py
+++ b/apps/web/app/sheets.py
@@ -817,9 +817,18 @@ class SheetsClient:
         return None
 
     def approve_spend(self, row_index: int, verified_cost: int,
-                      reviewer: str, notes: str = '') -> None:
+                      reviewer: str, notes: str = '',
+                      trait_name: str | None = None) -> None:
         ws = self._ws(TAB_SPEND_REQUESTS)
         row_num = row_index + 2
+
+        if trait_name:
+            trait_col = SPEND_REQUESTS_HEADERS.index('trait_name') + 1
+            ws.update(
+                gspread.utils.rowcol_to_a1(row_num, trait_col),
+                [[trait_name]],
+                value_input_option='RAW',
+            )
 
         status_col = SPEND_REQUESTS_HEADERS.index('status') + 1
         end_col = status_col + 4

--- a/apps/web/app/sheets_sync.py
+++ b/apps/web/app/sheets_sync.py
@@ -184,13 +184,21 @@ class SheetsSyncWorker:
 
     def sync_approve_spend(self, character_name: str, trait_name: str,
                            spend_category: str, current_dots: int, new_dots: int,
-                           verified_cost: int, reviewer: str, notes: str = '') -> None:
+                           verified_cost: int, reviewer: str, notes: str = '',
+                           original_trait_name: str | None = None) -> None:
+        # original_trait_name is the name the row was submitted/mirrored
+        # under — needed when staff renamed the trait at approval time, since
+        # the mirrored Sheets row still has the pre-correction name and won't
+        # match on the corrected trait_name.
+        match_trait_name = original_trait_name or trait_name
+        rename = trait_name if original_trait_name and original_trait_name != trait_name else None
+
         def _task():
             try:
                 match = next(
                     (s for s in self._sheets.get_all_spends()
                      if s.character_name.lower() == character_name.lower()
-                     and s.trait_name == trait_name
+                     and s.trait_name == match_trait_name
                      and s.spend_category == spend_category
                      and s.current_dots == current_dots
                      and s.new_dots == new_dots
@@ -199,9 +207,11 @@ class SheetsSyncWorker:
                 )
                 if match is None:
                     logger.warning('sheets_sync: approve_spend no match for %s / %s',
-                                   character_name, trait_name)
+                                   character_name, match_trait_name)
                     return
-                self._sheets.approve_spend(match.row_index, verified_cost, reviewer, notes)
+                self._sheets.approve_spend(
+                    match.row_index, verified_cost, reviewer, notes, trait_name=rename
+                )
             except Exception as exc:
                 logger.warning('sheets_sync_failed: approve_spend — %s', exc)
         _executor.submit(_task)

--- a/apps/web/tests/test_spends_trait_name_correction.py
+++ b/apps/web/tests/test_spends_trait_name_correction.py
@@ -268,6 +268,36 @@ def test_approve_with_corrected_trait_name_rejects_mismatched_level():
     ]
 
 
+def test_approve_with_casing_variant_correction_rejects_mismatched_level():
+    """A casing variant of an existing entry's name isn't picked up by
+    find_trait_sheet_match's prefix-filtered close_matches (it only surfaces
+    entries starting with the *original* submitted name), but _apply_patch
+    still matches it case-insensitively and would silently overwrite it —
+    so the level check must catch this case too, not just exact-cased
+    close-match suggestions."""
+    app = _app()
+    _seed(app, {
+        'merits': [{'name': 'Retainer (Bob)', 'level': 3, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+    row_id = _submit(app, trait_name='Retainer', current_dots=1, new_dots=2)
+    client = _staff_client(app)
+
+    resp = client.post(
+        f'/spends/{row_id}/approve',
+        data={'verified_cost': '3', 'trait_name': 'retainer (bob)'},
+    )
+    assert resp.status_code == 302
+
+    with app.app_context():
+        row = DbSpendRequest.query.get(row_id)
+        assert row.status == 'Pending'
+
+    data = _sheet_data(app)
+    assert data['merits'] == [
+        {'name': 'Retainer (Bob)', 'level': 3, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
 def test_approve_with_same_trait_name_is_a_no_op_rename():
     """Submitting trait_name identical to the current value shouldn't log a
     spurious rename note."""

--- a/apps/web/tests/test_spends_trait_name_correction.py
+++ b/apps/web/tests/test_spends_trait_name_correction.py
@@ -180,6 +180,94 @@ def test_approve_with_blank_trait_name_field_keeps_original_name():
         assert row.trait_name == 'Iron Will'
 
 
+class _FakeSheetsSync:
+    def __init__(self):
+        self.approve_calls = []
+
+    def sync_approve_spend(self, **kwargs):
+        self.approve_calls.append(kwargs)
+
+    def sync_log_action(self, **kwargs):
+        pass
+
+
+def test_approve_with_corrected_trait_name_passes_original_name_for_sheet_matching():
+    """sync_approve_spend must be told the pre-correction name too — the
+    mirrored Sheets row is still filed under the name it was submitted as,
+    so matching on the corrected name alone would find nothing and leave a
+    stray pending row behind (see sheets_sync.sync_approve_spend)."""
+    app = _app()
+    _seed(app, {
+        'merits': [{'name': 'Retainer (Mortal Steve)', 'level': 1, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+    row_id = _submit(app, trait_name='Retainer', current_dots=1, new_dots=2)
+    fake_sync = _FakeSheetsSync()
+    spends_module.sheets_sync = fake_sync
+    client = _staff_client(app)
+
+    client.post(
+        f'/spends/{row_id}/approve',
+        data={'verified_cost': '3', 'trait_name': 'Retainer (Mortal Steve)'},
+    )
+
+    spends_module.sheets_sync = None
+
+    assert len(fake_sync.approve_calls) == 1
+    call = fake_sync.approve_calls[0]
+    assert call['trait_name'] == 'Retainer (Mortal Steve)'
+    assert call['original_trait_name'] == 'Retainer'
+
+
+def test_approve_without_rename_passes_matching_trait_and_original_name():
+    """No rename happened, so original_trait_name should equal trait_name —
+    sync_approve_spend must treat this as a no-op rename, not try to
+    relabel the mirrored Sheets row."""
+    app = _app()
+    _seed(app, {'merits': []})
+    row_id = _submit(app, trait_name='Iron Will', current_dots=0, new_dots=1)
+    fake_sync = _FakeSheetsSync()
+    spends_module.sheets_sync = fake_sync
+    client = _staff_client(app)
+
+    client.post(f'/spends/{row_id}/approve', data={'verified_cost': '3'})
+
+    spends_module.sheets_sync = None
+
+    assert len(fake_sync.approve_calls) == 1
+    call = fake_sync.approve_calls[0]
+    assert call['trait_name'] == 'Iron Will'
+    assert call['original_trait_name'] == 'Iron Will'
+
+
+def test_approve_with_corrected_trait_name_rejects_mismatched_level():
+    """The matched sheet entry must currently be at spend.current_dots — a
+    level-3 "Retainer (Bob)" can't stand in for a submitted 1->2 spend,
+    since approving would charge for 1->2 while silently dropping the
+    existing entry from 3 to 2."""
+    app = _app()
+    _seed(app, {
+        'merits': [{'name': 'Retainer (Bob)', 'level': 3, 'summary': '', 'excludes': [], 'type': 'merit'}],
+    })
+    row_id = _submit(app, trait_name='Retainer', current_dots=1, new_dots=2)
+    client = _staff_client(app)
+
+    resp = client.post(
+        f'/spends/{row_id}/approve',
+        data={'verified_cost': '3', 'trait_name': 'Retainer (Bob)'},
+    )
+    assert resp.status_code == 302
+
+    with app.app_context():
+        row = DbSpendRequest.query.get(row_id)
+        assert row.status == 'Pending'
+        assert row.trait_name == 'Retainer'
+
+    data = _sheet_data(app)
+    assert data['merits'] == [
+        {'name': 'Retainer (Bob)', 'level': 3, 'summary': '', 'excludes': [], 'type': 'merit'},
+    ]
+
+
 def test_approve_with_same_trait_name_is_a_no_op_rename():
     """Submitting trait_name identical to the current value shouldn't log a
     spurious rename note."""


### PR DESCRIPTION
## Summary
Follow-up to #402, addressing its two Codex review comments (which landed after the PR was merged):

- **P1** — `sync_approve_spend` matched the mirrored Sheets row on the *corrected* trait name, so it couldn't find the row filed under the original submitted name and would strand it while appending a duplicate on reconciliation. It now matches on the original name and renames the row in place.
- **P2** — Accepting a close-match suggestion with a different level than `spend.current_dots` still validated/charged using the originally submitted dot range, while the sheet patch unconditionally set that entry to `new_dots` — silently lowering/raising an unrelated trait. `approve()` now rejects the rename if the matched entry's level doesn't equal `spend.current_dots`.

## Test plan
- [x] `pytest` (405 passed) including 4 new tests covering both fixes
- [x] Cherry-picked cleanly onto current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)