### PR TITLE
Track Codex/Cursor OpenSpec tooling configs, ignore understand-anything cache

### DIFF
--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -73,7 +73,10 @@ Archive a completed change in the experimental workflow.
 
 3. **Check task completion status**
 
-   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+   Resolve the task file from `artifactPaths.tasks.existingOutputPaths` in the
+   status JSON from step 2 (fall back to `<changeRoot>/tasks.md` only if that
+   entry is absent — do not assume a repo-root-relative `tasks.md`). Read it to
+   check for incomplete tasks.
 
    Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
 

--- a/.cursor/skills/openspec-archive-change/SKILL.md
+++ b/.cursor/skills/openspec-archive-change/SKILL.md
@@ -73,7 +73,10 @@ Archive a completed change in the experimental workflow.
 
 3. **Check task completion status**
 
-   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+   Resolve the task file from `artifactPaths.tasks.existingOutputPaths` in the
+   status JSON from step 2 (fall back to `<changeRoot>/tasks.md` only if that
+   entry is absent — do not assume a repo-root-relative `tasks.md`). Read it to
+   check for incomplete tasks.
 
    Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
 


### PR DESCRIPTION
## Summary
- Tracks `.codex/` and `.cursor/` (OpenSpec skills/commands for Codex CLI and Cursor), mirroring what's already available to Claude via `.claude/`.
- Adds `.ua/` to `.gitignore` — generated knowledge-graph cache/output from the understand-anything tool (~15MB, includes a `.trash-*` dir), not source.

## Test plan
- N/A — config/tooling files only, no app code touched.