### PR TITLE
Add Blood Potency XP spend + collapse duplicate Cloud Run deploy path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ mcbn-xp-tracker/
   apps/
     web/          # Flask app (Python 3.12) — system of record
     bot/          # Discord bot (Node 20 / TypeScript)
+    character-app/# React character-creator SPA, built into the web image at deploy time
   packages/
     api-contract/ # Shared request/response schemas and enums
     rules/        # Shared XP/spend formulas and fixtures
   infra/
-    cloudrun/     # Deploy scripts and service config
+    ursula/       # Bot host: agents, dashboard, failover (Cloud Run config lives in CI)
+    bot-hosting/  # systemd / launchd unit templates for the bot
+    web-hosting/  # launchd template for a local dev web instance
   docs/           # Runbooks, architecture, release notes
   scripts/        # Local bootstrap and ops scripts
   compose.web.yml   # Docker profile: web only
@@ -76,9 +79,22 @@ Container names: `mcbn-xp-tracker-web`, `lasombra-bot`.
 
 ```bash
 cd apps/web
-./deploy.sh     # build/push image, deploy Cloud Run revision
 ./setup-secrets.sh  # sync env values to GCP Secret Manager
+./deploy.sh         # trigger prod deploy workflow (workflow_dispatch, needs gh)
+./deploy.sh dev     # trigger dev deploy workflow from the current branch
 ```
