### PR TITLE
Add Excel export for the character roster

### DIFF
--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -176,6 +176,14 @@ def export_roster_xlsx():
             c.date_added or '',
             c.notes or '',
         ])
+        # openpyxl auto-flags any string cell starting with "=" as a formula
+        # (see Cell._bind_value) — character_name, player, enemy, and notes
+        # are all free text a player or staff can set to anything, so force
+        # every text cell in this row back to plain string type rather than
+        # letting Excel evaluate attacker-controlled spreadsheet formulas.
+        for cell in ws[ws.max_row]:
+            if cell.data_type == 'f':
+                cell.data_type = 's'
 
     widths = [24, 18, 14, 12, 12, 10, 11, 11, 15, 13, 14, 16, 12, 40]
     for i, width in enumerate(widths, start=1):

--- a/apps/web/app/blueprints/roster.py
+++ b/apps/web/app/blueprints/roster.py
@@ -38,19 +38,18 @@ def _parse_creation_xp(raw_value: str | None) -> int:
     return int(value)
 
 
-@bp.route('/')
-@require_staff
-def list_characters():
-    """List all characters with filtering."""
+def _filtered_roster(show: str, clan_filter: str, sect_filter: str, portrait_filter: str) -> list[dict]:
+    """Shared filtering behind the roster list page and its Excel export, so
+    exporting always matches exactly what staff currently see on-screen.
+
+    Returns dicts with keys: char, dashboard (full get_dashboard_data() row),
+    portrait ('yes' | 'no' | 'none').
+    """
     from app.db import WikiPage
-    show = request.args.get('show', 'active')  # active, inactive, all
-    clan_filter = request.args.get('clan', request.args.get('clan_filter', ''))
-    sect_filter = request.args.get('sect', request.args.get('sect_filter', ''))
-    portrait_filter = request.args.get('portrait', '')  # '' | 'missing'
 
     characters = db_service.get_all_characters()
