### PR TITLE
Fix PC profile name matching against quote-wrapped thread nicknames

### DIFF
--- a/apps/bot/src/__tests__/discordWikiSyncNameMatch.test.ts
+++ b/apps/bot/src/__tests__/discordWikiSyncNameMatch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { lookupPcProfile, type PcProfile } from '../scripts/discord-wiki-sync';
+
+vi.mock('../config', () => ({
+  config: {
+    botToken: 'bot-token',
+    discordGuildId: 'guild-1',
+    webAppBaseUrl: 'https://web.example',
+    webAppApiToken: 'legacy-token',
+    webAppApiReadToken: 'read-token',
+    webAppApiWriteToken: 'write-token',
+  },
+}));
+
+function profileMap(entries: Record<string, PcProfile>): Map<string, PcProfile> {
+  return new Map(Object.entries(entries));
+}
+
+describe('lookupPcProfile', () => {
+  it('matches exactly on a normalized key', () => {
+    const map = profileMap({ 'alice smith': { image: 'https://cdn/alice.png', markdown: '' } });
+    expect(lookupPcProfile(map, 'Alice Smith')?.image).toBe('https://cdn/alice.png');
+  });
+
+  it('matches when the thread title wraps a nickname in double quotes', () => {
+    // real case: DB name "Big Joey Puttanesca" vs thread title `"Big" Joey Puttanesca`
+    const map = profileMap({ '"big" joey puttanesca': { image: 'https://cdn/joey.png', markdown: '' } });
+    expect(lookupPcProfile(map, 'Big Joey Puttanesca')?.image).toBe('https://cdn/joey.png');
+  });
+
+  it('matches when the thread title wraps a nickname in single quotes alongside the full first name', () => {
+    // real case: DB name "Maggie Carter" vs thread title `Margaret 'Maggie' Carter`
+    const map = profileMap({ "margaret 'maggie' carter": { image: 'https://cdn/maggie.png', markdown: '' } });
+    expect(lookupPcProfile(map, 'Maggie Carter')?.image).toBe('https://cdn/maggie.png');
+  });
+
+  it('returns null when no thread name overlaps at all', () => {
+    const map = profileMap({ frankie: { image: 'https://cdn/frankie.png', markdown: '' } });
+    expect(lookupPcProfile(map, 'Francis Lombardi')).toBeNull();
+  });
+});

--- a/apps/bot/src/scripts/discord-wiki-sync.ts
+++ b/apps/bot/src/scripts/discord-wiki-sync.ts
@@ -161,7 +161,7 @@ export async function firstImageInThread(
   return firstImage(msgs);
 }
 
-interface PcProfile { image: string | null; markdown: string; }
+export interface PcProfile { image: string | null; markdown: string; }
 
 /**
  * Build a map of normalised character name → { image, markdown } by scanning
@@ -182,7 +182,7 @@ async function buildPcProfileMap(
   for (const thread of threads) {
     const msgs = await fetchAllMessages(rest, thread.id, 50);
     await sleep(150);
-    map.set(thread.name.toLowerCase().trim(), {
+    map.set(normalizeForMatch(thread.name), {
       image: await firstImageInThread(rest, thread.id, msgs, 50),
       markdown: messagesToMarkdown(msgs),
     });
@@ -190,12 +190,26 @@ async function buildPcProfileMap(
   return map;
 }
 
-/** Best-effort profile lookup: exact match, then substring. */
-function lookupPcProfile(map: Map<string, PcProfile>, charName: string): PcProfile | null {
-  const key = charName.toLowerCase().trim();
+/**
+ * Normalises a name for matching: lowercase, and strip quote/apostrophe
+ * characters that players commonly wrap around a nickname in a thread title
+ * (e.g. `"Big" Joey Puttanesca`, `Margaret 'Maggie' Carter`) but that the DB
+ * character name doesn't include, so they'd otherwise break the substring
+ * match despite the names being the same character.
+ */
+function normalizeForMatch(name: string): string {
+  return name.toLowerCase().replace(/["'‘’“”]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/** Best-effort profile lookup: exact match, then substring. Normalizes both
+ *  sides itself, so it doesn't depend on the map's keys already being
+ *  normalized by the caller. */
+export function lookupPcProfile(map: Map<string, PcProfile>, charName: string): PcProfile | null {
+  const key = normalizeForMatch(charName);
   if (map.has(key)) return map.get(key)!;
   for (const [threadName, profile] of map) {
-    if (threadName.includes(key) || key.includes(threadName)) return profile;
+    const normalizedThreadName = normalizeForMatch(threadName);
+    if (normalizedThreadName.includes(key) || key.includes(normalizedThreadName)) return profile;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
Confirmed via production bot logs on Ursula after the previous wiki-sync portrait fixes (#407) shipped — Big Joey Puttanesca (and a few others) were still missing their portraits. This is a **third, distinct** bug from the embed/pagination fixes: `lookupPcProfile()`'s substring match breaks when a player's forum thread title wraps a nickname in quotes that the DB character name doesn't have.

| DB name | Actual thread title |
|---|---|
| `Big Joey Puttanesca` | `"Big" Joey Puttanesca` |
| `Maggie Carter` | `Margaret 'Maggie' Carter` |
| `Rosie Day` | `Rosalee 'Rosie' Day` |

Neither string is a substring of the other once the quote character breaks contiguity, so these characters got no profile match at all (no markdown either, not just no image).

- Added `normalizeForMatch()` — strips straight/curly quote and apostrophe characters before comparing — applied to both sides of the match.
- Exported `lookupPcProfile`/`PcProfile` for direct unit testing.

Some other roster/thread mismatches spotted in the same log diff (Viper, Raize, wesley, Francis Lombardi vs "Frankie", Cecelia vs "Cecilia Celeste DeLuca") have zero substring overlap even after normalization — nickname-vs-full-name swaps or missing threads entirely, a different (harder) problem not addressed here.

## Test plan
- [x] `npm run check` (lint, format, typecheck, 374 tests incl. 4 new, build) — all green
- [ ] Deploy to Ursula, run wiki sync, confirm Big Joey Puttanesca, Maggie Carter, Rosie Day all get portraits + profile markdown