### PR TITLE
Fix wiki sync: PC profile channel was renamed on Discord

### DIFF
--- a/apps/bot/src/scripts/discord-wiki-sync.ts
+++ b/apps/bot/src/scripts/discord-wiki-sync.ts
@@ -88,7 +88,7 @@ const LORE_CHANNEL_NAMES = [
   'anarch-mandates',
   'hecata-notices',
   'backgrounds',            // forum
-  'children-of-the-night',  // forum
+  'player-characters',      // forum — PC profiles (formerly named "children-of-the-night")
   'retired',                // forum — processed as retired character wiki pages
   'spc-profiles',
 ];
@@ -141,7 +141,8 @@ interface PcProfile { image: string | null; markdown: string; }
 
 /**
  * Build a map of normalised character name → { image, markdown } by scanning
- * forum threads in the PC background channel (children-of-the-night).
+ * forum threads in the PC profile forum (player-characters — formerly named
+ * children-of-the-night before a server reorg renamed it).
  */
 async function buildPcProfileMap(
   rest: REST,
@@ -149,7 +150,7 @@ async function buildPcProfileMap(
   channelByName: Map<string, DiscordChannel>,
 ): Promise<Map<string, PcProfile>> {
   const map = new Map<string, PcProfile>();
-  const ch = channelByName.get('children-of-the-night');
+  const ch = channelByName.get('player-characters');
   if (!ch || ch.type !== CH_FORUM) return map;
   let threads: DiscordThread[] = [];
   try { threads = await fetchForumThreads(rest, guildId, ch.id); }
@@ -419,14 +420,14 @@ async function main(opts: WikiSyncOptions) {
   }
 
   // ------------------------------------------------------------------
-  // 5.5 Build PC profile map from #children-of-the-night forum
+  // 5.5 Build PC profile map from #player-characters forum
   // ------------------------------------------------------------------
-  console.log('\n[5.5/7] Building PC profile map from #children-of-the-night…');
+  console.log('\n[5.5/7] Building PC profile map from #player-characters…');
   const pcProfileMap = await buildPcProfileMap(rest, GUILD_ID, channelByName);
   console.log(`  Found profiles for ${pcProfileMap.size} character(s).`);
 
   // ------------------------------------------------------------------
-  // 5.6 Remove stale lore pages created from #children-of-the-night
+  // 5.6 Remove stale lore pages created from #player-characters
   //     (these were created by earlier syncs before PC profiles were
   //     merged into character pages — delete them by slug)
   // ------------------------------------------------------------------
@@ -610,10 +611,10 @@ async function main(opts: WikiSyncOptions) {
           const messages = await fetchAllMessages(rest, thread.id, 100);
           await sleep(200);
           const cover = firstImage(messages);
-          // children-of-the-night threads are PC profiles — merged into character
+          // player-characters threads are PC profiles — merged into character
           // pages in step 6, not duplicated as lore wiki pages.
           // backgrounds forum gets its own wiki category.
-          if (chanName !== 'children-of-the-night') {
+          if (chanName !== 'player-characters') {
             const pageCategory = chanName === 'backgrounds' ? 'backgrounds' : 'lore';
             await wikiClient.upsertPage({
               slug: wikiSlug('lore', title),


### PR DESCRIPTION
## Summary
Root-caused why active-PC wiki images/bios were still broken after the earlier GCS-permissions fix (see prior conversation/PR): the Discord server reorganized the forum the wiki-sync bot reads PC profiles from. The bot looks up `#children-of-the-night` by exact name; that channel is now `#player-characters` (moved under a "Children of the Night🩸" category), so `buildPcProfileMap()` has been silently finding nothing since the rename — every active character's cover image and bio have gone unsynced with no visible error (just a console.log the bot's structured logger doesn't surface).

Confirmed directly against the production guild via the bot's own REST client:
- Channel `1168655581486252042` (same ID `approveWizard.ts` already hardcodes under its old name) is now literally named `player-characters`.
- Its forum threads are the PC bios — "Adam Brushier" and 22 other active characters are right there.
- Retired characters were unaffected (separate `#retired` forum, never renamed).

## Change
Three lookups in `discord-wiki-sync.ts` updated from `'children-of-the-night'` → `'player-characters'` (channel list entry, `buildPcProfileMap`, and the lore-loop exclusion check), plus comments.

## Test plan
- [x] `npm run check` (lint, format, typecheck, 360 tests, build) — all pass
- [x] Verified the new channel name/ID against the live production guild via read-only Discord REST calls before making the change
- [ ] After merge+deploy, trigger a wiki sync and confirm `char-adam-brushier` picks up a live cover image

🤖 Generated with [Claude Code](https://claude.com/claude-code)