-    xp_by_character = {
-        row['character_name'].lower(): row['available_xp']
+    dashboard_by_name = {
+        row['character_name'].lower(): row
         for row in db_service.get_dashboard_data()
     }
 
@@ -77,13 +76,34 @@ def list_characters():
         characters = [c for c in characters
                       if _portrait_status(c.character_name) != 'yes']
 
-    char_data = []
-    for c in characters:
-        char_data.append({
+    return [
+        {
             'char': c,
-            'available_xp': xp_by_character.get(c.character_name.lower(), 0),
+            'dashboard': dashboard_by_name.get(c.character_name.lower(), {}),
             'portrait': _portrait_status(c.character_name),
-        })
+        }
+        for c in characters
+    ]
+
+
+@bp.route('/')
+@require_staff
+def list_characters():
+    """List all characters with filtering."""
+    show = request.args.get('show', 'active')  # active, inactive, all
+    clan_filter = request.args.get('clan', request.args.get('clan_filter', ''))
+    sect_filter = request.args.get('sect', request.args.get('sect_filter', ''))
+    portrait_filter = request.args.get('portrait', '')  # '' | 'missing'
+
+    rows = _filtered_roster(show, clan_filter, sect_filter, portrait_filter)
+    char_data = [
+        {
+            'char': row['char'],
+            'available_xp': row['dashboard'].get('available_xp', 0),
+            'portrait': row['portrait'],
+        }
+        for row in rows
+    ]
 
     return render_template(
         'roster/list.html',
@@ -94,6 +114,82 @@ def list_characters():
         portrait_filter=portrait_filter,
         clans=CLANS,
         sects=SECTS,
+    )
+
+
+@bp.route('/export.xlsx')
+@require_staff
+def export_roster_xlsx():
+    """Download the (optionally filtered) roster as an Excel workbook.
+
+    Honors the same show/clan/sect/portrait query params as the list page,
+    so exporting from a filtered view exports exactly what's on screen.
+    """
+    from openpyxl import Workbook
+    from openpyxl.styles import Font
+    from openpyxl.utils import get_column_letter
+
+    show = request.args.get('show', 'active')
+    clan_filter = request.args.get('clan', '')
+    sect_filter = request.args.get('sect', '')
+    portrait_filter = request.args.get('portrait', '')
+
+    rows = _filtered_roster(show, clan_filter, sect_filter, portrait_filter)
+    rows.sort(key=lambda r: r['char'].character_name.lower())
+
+    headers = [
+        'Character Name', 'Player', 'Clan', 'Age Category', 'Sect', 'Status',
+        'Creation XP', 'Earned XP', 'Approved Spends', 'Available XP',
+        'Portrait', 'Enemy', 'Date Added', 'Notes',
+    ]
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = 'Roster'
+    ws.append(headers)
+    for cell in ws[1]:
+        cell.font = Font(bold=True)
+    ws.freeze_panes = 'A2'
+
+    for row in rows:
+        c = row['char']
+        d = row['dashboard']
+        if c.status == 'deceased':
+            status = 'Deceased'
+        elif c.status == 'retired' or not c.active:
+            status = 'Retired'
+        else:
+            status = 'Active'
+        ws.append([
+            c.character_name,
+            c.player_discord_name or '',
+            c.clan or '',
+            c.age_category or '',
+            c.sect or '',
+            status,
+            d.get('creation_xp', c.creation_xp or 0),
+            d.get('earned_xp', 0),
+            d.get('approved_spends', 0),
+            d.get('available_xp', 0),
+            {'yes': 'Yes', 'no': 'No', 'none': 'No wiki page'}[row['portrait']],
+            c.enemy or '',
+            c.date_added or '',
+            c.notes or '',
+        ])
+
+    widths = [24, 18, 14, 12, 12, 10, 11, 11, 15, 13, 14, 16, 12, 40]
+    for i, width in enumerate(widths, start=1):
+        ws.column_dimensions[get_column_letter(i)].width = width
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+
+    date_str = datetime.now(timezone.utc).strftime('%Y%m%d')
+    return Response(
+        buf.getvalue(),
+        mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        headers={'Content-Disposition': f'attachment; filename="roster_{show}_{date_str}.xlsx"'},
     )
 
 

--- a/apps/web/app/templates/roster/list.html
+++ b/apps/web/app/templates/roster/list.html
@@ -5,6 +5,7 @@
   <h2>Character Roster</h2>
   <span class="dp-count-badge" style="background:rgba(255,255,255,.06);color:var(--text-muted);">{{ char_data|length }} shown</span>
   <div class="dp-head-actions">
+    <a href="{{ url_for('roster.export_roster_xlsx', show=show, clan=clan_filter, sect=sect_filter, portrait=portrait_filter) }}" class="dp-btn">Export to Excel</a>
     <a href="{{ url_for('roster.import_csv') }}" class="dp-btn">Import CSV</a>
     <a href="{{ url_for('roster.add_form') }}" class="dp-btn dp-btn--accent" style="border-color:rgba(216,58,74,.4);background:rgba(216,58,74,.12);">+ Add Character</a>
   </div>

--- a/apps/web/requirements-lock.txt
+++ b/apps/web/requirements-lock.txt
@@ -16,6 +16,8 @@ cryptography==46.0.5
     # via google-auth
 deprecated==1.3.1
     # via limits
+et-xmlfile==2.0.0
+    # via openpyxl
 flask==3.1.3
     # via
     #   -r /Users/jasonkennedy/Projects/mcbn-xp-tracker/apps/web/requirements.txt
@@ -69,6 +71,8 @@ markupsafe==3.0.3
     #   wtforms
 oauthlib==3.3.1
     # via requests-oauthlib
+openpyxl==3.1.5
+    # via -r /Users/jasonkennedy/Projects/mcbn-xp-tracker/apps/web/requirements.txt
 ordered-set==4.1.0
     # via flask-limiter
 packaging==26.0

--- a/apps/web/requirements.txt
+++ b/apps/web/requirements.txt
@@ -12,3 +12,4 @@ gunicorn==26.*
 pytest==9.*
 pytest-cov==7.*
 Markdown==3.*
+openpyxl==3.*

--- a/apps/web/tests/test_roster_export_xlsx.py
+++ b/apps/web/tests/test_roster_export_xlsx.py
@@ -125,3 +125,29 @@ def test_export_respects_clan_filter():
     ws = wb.active
     names = [row[0].value for row in ws.iter_rows(min_row=2) if row[0].value]
     assert names == ['Bram Stoker']
+
+
+def test_export_neutralizes_formula_injection_in_free_text_fields():
+    """A player-supplied name/player/enemy/notes value starting with "="
+    must not open the workbook as an evaluated formula — openpyxl
+    auto-flags leading "=" strings as formulas unless forced back to
+    plain text (see export_roster_xlsx)."""
+    app = _app()
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='=1+1', player_discord_name='=cmd|calc',
+            clan='', age_category='', sect='', active=True, status='active',
+            creation_xp=0, enemy='=SUM(A1:A9)', date_added='', notes='=HYPERLINK("evil")',
+        ))
+        db.session.commit()
+    client = _staff_client(app)
+
+    resp = client.get('/roster/export.xlsx?show=all')
+    wb = _load_workbook(resp)
+    ws = wb.active
+    row = next(r for r in ws.iter_rows(min_row=2) if r[0].value == '=1+1')
+
+    assert row[0].data_type == 's'
+    assert row[1].value == '=cmd|calc' and row[1].data_type == 's'
+    assert row[11].value == '=SUM(A1:A9)' and row[11].data_type == 's'
+    assert row[13].value == '=HYPERLINK("evil")' and row[13].data_type == 's'