+
+`deploy.sh` no longer builds or deploys anything itself — it only triggers the
+GitHub Actions workflow. The workflows are the single source of truth for image
+build, Cloud Run resource flags, env vars, and secret bindings; do not add a
+second `gcloud run deploy` invocation anywhere.
+
+Deploys are normally automatic, not run by hand. GitHub Actions chains them:
+CI passing on **any branch** deploys to dev (`deploy-web-dev.yml` has no branch
+filter — dev is shared, and a feature-branch push replaces what's deployed
+there); a dev deploy succeeding **on `main`** then gates prod; the bot
+redeploys on CI passing **on `main`** via a self-hosted runner on Ursula. See
+[CONTRIBUTING.md](CONTRIBUTING.md#deploy-paths).
 
 Current deployment topology: production web runs on Cloud Run service
 `mcbn-xp-tracker` at `mcbn.jkomg.us`; dev web runs on the separate Cloud Run service
@@ -129,6 +145,8 @@ The `docker-and-docs-hygiene` job validates all compose files and smoke-starts t
 
 ## Key Docs
 
+- `CONTRIBUTING.md` — **development rules and paths**: required toolchain versions, local setup, the exact test/lint commands CI gates on, migration workflow, branch/PR conventions, deploy paths per environment
+- `docs/REGRESSION_HYGIENE_CHECKLIST.md` — pre/post-change checklist; every item traces to a real incident
 - `docs/API_ENDPOINTS.md` — bot-facing API reference (auth, all routes, request/response schemas)
 - `docs/MONOREPO_ARCHITECTURE.md` — system boundaries and runtime model
 - `docs/ENV_AND_SECRETS.md` — env and secrets flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,33 @@ deliberate (it lets you test a PR on real infrastructure pre-merge), but it
 means **dev is shared**: coordinate before pushing work-in-progress if someone
 else is testing there.
 
+### Rebase before you push, or dev will fail to boot
+
+**Dev has one database, shared by every branch that deploys to it.** Because
+`entrypoint.sh` runs `flask db upgrade` under `set -e` before gunicorn starts,
+a branch whose `migrations/versions/` is missing the revision the dev database
+is currently stamped at cannot boot at all: Alembic can't locate the current
+revision, the entrypoint exits, nothing listens on `$PORT`, and the deploy
+fails with
+
+```
+ERROR: (gcloud.run.deploy) The user-provided container failed the
+configured startup probe checks.
+```
+
+This looks like an application crash but is really a stale branch. If someone
+merges a migration to `main` after you branched, **rebase onto `main` and
+force-push** — that is the fix, not a retry:
+
+```bash
+git fetch origin
+git rebase origin/main
+git push --force-with-lease
+```
+
+The same failure mode hits prod only via `main`, which is always at head, so
+this is specifically a dev/PR-branch hazard.
+
 Prod is only reachable through `main`, and the bot only redeploys when
 `apps/bot/**` or `packages/**` actually changed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,61 +4,218 @@ Thanks for your interest in contributing.
 
 ## Before You Start
 
-- Read [README.md](README.md) for architecture and setup.
+- Read [README.md](README.md) for architecture, and [docs/MONOREPO_ARCHITECTURE.md](docs/MONOREPO_ARCHITECTURE.md) for system boundaries.
 - Check open issues and existing PRs to avoid duplicate work.
 - For security issues, do **not** open a public issue. See [SECURITY.md](SECURITY.md).
 
+> **Read this first if you are pushing a branch:** every push that passes CI
+> deploys to the **shared dev site** at `dev.mcbn.jkomg.us` — on *any* branch,
+> with or without an open PR. See [Deploy paths](#deploy-paths) below.
+
+## Repository Layout
+
+This is a monorepo. Almost every command below is run from an **app directory**,
+not the repo root.
+
+| Path | What it is | Language |
+|------|-----------|----------|
+| `apps/web/` | Flask app — system of record, staff + player portal | Python 3.12 |
+| `apps/bot/` | Discord bot ("Lasombra") | Node 20.11+ / TypeScript |
+| `apps/character-app/` | React character-creator SPA, built into the web image | TypeScript |
+| `packages/api-contract/` | Shared spend categories | JSON |
+| `packages/rules/` | Shared XP cost formulas | JSON |
+| `infra/`, `scripts/`, `docs/` | Deploy config, ops scripts, runbooks | — |
+
+## Required Toolchain
+
+| Tool | Version | Enforced by |
+|------|---------|-------------|
+| Python | **3.12** | `.github/workflows/ci.yml`, `apps/web/Dockerfile` |
+| Node | **20.11+** | `apps/bot/package.json` (`engines`) |
+| ruff | **pinned — see below** | `.github/workflows/ci.yml` |
+
+Python 3.9 (the macOS system Python) **will not work** — several dependencies
+require 3.12.
+
+> **Never copy a `venv/` between machines or check one into git.** A virtualenv
+> hardcodes an absolute path to the interpreter that created it, so a copied
+> `venv/` breaks with a confusing `no such file or directory` on its own
+> `bin/python`. If that happens, delete it and recreate it with the steps below.
+
 ## Local Setup
 
+### Docker (preferred)
+
+Handles env files, container naming, and startup for you:
+
 ```bash
-python3 --version  # requires 3.12+
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
+./scripts/bootstrap-local.sh web-only     # web only
+./scripts/bootstrap-local.sh web+bot      # full stack
+```
+
+Web runs at `http://127.0.0.1:5001`. See [docs/RUN_WEB_DOCKER.md](docs/RUN_WEB_DOCKER.md).
+
+### Host — web
+
+```bash
+cd apps/web
+python3.12 -m venv venv                   # must be 3.12
+./venv/bin/pip install -r requirements.txt
+cp .env.example .env                      # per-app; the ROOT .env.example is only a pointer
+./venv/bin/python -m flask run --port 5001
+```
+
+### Host — bot
+
+```bash
+cd apps/bot
+npm ci
 cp .env.example .env
+npm start
 ```
 
-Then configure `.env` values and run:
+In full-stack Docker the bot must use `WEB_APP_BASE_URL=http://web:5001`, not
+`127.0.0.1` — `bootstrap-local.sh` patches this automatically.
+
+Secrets and env flow: [docs/ENV_AND_SECRETS.md](docs/ENV_AND_SECRETS.md).
+
+## Testing and Lint
+
+CI gates on these exact commands. Run them before opening a PR.
+
+### Web (`apps/web`)
 
 ```bash
-./dev.sh
+cd apps/web
+./venv/bin/pytest -q --cov=app --cov-report=term-missing --cov-fail-under=30
+./venv/bin/python -m pip install ruff==0.15.20
+./venv/bin/ruff check app tests
 ```
+
+Two things that bite people:
+
+- **Coverage gate**: CI fails under **30%** coverage. A bare `pytest -q` passes
+  locally while CI fails.
+- **Pin ruff to `0.15.20`.** An unpinned install picks up whatever is newest,
+  and a new ruff release can enable new default rules that fail CI with no code
+  change — this happened on 2026-07-23 (ruff 0.16.0, 207 new violations). CI
+  pins the version; match it locally or you will chase phantom findings.
+
+CI also runs `mypy`, but it is **informational and non-blocking**.
+
+### Bot (`apps/bot`)
+
+```bash
+cd apps/bot
+npm run check    # lint → format:check → typecheck → test → build
+```
+
+This single command is what CI gates on. Don't skip typecheck.
+
+### Which CI jobs run
+
+Jobs are path-filtered, and all of them roll up into a single required
+`test-and-lint` check:
+
+| Job | Triggers on |
+|-----|------------|
+| `web-test-and-lint` | `apps/web/**`, `packages/**` |
+| `bot-test-and-lint` | `apps/bot/**`, `packages/**` |
+| `contract-tests` | `packages/api-contract/**`, `packages/rules/**` |
+| `docker-and-docs-hygiene` | compose files, `scripts/bootstrap-local.sh`, `docs/**`, `README.md` |
+
+Editing anything in `packages/` triggers **both** app suites, because both apps
+load those JSON files at runtime.
+
+## Database Migrations
+
+The database is **Turso (libsql)** in production and dev; local dev defaults to
+SQLite. Google Sheets is a best-effort backup mirror only — never a read source.
+
+To change the schema:
+
+```bash
+# 1. Edit apps/web/app/db.py
+cd apps/web
+FLASK_APP=app:create_app ./venv/bin/flask db migrate -m "description"
+# 2. REVIEW the generated file in migrations/versions/ — do not trust it blindly
+./venv/bin/flask db upgrade
+# 3. Commit the migration alongside your code change
+```
+
+Two footguns:
+
+- `db.create_all()` runs before Alembic's autogenerate diff on every boot, so a
+  `CREATE TABLE` migration autogenerates an **empty body** against a fresh
+  database. Such migrations need a hand-written `_table_exists` guard.
+- Migrations are applied **automatically on every deploy** by
+  `apps/web/entrypoint.sh` before gunicorn starts. A bad migration takes the
+  service down on boot — review the generated file.
+
+See `apps/web/migrations/README`.
 
 ## Branching and PRs
 
-- Create a branch from `main`.
+- Branch from `main`. Use a `type/short-description` prefix, matching existing
+  history: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`.
 - Keep PRs focused and reasonably small.
-- Include tests for behavior changes when possible.
-- Update docs (`README.md`/`CHANGELOG.md`) for user-visible changes.
+- Include tests for behavior changes.
+- Update `CHANGELOG.md` and any affected `docs/` page for user-visible changes.
+- Commit messages: short imperative summaries, e.g. `Fix advantage cost for
+  0->2 purchases`, `Add CSRF protection to staff forms`.
 
-## Testing
+## Deploy Paths
 
-Run tests before opening a PR:
+Deploys are chained GitHub Actions `workflow_run` triggers, not manual steps.
 
-```bash
-./venv/bin/pytest -q
-```
+| Environment | Service | Trigger |
+|------------|---------|---------|
+| **Dev web** | Cloud Run `mcbn-xp-tracker-dev` (`dev.mcbn.jkomg.us`) | CI passing on **any branch** |
+| **Prod web** | Cloud Run `mcbn-xp-tracker` (`mcbn.jkomg.us`) | Dev deploy succeeding **on `main`** |
+| **Bot** | Docker `lasombra-bot` on **Ursula** (self-hosted runner) | CI passing **on `main`** |
 
-Run lint:
+Read the dev row carefully: `deploy-web-dev.yml` has **no branch filter**. Any
+push to any branch that passes CI redeploys the shared dev service and posts a
+Discord notification — before review, and without an open PR. This is
+deliberate (it lets you test a PR on real infrastructure pre-merge), but it
+means **dev is shared**: coordinate before pushing work-in-progress if someone
+else is testing there.
 
-```bash
-./venv/bin/python -m pip install ruff
-./venv/bin/ruff check app tests
-```
+Prod is only reachable through `main`, and the bot only redeploys when
+`apps/bot/**` or `packages/**` actually changed.
+
+**The workflows are the single source of truth** for image build, Cloud Run
+resource flags, env vars, and secret bindings. `apps/web/deploy.sh` only
+*triggers* a workflow via `workflow_dispatch` (it needs the `gh` CLI); it does
+not deploy anything itself. Never add a second `gcloud run deploy` invocation —
+two definitions of one service drift, and `--set-env-vars` silently removes any
+env var it does not list.
+
+Environment details: [docs/DEV_ENVIRONMENT.md](docs/DEV_ENVIRONMENT.md).
+Bot host setup: `infra/ursula/README.md`.
 
 ## Coding Guidelines
 
 - Prefer clear, explicit logic over clever shortcuts.
-- Keep route handlers thin; put data logic in `app/sheets.py` or dedicated modules.
-- Validate all external input server-side.
-- Preserve backward compatibility for existing Google Sheet tab/header contracts.
+- **`apps/web` is the authority** for validation, approvals, and persistence.
+  The bot calls web API endpoints with a service token — it never writes to the
+  database or Sheets directly.
+- Keep route handlers thin. Put persistence logic in `app/db_service.py`
+  (authoritative) and mirror logic in `app/sheets_sync.py` (best-effort backup).
+- **Put shared rules in `packages/`, not in one app.** XP formulas and spend
+  categories live in `packages/rules/xp_costs.json` and
+  `packages/api-contract/spend_categories.json`, loaded by both apps. Adding a
+  category is usually a JSON edit, not new formula code — duplicating a formula
+  in one app is how the two clients drift apart.
+- Validate all external input server-side. Never trust client-supplied identity
+  or state (character ownership, coterie membership) — re-check it server-side.
+- Pair every database write with an audit-log entry, and check whether it needs
+  a Sheets-mirror counterpart. This is a convention, not something the type
+  system enforces; a missing pairing compiles fine and looks done.
 
-## Commit Messages
-
-Use short imperative summaries, e.g.:
-
-- `Fix advantage cost for 0->2 purchases`
-- `Add CSRF protection to staff forms`
+Before non-trivial changes, skim
+[docs/REGRESSION_HYGIENE_CHECKLIST.md](docs/REGRESSION_HYGIENE_CHECKLIST.md) —
+every item in it traces to something that actually broke.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ XP tracking and management for **Music City by Night** (MCbN), a Vampire: the Ma
 mcbn-xp-tracker/
   apps/
     web/          # Flask app (Python 3.12) — admin UI + REST API, Cloud Run deploy target
-    bot/          # Discord bot (Node 20/TypeScript) — locally hosted
+    bot/          # Discord bot (Node 20/TypeScript) — locally hosted on Ursula
+    character-app/# React character-creator SPA, built into the web image at deploy time
   packages/
     api-contract/ # Shared request/response schemas and enums
     rules/        # Shared XP/spend formulas and fixtures
   infra/
-    cloudrun/     # Deploy scripts and service config
+    ursula/       # Bot host: agents, dashboard, failover (Cloud Run config lives in CI)
+    bot-hosting/  # systemd / launchd unit templates for the bot
+    web-hosting/  # launchd template for a local dev web instance
   docs/           # Runbooks, architecture, API reference
   scripts/        # Local bootstrap and ops scripts
   compose.web.yml   # Docker profile: web only
@@ -45,9 +48,14 @@ Non-Docker alternative: `cd apps/web && python -m flask run --port 5001` / `cd a
 
 ## Production Deploy
 
+Deploys are automatic via GitHub Actions — dev on any CI-passing push, prod
+after a dev deploy succeeds on `main`. The commands below are only for forcing
+a redeploy without a new commit (e.g. after rotating a secret):
+
 ```bash
-cd apps/web && ./deploy.sh           # build/push image, deploy Cloud Run revision
 cd apps/web && ./setup-secrets.sh    # sync env values to GCP Secret Manager
+cd apps/web && ./deploy.sh           # trigger the prod deploy workflow (needs gh CLI)
+cd apps/web && ./deploy.sh dev       # trigger the dev deploy workflow
 ```
 
 The current production web app runs on Cloud Run as `mcbn-xp-tracker` and the dev web

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -460,6 +460,10 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         data['humanity'] = new_dots
         return True
 
+    if category == 'Blood Potency':
+        data['bloodPotency'] = new_dots
+        return True
+
     return False
 
 
@@ -603,7 +607,17 @@ def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name:
             return True
         return False
 
+    if category == 'Blood Potency':
+        if data.get('bloodPotency') == new_dots:
+            data['bloodPotency'] = current_dots
+            return True
+        return False
+
     return False
+
+
+# Humanity and Blood Potency are rated 0-10; every other dotted trait is 0-5.
+_VITALS_MAX_DOTS = 10
 
 
 def _dots_str(n: int, max_dots: int = 5) -> str:
@@ -618,10 +632,12 @@ def _generate_stats_markdown(data: dict) -> str:
     humanity = data.get('humanity', 0)
     if bp or humanity:
         parts = []
+        # Both tracks run 0-10, unlike the 0-5 traits below — render the full
+        # ten-dot track so a rating above 5 isn't silently clamped to 5.
         if bp:
-            parts.append(f'Blood Potency {_dots_str(bp)}')
+            parts.append(f'Blood Potency {_dots_str(bp, _VITALS_MAX_DOTS)}')
         if humanity:
-            parts.append(f'Humanity {_dots_str(humanity)}')
+            parts.append(f'Humanity {_dots_str(humanity, _VITALS_MAX_DOTS)}')
         lines.append('  '.join(parts))
         lines.append('')
 

--- a/apps/web/app/character_sheet.py
+++ b/apps/web/app/character_sheet.py
@@ -62,6 +62,15 @@ _DISCIPLINE_CATEGORIES = frozenset({
 
 _SKILL_CATEGORIES = frozenset({'Skill', 'New Skill'})
 
+# Fixed-trait "vital" categories: the category itself names the trait, and the
+# sheet stores it as a plain scalar rather than an entry in a named collection.
+# Maps spend category -> character_data field. Mirrored client-side by
+# FIXED_TRAIT_CATEGORIES in player/character.html.
+_VITAL_SHEET_FIELDS = {
+    'Humanity': 'humanity',
+    'Blood Potency': 'bloodPotency',
+}
+
 # Advantages (Merits/Backgrounds) that track a required sub-category/faction
 # via a parenthetical suffix on the plain sheet name — e.g. "Status (Tremere)"
 # is the existing informal convention already present in sheet data, not a
@@ -191,6 +200,36 @@ def character_skill_rating(character_name: str, skill_name: str) -> int:
         return int(data.get('skills', {}).get(_normalize_skill_key(skill_name), 0))
     except (TypeError, ValueError):
         return 0
+
+
+def character_vital_rating(character_name: str, category: str) -> int | None:
+    """Return the sheet's current rating for a fixed-trait vital, or None.
+
+    Covers the categories in _VITAL_SHEET_FIELDS (Humanity, Blood Potency) —
+    the ones whose trait is fixed by the category itself and stored as a plain
+    scalar on the sheet, so the current rating is unambiguous with no name
+    matching involved.
+
+    None means "cannot be determined" — a different category, no roster
+    character, no approved draft, unparseable JSON, or the field simply absent
+    from the sheet. Callers must treat None as "skip the check" rather than
+    zero: a character with no imported sheet must still be able to submit
+    spends, and `data.get(field)` returning None is not the same as a sheet
+    that genuinely records 0.
+    """
+    field = _VITAL_SHEET_FIELDS.get(category)
+    if field is None:
+        return None
+    data = _load_approved_sheet_data(character_name)
+    if data is None:
+        return None
+    raw = data.get(field)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
 
 
 def character_has_specialty(character_name: str, skill_name: str, specialty_name: str) -> bool:
@@ -456,12 +495,8 @@ def _apply_patch(data: dict, category: str, trait_name: str, power_name: str, ne
         specialties.append(power_name)
         return True
 
-    if category == 'Humanity':
-        data['humanity'] = new_dots
-        return True
-
-    if category == 'Blood Potency':
-        data['bloodPotency'] = new_dots
+    if category in _VITAL_SHEET_FIELDS:
+        data[_VITAL_SHEET_FIELDS[category]] = new_dots
         return True
 
     return False
@@ -601,15 +636,10 @@ def _apply_reverse_patch(data: dict, category: str, trait_name: str, power_name:
                 return True
         return False
 
-    if category == 'Humanity':
-        if data.get('humanity') == new_dots:
-            data['humanity'] = current_dots
-            return True
-        return False
-
-    if category == 'Blood Potency':
-        if data.get('bloodPotency') == new_dots:
-            data['bloodPotency'] = current_dots
+    if category in _VITAL_SHEET_FIELDS:
+        field = _VITAL_SHEET_FIELDS[category]
+        if data.get(field) == new_dots:
+            data[field] = current_dots
             return True
         return False
 

--- a/apps/web/app/db_service.py
+++ b/apps/web/app/db_service.py
@@ -849,9 +849,30 @@ class DBService:
                              coterie_id: int | None = None) -> int:
         """Submit a new spend request. Returns the calculated XP cost.
 
-        Raises ValueError if the cost calculation fails.
+        Raises ValueError if the cost calculation fails, or if a fixed-trait
+        vital's current_dots contradicts the character sheet.
         """
+        from app.character_sheet import character_vital_rating
         from app.xp_rules import calculate_xp_cost
+
+        # Fixed-trait vitals (Humanity, Blood Potency) are stored on the sheet
+        # as unambiguous scalars, so a client-supplied current_dots can and
+        # must be checked against them rather than trusted. This is the shared
+        # chokepoint: both player.submit_spend and player.convert_wish_list_item
+        # land here, and the latter bypasses the route-level validation
+        # entirely — a wish-list item left at the default 0->1 would otherwise
+        # charge 10 XP to "raise" a Blood Potency 4 character and downgrade the
+        # sheet to 1 on approval. A None rating means unknown (no imported
+        # sheet, or the field is absent), so there is nothing to check against
+        # and the spend proceeds as before.
+        sheet_rating = character_vital_rating(character_name, spend_category)
+        if sheet_rating is not None and sheet_rating != current_dots:
+            raise ValueError(
+                f'{spend_category} is {sheet_rating} on the character sheet, '
+                f'but this request says {current_dots}. Re-submit with the '
+                f'correct current rating.'
+            )
+
         xp_cost = calculate_xp_cost(spend_category, current_dots, new_dots)
 
         row = DbSpendRequest(

--- a/apps/web/app/templates/player/character.html
+++ b/apps/web/app/templates/player/character.html
@@ -1132,6 +1132,9 @@
                         <tr><td>Advantage</td><td>3 XP per dot purchased</td><td>0→2 = 6 XP</td></tr>
                         <tr><td>Loresheet</td><td>Purchased dot × 3</td><td>Buy dot 3 = 9 XP</td></tr>
                         <tr><td>Humanity</td><td>New rating × 2</td><td>5→6 = 12 XP</td></tr>
+                        <tr><td>Blood Potency</td><td>New rating × 10</td><td>1→2 = 20 XP</td></tr>
+                        <tr><td>Ghoul Discipline (0→1)</td><td>10 XP flat</td><td>0→1 = 10 XP</td></tr>
+                        <tr><td>Skill Specialty</td><td>3 XP flat</td><td>Add specialty = 3 XP</td></tr>
                     </tbody>
                 </table>
                 <small class="text-muted mt-2 d-block">For multi-dot purchases, add each step. Example: In-Clan Discipline 1→3 = (2×5) + (3×5) = 25 XP.</small>
@@ -1303,8 +1306,14 @@ document.addEventListener('DOMContentLoaded', function() {
         'Loresheet':                   { level_mult: 3, min: 0, max: 5 },
         'Ghoul Discipline':            { flat: 10, min: 0, max: 1 },
         'Humanity':                    { multiplier: 2, min: 1, max: 10 },
+        'Blood Potency':               { multiplier: 10, min: 0, max: 10 },
         'Skill Specialty':             { flat: 3, min: 0, max: 1 },
     };
+
+    // Categories whose trait name is fixed by the category itself (the trait
+    // name always equals the category name). Trait Name is auto-filled and
+    // made read-only for these. Mirrored by WL_FIXED_TRAIT_CATEGORIES below.
+    const FIXED_TRAIT_CATEGORIES = ['Humanity', 'Blood Potency'];
 
     function calcCost() {
         const cat = spendCategory.value;
@@ -1456,10 +1465,11 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
 
-        // Auto-fill trait name for fixed-trait categories
+        // Auto-fill trait name for fixed-trait categories — the category *is*
+        // the trait, so there is nothing for the player to type.
         if (traitNameInput) {
-            if (cat === 'Humanity') {
-                traitNameInput.value = 'Humanity';
+            if (FIXED_TRAIT_CATEGORIES.includes(cat)) {
+                traitNameInput.value = cat;
                 traitNameInput.readOnly = true;
             } else {
                 if (traitNameInput.readOnly) traitNameInput.value = '';
@@ -1502,6 +1512,10 @@ document.addEventListener('DOMContentLoaded', function() {
             const disc = discs.filter(p => (p.discipline || '').toLowerCase() === key);
             if (disc.length) return Math.max(...disc.map(p => p.level || 0));
             return null;
+        }
+        if (cat === 'Blood Potency') {
+            const v = SHEET_DATA.bloodPotency;
+            return (v != null) ? v : null;
         }
         if (cat === 'Advantage (Merit/Background)') {
             // Schema v7+ keeps Backgrounds in a separate array from Merits.
@@ -1580,6 +1594,14 @@ document.addEventListener('DOMContentLoaded', function() {
         'Loresheet':                   { level_mult: 3 },
         'Ghoul Discipline':            { flat: 10 },
         'Humanity':                    { multiplier: 2 },
+        'Blood Potency':               { multiplier: 10 },
+    };
+
+    // Fixed-trait categories and their dot bounds — mirrors
+    // FIXED_TRAIT_CATEGORIES / XP_RULES min+max in the spend form above.
+    const WL_FIXED_TRAIT_CATEGORIES = {
+        'Humanity':      { min: 1, max: 10 },
+        'Blood Potency': { min: 0, max: 10 },
     };
 
     function wlCost(cat, from, to) {
@@ -1677,13 +1699,14 @@ document.addEventListener('DOMContentLoaded', function() {
         const isDiscipline = wlCat.value === 'Discipline (In-Clan)' || wlCat.value === 'Discipline (Out-of-Clan)' || wlCat.value === 'Caitiff Discipline';
         if (wlInClanGroup) wlInClanGroup.classList.toggle('d-none', !isDiscipline);
         updateWlPowerNameGroup();
-        if (wlCat.value === 'Humanity') {
-            wlTrait.value = 'Humanity';
+        const fixedTrait = WL_FIXED_TRAIT_CATEGORIES[wlCat.value];
+        if (fixedTrait) {
+            wlTrait.value = wlCat.value;
             wlTrait.readOnly = true;
-            wlFrom.min = 1; wlFrom.max = 9;
-            wlTo.min = 2;   wlTo.max = 10;
-            if (parseInt(wlFrom.value) < 1) wlFrom.value = 1;
-            if (parseInt(wlTo.value) < 2)   wlTo.value = 2;
+            wlFrom.min = fixedTrait.min;     wlFrom.max = fixedTrait.max - 1;
+            wlTo.min = fixedTrait.min + 1;   wlTo.max = fixedTrait.max;
+            if (parseInt(wlFrom.value) < fixedTrait.min)     wlFrom.value = fixedTrait.min;
+            if (parseInt(wlTo.value) < fixedTrait.min + 1)   wlTo.value = fixedTrait.min + 1;
         } else {
             if (wlTrait.readOnly) wlTrait.value = '';
             wlTrait.readOnly = false;

--- a/apps/web/deploy.sh
+++ b/apps/web/deploy.sh
@@ -63,7 +63,16 @@ case "${TARGET}" in
     WORKFLOW="deploy-web-dev.yml"
     SERVICE="mcbn-xp-tracker-dev"
     SITE="https://dev.mcbn.jkomg.us"
+    # --ref must name a branch or tag; on a detached HEAD this returns the
+    # literal string "HEAD", which gh cannot resolve. Fail with something
+    # actionable rather than letting the dispatch error out opaquely.
     REF="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "${REF}" = "HEAD" ]; then
+      echo "ERROR: detached HEAD — cannot infer a branch to deploy." >&2
+      echo "Check out a branch, or dispatch explicitly:" >&2
+      echo "  gh workflow run ${WORKFLOW} --ref <branch-or-tag>" >&2
+      exit 1
+    fi
     ;;
   -h|--help|help)
     sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'

--- a/apps/web/deploy.sh
+++ b/apps/web/deploy.sh
@@ -1,12 +1,33 @@
 #!/bin/bash
-# MCbN XP Tracker — Cloud Run Deployment Script
-# Run this after completing the one-time GCP setup below.
+# MCbN XP Tracker — Cloud Run deploy trigger.
+#
+# This script no longer builds or deploys anything itself. It triggers the
+# GitHub Actions workflow that does, via workflow_dispatch.
+#
+# WHY: this script used to carry its own full `gcloud run deploy` invocation
+# targeting the same live service as .github/workflows/deploy-web.yml. Two
+# independent definitions of one service drift, and `--set-env-vars` REMOVES
+# any env var it does not list — so a manual run could silently revert config
+# set by CI. That happened: prod was bumped to 512Mi in a9c44f4 and this
+# script kept saying 256Mi. The workflows are now the single source of truth
+# for image build, resource flags, env vars, and secret bindings.
+#
+# Normal deploys are automatic and need no action here:
+#   - dev  (mcbn-xp-tracker-dev)  — every push that passes CI, on any branch
+#   - prod (mcbn-xp-tracker)      — after a dev deploy succeeds on main
+#
+# Use this only to force a redeploy without a new commit (e.g. after rotating
+# a secret in Secret Manager, since Cloud Run pins :latest at deploy time).
+#
+# Usage:
+#   ./deploy.sh            # redeploy prod from main
+#   ./deploy.sh dev        # redeploy dev from the current branch
 #
 # ============================================================
-# ONE-TIME GCP SETUP (do these steps first, only once):
+# ONE-TIME GCP SETUP (only needed when bootstrapping a new project):
 # ============================================================
 #
-# 1. Install Google Cloud CLI (if not already installed):
+# 1. Install Google Cloud CLI:
 #      brew install google-cloud-sdk
 #
 # 2. Log in and create/select a project:
@@ -14,126 +35,81 @@
 #      gcloud projects create mcbn-xp-tracker --name="MCbN XP Tracker"
 #      gcloud config set project mcbn-xp-tracker
 #
-#    NOTE: If "mcbn-xp-tracker" is taken, use a unique name and update
-#    PROJECT_ID below.
-#
 # 3. Enable required APIs (free):
 #      gcloud services enable run.googleapis.com
 #      gcloud services enable artifactregistry.googleapis.com
 #
-# 4. Create Artifact Registry repo (stores your Docker images, free tier):
+# 4. Create Artifact Registry repo (stores Docker images, free tier):
 #      gcloud artifacts repositories create mcbn-repo \
 #        --repository-format=docker \
 #        --location=us-central1
 #
-# 5. Configure Docker to push to Artifact Registry:
-#      gcloud auth configure-docker us-central1-docker.pkg.dev
-#
-# ============================================================
-# After the above, run this script to deploy (or re-deploy):
-#   ./deploy.sh
+# 5. Populate Secret Manager:
+#      ./setup-secrets.sh
 # ============================================================
 
-set -e
+set -euo pipefail
 
-# Ensure gcloud and docker are in PATH
-export PATH="/opt/homebrew/share/google-cloud-sdk/bin:/usr/local/bin:$PATH"
+TARGET="${1:-prod}"
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+case "${TARGET}" in
+  prod)
+    WORKFLOW="deploy-web.yml"
+    SERVICE="mcbn-xp-tracker"
+    SITE="https://mcbn.jkomg.us"
+    REF="main"
+    ;;
+  dev)
+    WORKFLOW="deploy-web-dev.yml"
+    SERVICE="mcbn-xp-tracker-dev"
+    SITE="https://dev.mcbn.jkomg.us"
+    REF="$(git rev-parse --abbrev-ref HEAD)"
+    ;;
+  -h|--help|help)
+    sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown target '${TARGET}' (expected 'prod' or 'dev')." >&2
+    exit 1
+    ;;
+esac
 
-PROJECT_ID="mcbn-xp-tracker"
-REGION="us-central1"
-SERVICE_NAME="mcbn-xp-tracker"
-REPO="us-central1-docker.pkg.dev/${PROJECT_ID}/mcbn-repo"
-IMAGE="${REPO}/${SERVICE_NAME}:latest"
-SPREADSHEET_ID_VALUE="${SPREADSHEET_ID:-$(grep '^SPREADSHEET_ID=' "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2-)}"
-WEB_APP_API_READ_TOKEN_VALUE="${WEB_APP_API_READ_TOKEN:-$(grep '^WEB_APP_API_READ_TOKEN=' "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2-)}"
-WEB_APP_API_WRITE_TOKEN_VALUE="${WEB_APP_API_WRITE_TOKEN:-$(grep '^WEB_APP_API_WRITE_TOKEN=' "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2-)}"
-CLOUD_SPEND_ADMIN_DISCORD_IDS_VALUE="${CLOUD_SPEND_ADMIN_DISCORD_IDS:-$(grep '^CLOUD_SPEND_ADMIN_DISCORD_IDS=' "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2-)}"
-CLOUD_SPEND_BILLING_TABLE_VALUE="${CLOUD_SPEND_BILLING_TABLE:-$(grep '^CLOUD_SPEND_BILLING_TABLE=' "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2-)}"
-CLOUD_SPEND_BILLING_PROJECT_ID_VALUE="${CLOUD_SPEND_BILLING_PROJECT_ID:-$(grep '^CLOUD_SPEND_BILLING_PROJECT_ID=' "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2-)}"
-
-OPTIONAL_SECRET_ARGS=()
-if [ -n "${WEB_APP_API_READ_TOKEN_VALUE}" ]; then
-  OPTIONAL_SECRET_ARGS+=(--update-secrets "WEB_APP_API_READ_TOKEN=mcbn-web-app-api-read-token:latest")
-fi
-if [ -n "${WEB_APP_API_WRITE_TOKEN_VALUE}" ]; then
-  OPTIONAL_SECRET_ARGS+=(--update-secrets "WEB_APP_API_WRITE_TOKEN=mcbn-web-app-api-write-token:latest")
-fi
-# CLOUD_SPEND_ADMIN_DISCORD_IDS is optional, like the two tokens above --
-# setup-secrets.sh's upsert_secret skips creating mcbn-cloud-spend-admin-ids
-# at all when the .env value is empty (the documented default, since the
-# whole pane is opt-in), and Cloud Run validates every --update-secrets
-# reference exists at deploy time. Binding it unconditionally would fail
-# the entire deploy for anyone who hasn't opted into Cloud Spend, not just
-# leave the pane disabled.
-if [ -n "${CLOUD_SPEND_ADMIN_DISCORD_IDS_VALUE}" ]; then
-  OPTIONAL_SECRET_ARGS+=(--update-secrets "CLOUD_SPEND_ADMIN_DISCORD_IDS=mcbn-cloud-spend-admin-ids:latest")
-fi
-if [ -n "${CLOUD_SPEND_BILLING_TABLE_VALUE}" ]; then
-  OPTIONAL_SECRET_ARGS+=(--set-env-vars "CLOUD_SPEND_BILLING_TABLE=${CLOUD_SPEND_BILLING_TABLE_VALUE}")
-fi
-if [ -n "${CLOUD_SPEND_BILLING_PROJECT_ID_VALUE}" ]; then
-  OPTIONAL_SECRET_ARGS+=(--set-env-vars "CLOUD_SPEND_BILLING_PROJECT_ID=${CLOUD_SPEND_BILLING_PROJECT_ID_VALUE}")
-fi
-
-if [ -z "${SPREADSHEET_ID_VALUE}" ]; then
-  echo "ERROR: SPREADSHEET_ID is required."
-  echo "Set it in your environment or in .env before running deploy.sh."
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: the GitHub CLI (gh) is required to trigger a deploy." >&2
+  echo "  brew install gh && gh auth login" >&2
+  echo "Alternatively, trigger '${WORKFLOW}' by hand from the Actions tab." >&2
   exit 1
 fi
 
-echo "==> Building Docker image (linux/amd64 for Cloud Run)..."
-docker build \
-  --platform linux/amd64 \
-  -f "${SCRIPT_DIR}/Dockerfile" \
-  -t "${IMAGE}" \
-  "${REPO_ROOT}"
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
 
-echo "==> Pushing to Artifact Registry..."
-docker push "${IMAGE}"
+echo "==> Target:   ${TARGET} (${SERVICE})"
+echo "==> Site:     ${SITE}"
+echo "==> Workflow: ${WORKFLOW} @ ${REF}"
+echo
 
-echo "==> Deploying to Cloud Run..."
-gcloud run deploy "${SERVICE_NAME}" \
-  --image "${IMAGE}" \
-  --project "${PROJECT_ID}" \
-  --region "${REGION}" \
-  --platform managed \
-  --allow-unauthenticated \
-  --memory 256Mi \
-  --cpu 1 \
-  --min-instances 0 \
-  --max-instances 2 \
-  --concurrency 80 \
-  --timeout 120 \
-  --cpu-throttling \
-  --no-session-affinity \
-  --startup-probe "httpGet.path=/api/health,httpGet.port=8080,initialDelaySeconds=0,timeoutSeconds=5,periodSeconds=5,failureThreshold=30" \
-  --set-env-vars "FLASK_DEBUG=false" \
-  --set-env-vars "SPREADSHEET_ID=${SPREADSHEET_ID_VALUE}" \
-  --set-env-vars "SHEETS_CACHE_TTL=30" \
-  --set-env-vars "AUTO_CREATE_PERIODS_ENABLED=true" \
-  --set-env-vars "BOT_API_REPLAY_PROTECTION_ENABLED=true" \
-  --set-env-vars "DISCORD_REDIRECT_URI=https://mcbn.jkomg.us/auth/callback" \
-  --update-secrets "FLASK_SECRET_KEY=mcbn-flask-secret:latest" \
-  --update-secrets "GOOGLE_CREDENTIALS_JSON=mcbn-google-creds:latest" \
-  --update-secrets "DISCORD_CLIENT_ID=mcbn-discord-client-id:latest" \
-  --update-secrets "DISCORD_CLIENT_SECRET=mcbn-discord-client-secret:latest" \
-  --update-secrets "ALLOWED_DISCORD_IDS=mcbn-discord-allowed-ids:latest" \
-  --update-secrets "SETTINGS_ADMIN_DISCORD_IDS=mcbn-settings-admin-ids:latest" \
-  --update-secrets "WEB_APP_API_TOKEN=mcbn-web-app-api-token:latest" \
-  --update-secrets "DATABASE_URL=mcbn-database-url:latest" \
-  --update-secrets "TURSO_AUTH_TOKEN=mcbn-turso-auth-token:latest" \
-  --update-secrets "DISCORD_WEBHOOK_URL=mcbn-discord-webhook-url:latest" \
-  "${OPTIONAL_SECRET_ARGS[@]}"
+if [ "${TARGET}" = "prod" ]; then
+  echo "This redeploys PRODUCTION from '${REF}'."
+  echo "Normal releases happen automatically on merge to main — you only need"
+  echo "this to force a redeploy without a new commit (e.g. after a secret"
+  echo "rotation)."
+  read -r -p "Continue? [y/N] " reply
+  case "${reply}" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
 
-echo "==> Routing 100% traffic to latest revision..."
-gcloud run services update-traffic "${SERVICE_NAME}" \
-  --project "${PROJECT_ID}" \
-  --region "${REGION}" \
-  --to-latest
+echo "==> Triggering ${WORKFLOW}..."
+gh workflow run "${WORKFLOW}" --ref "${REF}"
 
-echo ""
-echo "==> Deployed! Your app URL:"
-gcloud run services describe "${SERVICE_NAME}" --project "${PROJECT_ID}" --region "${REGION}" --format="value(status.url)"
+echo
+echo "==> Triggered. Watch it with:"
+echo "      gh run watch"
+echo "      gh run list --workflow=${WORKFLOW} --limit 5"
+echo
+echo "When it completes, verify at: ${SITE}/api/health"

--- a/apps/web/setup-secrets.sh
+++ b/apps/web/setup-secrets.sh
@@ -116,4 +116,5 @@ done
 echo "  ✓ All secrets accessible by Cloud Run"
 
 echo ""
-echo "=== Done! Run ./deploy.sh to deploy. ==="
+echo "=== Done! Cloud Run pins secret:latest at deploy time, so run"
+echo "=== ./deploy.sh to trigger a redeploy and pick these up. ==="

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -5,8 +5,11 @@ from flask import Flask
 
 import app as app_module
 from app.character_sheet import (
+    _DOT,
+    _EMPTY,
     _apply_patch,
     _apply_reverse_patch,
+    _generate_stats_markdown,
     _merge_cc_specialties,
     _normalize_skill_key,
     character_has_specialty,
@@ -513,3 +516,61 @@ def test_apply_patch_preserves_cc_specialties_when_adding_new_one():
         'firearms': ['Quickdraw'],
         'stealth': ['Shadowing'],
     }
+
+
+# ── Blood Potency ────────────────────────────────────────────────────────
+# trait_name is the fixed-trait category name itself here — the player.html
+# form auto-fills and read-onlys the trait name field for Humanity/Blood
+# Potency spends (FIXED_TRAIT_CATEGORIES), so _apply_patch is always called
+# with trait_name == 'Blood Potency', mirroring the existing Humanity branch.
+
+_BLOOD_POTENCY = 'Blood Potency'
+
+
+def test_apply_patch_sets_blood_potency():
+    data = {'bloodPotency': 1}
+    patched = _apply_patch(data, _BLOOD_POTENCY, _BLOOD_POTENCY, '', 2)
+    assert patched is True
+    assert data['bloodPotency'] == 2
+
+
+def test_apply_patch_sets_blood_potency_when_missing_from_draft():
+    data = {}
+    patched = _apply_patch(data, _BLOOD_POTENCY, _BLOOD_POTENCY, '', 1)
+    assert patched is True
+    assert data['bloodPotency'] == 1
+
+
+def test_apply_reverse_patch_restores_prior_blood_potency():
+    data = {'bloodPotency': 2}
+    reverted = _apply_reverse_patch(data, _BLOOD_POTENCY, _BLOOD_POTENCY, '', 1, 2)
+    assert reverted is True
+    assert data['bloodPotency'] == 1
+
+
+def test_apply_reverse_patch_blood_potency_no_op_when_stale():
+    """Staleness guard: if bloodPotency no longer equals new_dots (e.g. a
+    later spend raised it further), the reversal is a no-op that leaves the
+    newer value untouched — mirrors the existing Humanity staleness guard."""
+    data = {'bloodPotency': 3}
+    reverted = _apply_reverse_patch(data, _BLOOD_POTENCY, _BLOOD_POTENCY, '', 1, 2)
+    assert reverted is False
+    assert data['bloodPotency'] == 3
+
+
+# ── Vitals dot rendering (Humanity / Blood Potency are 0-10, not 0-5) ────────
+
+def test_stats_markdown_renders_vitals_on_a_ten_dot_track():
+    """Humanity and Blood Potency are rated 0-10, unlike every other dotted
+    trait. They must render a full ten-dot track, or a rating above 5 gets
+    silently clamped to 5 in the wiki stats block."""
+    markdown = _generate_stats_markdown({'bloodPotency': 7, 'humanity': 8})
+    assert f'Blood Potency {_DOT * 7}{_EMPTY * 3}' in markdown
+    assert f'Humanity {_DOT * 8}{_EMPTY * 2}' in markdown
+
+
+def test_stats_markdown_still_renders_five_dot_traits_on_a_five_dot_track():
+    """The 0-10 track applies only to the vitals — Attributes and Skills keep
+    their five-dot rendering."""
+    markdown = _generate_stats_markdown({'attributes': {'strength': 3}})
+    assert f'Strength {_DOT * 3}{_EMPTY * 2}' in markdown

--- a/apps/web/tests/test_character_sheet_patch.py
+++ b/apps/web/tests/test_character_sheet_patch.py
@@ -14,6 +14,7 @@ from app.character_sheet import (
     _normalize_skill_key,
     character_has_specialty,
     character_skill_rating,
+    character_vital_rating,
     find_trait_sheet_match,
     subcategory_label_for_trait,
 )
@@ -574,3 +575,103 @@ def test_stats_markdown_still_renders_five_dot_traits_on_a_five_dot_track():
     their five-dot rendering."""
     markdown = _generate_stats_markdown({'attributes': {'strength': 3}})
     assert f'Strength {_DOT * 3}{_EMPTY * 2}' in markdown
+
+
+# ── Fixed-trait vitals: current_dots must match the sheet ────────────────────
+
+def test_character_vital_rating_reads_both_vitals(app_ctx):
+    _seed_approved_character('Vitals Vera', {'bloodPotency': 4, 'humanity': 6})
+    assert character_vital_rating('Vitals Vera', 'Blood Potency') == 4
+    assert character_vital_rating('Vitals Vera', 'Humanity') == 6
+
+
+def test_character_vital_rating_none_for_other_categories(app_ctx):
+    _seed_approved_character('Vitals Vera', {'bloodPotency': 4})
+    assert character_vital_rating('Vitals Vera', 'Attribute') is None
+
+
+def test_character_vital_rating_none_when_field_absent(app_ctx):
+    """Absent field must read as unknown, not 0 — a character whose sheet
+    never recorded the vital must still be able to submit spends."""
+    _seed_approved_character('No Vitals Nick', {'attributes': {'strength': 2}})
+    assert character_vital_rating('No Vitals Nick', 'Blood Potency') is None
+
+
+def test_character_vital_rating_none_without_a_sheet(app_ctx):
+    assert character_vital_rating('Ghost Who Has No Draft', 'Blood Potency') is None
+
+
+def test_submit_spend_request_rejects_stale_blood_potency(app_ctx):
+    """The bug this guards: a wish-list item left at the default 0->1 would
+    charge 10 XP to 'raise' a Blood Potency 4 character and downgrade the
+    sheet to 1 on approval."""
+    _seed_approved_character('Potent Pete', {'bloodPotency': 4})
+    with pytest.raises(ValueError, match='Blood Potency is 4'):
+        app_module.db_service.submit_spend_request(
+            character_name='Potent Pete',
+            spend_category='Blood Potency',
+            trait_name='Blood Potency',
+            current_dots=0,
+            new_dots=1,
+            is_in_clan=False,
+            justification='stale wish-list default',
+        )
+
+
+def test_submit_spend_request_rejects_inflated_humanity(app_ctx):
+    """Same guard in the undercharge direction, on the pre-existing category."""
+    _seed_approved_character('Moral Mona', {'humanity': 6})
+    with pytest.raises(ValueError, match='Humanity is 6'):
+        app_module.db_service.submit_spend_request(
+            character_name='Moral Mona',
+            spend_category='Humanity',
+            trait_name='Humanity',
+            current_dots=8,
+            new_dots=9,
+            is_in_clan=False,
+            justification='inflated current rating',
+        )
+
+
+def test_submit_spend_request_allows_matching_blood_potency(app_ctx):
+    _seed_approved_character('Potent Pete', {'bloodPotency': 4})
+    cost = app_module.db_service.submit_spend_request(
+        character_name='Potent Pete',
+        spend_category='Blood Potency',
+        trait_name='Blood Potency',
+        current_dots=4,
+        new_dots=5,
+        is_in_clan=False,
+        justification='honest raise',
+    )
+    assert cost == 50
+
+
+def test_submit_spend_request_unaffected_without_a_sheet(app_ctx):
+    """No imported sheet means nothing to validate against — must not block."""
+    cost = app_module.db_service.submit_spend_request(
+        character_name='Sheetless Sam',
+        spend_category='Blood Potency',
+        trait_name='Blood Potency',
+        current_dots=1,
+        new_dots=2,
+        is_in_clan=False,
+        justification='no sheet on file',
+    )
+    assert cost == 20
+
+
+def test_submit_spend_request_does_not_gate_other_categories(app_ctx):
+    """The gate is scoped to fixed-trait vitals; named-collection traits still
+    go through unchecked, same as before this change."""
+    _seed_approved_character('Potent Pete', {'bloodPotency': 4, 'attributes': {'strength': 3}})
+    cost = app_module.db_service.submit_spend_request(
+        character_name='Potent Pete',
+        spend_category='Attribute',
+        trait_name='Strength',
+        current_dots=1,
+        new_dots=2,
+        is_in_clan=False,
+        justification='unchecked category',
+    )
+    assert cost == 10

--- a/apps/web/tests/test_xp_rules.py
+++ b/apps/web/tests/test_xp_rules.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.xp_rules import calculate_xp_cost
 
 
@@ -16,3 +18,22 @@ def test_progressive_categories_still_use_progressive_math():
 def test_loresheet_uses_selected_dot_times_three():
     assert calculate_xp_cost("Loresheet", 0, 3) == 9
     assert calculate_xp_cost("Loresheet", 0, 5) == 15
+
+
+def test_blood_potency_uses_progressive_math():
+    assert calculate_xp_cost("Blood Potency", 0, 1) == 10
+    assert calculate_xp_cost("Blood Potency", 1, 2) == 20
+    assert calculate_xp_cost("Blood Potency", 2, 3) == 30
+    assert calculate_xp_cost("Blood Potency", 1, 3) == 50
+
+
+def test_blood_potency_rejects_non_increasing_dots():
+    with pytest.raises(ValueError):
+        calculate_xp_cost("Blood Potency", 2, 2)
+    with pytest.raises(ValueError):
+        calculate_xp_cost("Blood Potency", 3, 1)
+
+
+def test_blood_potency_rejects_dots_above_max():
+    with pytest.raises(ValueError):
+        calculate_xp_cost("Blood Potency", 9, 11)

--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -1,8 +1,12 @@
 # Dev Environment Setup
 
-The dev Cloud Run service (`mcbn-xp-tracker-dev`) runs every commit that lands on `main`
-before (or alongside) the prod deploy. Its isolated Turso DB means migration errors and
-startup crashes surface in dev first.
+The dev Cloud Run service (`mcbn-xp-tracker-dev`) redeploys on **every CI-passing push, on
+any branch** — not just `main`, and not only when a PR is open. Its isolated Turso DB means
+migration errors and startup crashes surface in dev first.
+
+> **Dev is shared.** Because there is no branch filter, pushing a work-in-progress branch
+> replaces whatever is currently deployed to `dev.mcbn.jkomg.us` and pings Discord.
+> Coordinate before pushing if someone else is testing there.
 
 ## One-time setup
 
@@ -64,12 +68,16 @@ allowed redirect URI for the bot's OAuth application.
 
 ## How it works
 
-- `deploy-web-dev.yml` triggers after `CI` passes on `main` (same trigger as prod)
+- `deploy-web-dev.yml` triggers after `CI` completes — on **any branch**, deliberately
+  unfiltered so a PR can be tested on real infrastructure before it merges
 - Builds the same Docker image tagged with the commit SHA
 - Deploys to `mcbn-xp-tracker-dev` using `mcbn-dev-database-url` / `mcbn-dev-turso-auth-token`
 - Runs a 60s smoke test against `/api/health` — if the app crashes on startup (e.g. missing
   migration file), the smoke test fails and the Discord webhook posts a warning
-- Prod deploy (`deploy-web.yml`) runs in parallel — if dev smoke test fails, check prod logs
+- Prod deploy (`deploy-web.yml`) is **chained after this one, not parallel**: it triggers on
+  `Deploy Web to Cloud Run (Dev)` completing, filtered to `branches: [main]`. So dev acts as
+  a gate — prod only deploys after a dev deploy succeeds on `main`, and a feature-branch dev
+  deploy can never reach prod.
 
 ## Local dev rule
 

--- a/docs/ENV_AND_SECRETS.md
+++ b/docs/ENV_AND_SECRETS.md
@@ -320,8 +320,14 @@ Production secrets are managed via GCP Secret Manager:
 ```bash
 cd apps/web
 ./setup-secrets.sh    # interactive: reads values from .env, pushes to Secret Manager
-./deploy.sh           # build/push image and deploy new Cloud Run revision
+./deploy.sh           # trigger the prod deploy workflow so Cloud Run picks up :latest
 ```
+
+Cloud Run resolves `secret:latest` at deploy time, so rotating a secret in
+Secret Manager does **not** take effect until the service redeploys — that is
+what the `./deploy.sh` step above is for. It triggers
+`.github/workflows/deploy-web.yml` via `workflow_dispatch`; it does not build
+or deploy anything locally.
 
 To add or remove staff Discord IDs without a full redeploy:
 

--- a/docs/MONOREPO_ARCHITECTURE.md
+++ b/docs/MONOREPO_ARCHITECTURE.md
@@ -17,7 +17,10 @@ mcbn/
     api-contract/             # Shared request/response schemas + enums
     rules/                    # Shared XP/spend formulas + fixtures
   infra/
-    cloudrun/                 # Deploy scripts, service config, release notes
+    ursula/                   # Bot host: agents, dashboard, failover
+    bot-hosting/              # systemd / launchd unit templates for the bot
+    web-hosting/              # launchd template for a local dev web instance
+                              # (Cloud Run service config lives in .github/workflows/)
   docs/
     MONOREPO_ARCHITECTURE.md
     MONOREPO_MIGRATION_PLAN.md

--- a/docs/MONOREPO_CI_CD_BLUEPRINT.md
+++ b/docs/MONOREPO_CI_CD_BLUEPRINT.md
@@ -1,5 +1,15 @@
 # Monorepo CI/CD Blueprint (Free-Tier Friendly)
 
+> **⚠️ HISTORICAL DESIGN DOC — not current behavior.** This was the plan written
+> during the monorepo migration. What actually got built differs in several
+> material ways: deploys chain off `workflow_run` rather than path-filtered
+> pushes, the bot deploys automatically via a self-hosted GitHub Actions runner
+> on Ursula (not a manual `git pull` + `systemctl restart`), `infra/cloudrun/`
+> never held any deploy config and has been removed, and the per-app release
+> tag scheme below was never adopted. For current behavior see [CONTRIBUTING.md](../CONTRIBUTING.md#deploy-paths)
+> and [DEV_ENVIRONMENT.md](DEV_ENVIRONMENT.md). The CI job/path-filter strategy
+> below *was* implemented and is still accurate.
+
 ## Objectives
 
 - Keep branch protection stable (`test-and-lint` required check).

--- a/packages/api-contract/spend_categories.json
+++ b/packages/api-contract/spend_categories.json
@@ -11,5 +11,6 @@
   "Loresheet",
   "Ghoul Discipline",
   "Humanity",
+  "Blood Potency",
   "Skill Specialty"
 ]

--- a/packages/rules/xp_costs.json
+++ b/packages/rules/xp_costs.json
@@ -71,6 +71,12 @@
     "min_dots": 1,
     "max_dots": 10
   },
+  "Blood Potency": {
+    "multiplier": 10,
+    "description": "New rating × 10",
+    "min_dots": 0,
+    "max_dots": 10
+  },
   "Skill Specialty": {
     "flat_cost": 3,
     "description": "3 XP (0 → 1)",


### PR DESCRIPTION
Two related-but-separable changes; happy to split if you'd rather review them apart.

## 1. Blood Potency as a purchasable XP category

Players can now buy Blood Potency through the normal spend flow at the V5 cost of **New Level × 10**.

The category is defined in the shared JSON contracts (`packages/rules/xp_costs.json`, `packages/api-contract/spend_categories.json`), so both the web app and the bot pick it up with **no formula code in either** — `xpRules.ts` is fully data-driven and `XpSpendCategory` is just `string`, so no bot changes were needed. The dropdowns populate from `spend_categories.json`, so no select markup changed either.

- `character_sheet.py` — apply/reverse sheet patch for `bloodPotency`, mirroring the existing `Humanity` branches including the staleness guard on reversal
- `character.html` — reference-table row, live cost preview, sheet pre-fill

Two drive-by fixes in the same surface:

- The XP Cost Reference was missing **Ghoul Discipline** and **Skill Specialty**, both live categories in the dropdown.
- **Humanity and Blood Potency are rated 0–10**, but the wiki stats markdown rendered both through `_dots_str()`'s five-dot default, clamping anything above 5. Added `_VITALS_MAX_DOTS`. The player templates already rendered ten pips, so this was the only place it truncated.

Also replaced the `Humanity`-only trait auto-fill special case with a `FIXED_TRAIT_CATEGORIES` list so both fixed-trait categories share one path.

## 2. Deploy path and stale docs

`apps/web/deploy.sh` carried its own full `gcloud run deploy` targeting the **same live prod service** as `.github/workflows/deploy-web.yml`. Two independent definitions of one service drift, and they had: `a9c44f4` bumped prod to 512Mi *to match the live config*, and `deploy.sh` kept saying 256Mi — **a manual run would have silently halved prod memory**. `--set-env-vars` also removes any env var it doesn't list, so the stale script could have stripped `CLOUD_SPEND_*` vars depending on the operator's local `.env`.

`deploy.sh` now only *triggers* the workflow via `workflow_dispatch` (`./deploy.sh` prod, `./deploy.sh dev`), making the workflows the single source of truth for image build, resource flags, env vars, and secret bindings. Its main legitimate use is forcing a redeploy after a secret rotation, since Cloud Run pins `secret:latest` at deploy time.

Removed `infra/cloudrun/` — an empty vestigial directory from the migration blueprint that never held any deploy config, despite three docs describing it as the home for exactly that.

Docs were substantially stale:

- **`CONTRIBUTING.md` predated the monorepo split and its setup instructions did not work** (root venv, `cp .env.example .env` against a root file that's only a pointer comment, pytest/ruff invoked from a directory with no `tests/`). Rewritten with real toolchain versions, per-app setup, the exact commands CI gates on — including the **30% coverage gate** and the **`ruff==0.15.20` pin** — the migration workflow, branch/PR conventions, and deploy paths.
- **`DEV_ENVIRONMENT.md` was factually wrong twice**: it claimed dev deploys on `main` (there's no branch filter at all) and that prod runs "in parallel" (prod chains *after* dev, gated to `main`). Corrected, with the shared-dev hazard called out.
- `MONOREPO_CI_CD_BLUEPRINT.md` flagged as historical — it describes a plan that isn't what was built.
- `apps/character-app` was missing from the repo tree in README and CLAUDE.md despite being a required build stage of every web deploy.

## Verification

- `pytest -q --cov=app --cov-fail-under=30` → **424 passed**, 48.6% coverage (7 new tests: cost math, dot bounds, apply/reverse patch, staleness guard, ten-dot vitals rendering)
- `ruff check app tests` at the CI-pinned `0.15.20` → clean
- `apps/bot npm run check` → **376 tests**, lint, typecheck, build all pass with no bot source changes
- Jinja template parses; JS blocks brace-balanced

No JS test harness exists here, so an interactive click-through of the spend form and wish list is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)