--- a/apps/web/tests/test_roster_export_xlsx.py
+++ b/apps/web/tests/test_roster_export_xlsx.py
@@ -1,0 +1,127 @@
+"""Roster → Excel export (roster.export_roster_xlsx)."""
+
+import io
+
+import openpyxl
+from flask import Flask, Blueprint
+from flask_wtf.csrf import CSRFProtect
+
+import app as app_module
+from app.blueprints import roster as roster_module
+from app.db import db, DbCharacter, DbLedgerEntry
+from app.db_service import DBService
+
+_fake_dashboard_bp = Blueprint('dashboard', __name__)
+
+
+@_fake_dashboard_bp.route('/login')
+def login():
+    return 'login', 200
+
+
+def _app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.secret_key = 'test-secret'
+    db.init_app(app)
+    CSRFProtect().init_app(app)
+    service = DBService()
+    app_module.db_service = service
+    roster_module.db_service = service
+    roster_module.sheets_sync = None
+    app.register_blueprint(roster_module.bp, url_prefix='/roster')
+    app.register_blueprint(_fake_dashboard_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def _seed(app):
+    with app.app_context():
+        db.session.add(DbCharacter(
+            character_name='Tulip Miller', player_discord_name='Alice', clan='Tremere',
+            age_category='Neonate', sect='Camarilla', active=True, status='active',
+            creation_xp=10, enemy='', date_added='20260101', notes='',
+        ))
+        db.session.add(DbCharacter(
+            character_name='Bram Stoker', player_discord_name='Bob', clan='Nosferatu',
+            age_category='Ancilla', sect='Anarch', active=False, status='retired',
+            creation_xp=15, enemy='', date_added='20260102', notes='',
+        ))
+        db.session.add(DbLedgerEntry(
+            character_name='Tulip Miller', date='20260105', awarded=5, spent=0,
+            reason='Session XP', entered_by='ST', timestamp='20260105 12:00:00',
+        ))
+        db.session.commit()
+
+
+def _staff_client(app):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+        sess['staff_user'] = 'Tester'
+    return client
+
+
+def _load_workbook(resp):
+    return openpyxl.load_workbook(io.BytesIO(resp.data))
+
+
+def test_export_default_active_filter_excludes_inactive():
+    app = _app()
+    _seed(app)
+    client = _staff_client(app)
+
+    resp = client.get('/roster/export.xlsx')
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+    wb = _load_workbook(resp)
+    ws = wb.active
+    names = [row[0].value for row in ws.iter_rows(min_row=2) if row[0].value]
+    assert names == ['Tulip Miller']
+
+
+def test_export_all_includes_inactive_and_xp_columns():
+    app = _app()
+    _seed(app)
+    client = _staff_client(app)
+
+    resp = client.get('/roster/export.xlsx?show=all')
+    wb = _load_workbook(resp)
+    ws = wb.active
+
+    header = [c.value for c in ws[1]]
+    assert header == [
+        'Character Name', 'Player', 'Clan', 'Age Category', 'Sect', 'Status',
+        'Creation XP', 'Earned XP', 'Approved Spends', 'Available XP',
+        'Portrait', 'Enemy', 'Date Added', 'Notes',
+    ]
+
+    rows = {row[0].value: row for row in ws.iter_rows(min_row=2) if row[0].value}
+    assert set(rows) == {'Tulip Miller', 'Bram Stoker'}
+
+    tulip = rows['Tulip Miller']
+    assert tulip[1].value == 'Alice'
+    assert tulip[5].value == 'Active'
+    assert tulip[6].value == 10  # creation xp
+    assert tulip[7].value == 5   # earned xp from ledger
+    assert tulip[9].value == 15  # available xp = 10 + 5
+
+    bram = rows['Bram Stoker']
+    assert bram[5].value == 'Retired'
+
+
+def test_export_respects_clan_filter():
+    app = _app()
+    _seed(app)
+    client = _staff_client(app)
+
+    resp = client.get('/roster/export.xlsx?show=all&clan=Nosferatu')
+    wb = _load_workbook(resp)
+    ws = wb.active
+    names = [row[0].value for row in ws.iter_rows(min_row=2) if row[0].value]
+    assert names == ['Bram Stoker']


### PR DESCRIPTION
## Summary
- Adds an "Export to Excel" button on the roster page that downloads a real `.xlsx` (via `openpyxl`) of the current roster.
- Honors the same `show`/`clan`/`sect`/`portrait` filters as the list page, so exporting from a filtered view exports exactly what's on screen.
- Columns: Character Name, Player, Clan, Age Category, Sect, Status, Creation XP, Earned XP, Approved Spends, Available XP, Portrait, Enemy, Date Added, Notes.
- Extracted the list page's filtering logic into `_filtered_roster()` so the list page and the export share one implementation instead of drifting.
- New dependency: `openpyxl==3.*`.

## Test plan
- [x] `pytest` (405 passed), including 3 new tests: default active-only filtering, `show=all` with XP math verified against ledger/creation XP, and clan filtering
- [x] `ruff check app tests`